### PR TITLE
fix(docs): Remove broken service links pointing to invalid routes

### DIFF
--- a/admin/docs/getting-started.md
+++ b/admin/docs/getting-started.md
@@ -98,11 +98,9 @@ Kiwix stores compressed versions of websites and references that work without in
 - Classic books from Project Gutenberg
 
 **How to use it:**
-1. Click **Kiwix** from the Command Center
+1. Click **Kiwix** from the Command Center home screen or [Apps](/settings/apps) page
 2. Choose a collection (like Wikipedia)
 3. Search or browse just like the regular website
-
-**[Open Kiwix →](/kiwix)**
 
 ---
 
@@ -117,13 +115,11 @@ Kolibri provides complete educational courses that work offline.
 - Works for all ages
 
 **How to use it:**
-1. Click **Kolibri** from the Command Center
+1. Click **Kolibri** from the Command Center home screen or [Apps](/settings/apps) page
 2. Sign in or create a learner account
 3. Browse courses and start learning
 
 **Tip:** Kolibri supports multiple users. Create accounts for each family member to track individual progress.
-
-**[Open Kolibri →](/kolibri)**
 
 ---
 
@@ -139,13 +135,11 @@ Chat with a local AI that runs entirely on your server — no internet needed.
 - Assist with problem-solving
 
 **How to use it:**
-1. Click **Open WebUI** from the Command Center
+1. Click **Open WebUI** from the Command Center home screen or [Apps](/settings/apps) page
 2. Type your question or request
 3. The AI responds in conversational style
 
 **Tip:** Be specific in your questions. Instead of "tell me about plants," try "what vegetables grow well in shade?"
-
-**[Open AI Chat →](/openwebui)**
 
 ---
 

--- a/admin/docs/home.md
+++ b/admin/docs/home.md
@@ -13,17 +13,17 @@ Think of it as having Wikipedia, Khan Academy, an AI assistant, and offline maps
 ### Browse Offline Knowledge
 Access millions of Wikipedia articles, medical references, how-to guides, and ebooks — all stored locally on your server. No internet required.
 
-**[Open Kiwix →](/kiwix)**
+*Launch Kiwix from the [Apps](/settings/apps) page or the home screen.*
 
 ### Learn Something New
 Khan Academy courses covering math, science, economics, and more. Complete with videos and exercises, all available offline.
 
-**[Open Kolibri →](/kolibri)**
+*Launch Kolibri from the [Apps](/settings/apps) page or the home screen.*
 
 ### Chat with AI
 Ask questions, get explanations, brainstorm ideas, or get help with writing. Your local AI assistant works completely offline.
 
-**[Open AI Chat →](/openwebui)**
+*Launch Open WebUI from the [Apps](/settings/apps) page or the home screen.*
 
 ### View Offline Maps
 Navigate and explore maps without an internet connection. Download regions you need before going offline.


### PR DESCRIPTION
## Summary
- Fixed broken links in documentation that pointed to non-existent routes (`/kiwix`, `/kolibri`, `/openwebui`)
- Services run on separate ports, not as paths under the Command Center
- Updated `home.md` and `getting-started.md` to direct users to the Apps page or home screen instead

## Changes
| File | Change |
|------|--------|
| `home.md` | Replaced broken links with "Launch from Apps page or home screen" |
| `getting-started.md` | Updated "How to use it" instructions with correct navigation |

## Notes
- `/maps` link was kept as Maps is embedded in the Command Center
- Links to `/settings/apps` work correctly for launching services

🤖 Generated with [Claude Code](https://claude.ai/code)