### PR TITLE
fix: Notification auto-dismiss not working due to stale closure

### DIFF
--- a/admin/inertia/providers/NotificationProvider.tsx
+++ b/admin/inertia/providers/NotificationProvider.tsx
@@ -22,7 +22,7 @@ const NotificationsProvider = ({ children }: { children: React.ReactNode }) => {
   }
 
   const removeNotification = (id: string) => {
-    setNotifications(notifications.filter((n) => n.id !== id))
+    setNotifications((prev) => prev.filter((n) => n.id !== id))
   }
 
   const removeAllNotifications = () => {


### PR DESCRIPTION
## Summary
- Fixes notifications not auto-dismissing after the 5-second timeout

## Problem
The `removeNotification` function was using a stale reference to the `notifications` array from the closure scope. When the `setTimeout` callback fired, it was filtering against an outdated empty array instead of the current state.

## Solution
Changed to use the functional update pattern which correctly references current state:

```diff
- setNotifications(notifications.filter((n) => n.id !== id))
+ setNotifications((prev) => prev.filter((n) => n.id !== id))
```

## Test plan
- [x] Trigger a notification (e.g., fetch collections in Easy Setup)
- [x] Verify notification auto-dismisses after 5 seconds
- [x] Verify manual click dismiss still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)