### PR TITLE
feat: Use friendly app names on Dashboard with open source attribution

### DIFF
--- a/admin/app/models/service.ts
+++ b/admin/app/models/service.ts
@@ -27,6 +27,12 @@ export default class Service extends BaseModel {
   declare description: string | null
 
   @column()
+  declare powered_by: string | null
+
+  @column()
+  declare display_order: number | null
+
+  @column()
   declare icon: string | null // must be a TablerIcons name to be properly rendered in the UI (e.g. "IconBrandDocker")
 
   @column({

--- a/admin/app/services/system_service.ts
+++ b/admin/app/services/system_service.ts
@@ -61,6 +61,7 @@ export class SystemService {
     await this._syncContainersWithDatabase() // Sync up before fetching to ensure we have the latest status
 
     const query = Service.query()
+      .orderBy('display_order', 'asc')
       .orderBy('friendly_name', 'asc')
       .select(
         'id',
@@ -70,7 +71,9 @@ export class SystemService {
         'ui_location',
         'friendly_name',
         'description',
-        'icon'
+        'icon',
+        'powered_by',
+        'display_order'
       )
       .where('is_dependency_service', false)
     if (installedOnly) {
@@ -98,6 +101,8 @@ export class SystemService {
         installation_status: service.installation_status,
         status: status ? status.status : 'unknown',
         ui_location: service.ui_location || '',
+        powered_by: service.powered_by,
+        display_order: service.display_order,
       })
     }
 

--- a/admin/database/migrations/1769300000001_add_powered_by_and_display_order_to_services.ts
+++ b/admin/database/migrations/1769300000001_add_powered_by_and_display_order_to_services.ts
@@ -1,0 +1,19 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'services'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.string('powered_by').nullable()
+      table.integer('display_order').nullable().defaultTo(100)
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('powered_by')
+      table.dropColumn('display_order')
+    })
+  }
+}

--- a/admin/database/migrations/1769300000002_update_services_friendly_names.ts
+++ b/admin/database/migrations/1769300000002_update_services_friendly_names.ts
@@ -1,0 +1,113 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'services'
+
+  async up() {
+    // Update existing services with new friendly names and powered_by values
+    await this.db.rawQuery(`
+      UPDATE services SET
+        friendly_name = 'Information Library',
+        powered_by = 'Kiwix',
+        display_order = 1,
+        description = 'Offline access to Wikipedia, medical references, how-to guides, and encyclopedias'
+      WHERE service_name = 'nomad_kiwix_serve'
+    `)
+
+    await this.db.rawQuery(`
+      UPDATE services SET
+        friendly_name = 'Education Platform',
+        powered_by = 'Kolibri',
+        display_order = 2,
+        description = 'Interactive learning platform with video courses and exercises'
+      WHERE service_name = 'nomad_kolibri'
+    `)
+
+    await this.db.rawQuery(`
+      UPDATE services SET
+        friendly_name = 'AI Assistant',
+        powered_by = 'Open WebUI + Ollama',
+        display_order = 3,
+        description = 'Local AI chat that runs entirely on your hardware - no internet required'
+      WHERE service_name = 'nomad_open_webui'
+    `)
+
+    await this.db.rawQuery(`
+      UPDATE services SET
+        friendly_name = 'Notes',
+        powered_by = 'FlatNotes',
+        display_order = 10,
+        description = 'Simple note-taking app with local storage'
+      WHERE service_name = 'nomad_flatnotes'
+    `)
+
+    await this.db.rawQuery(`
+      UPDATE services SET
+        friendly_name = 'Data Tools',
+        powered_by = 'CyberChef',
+        display_order = 11,
+        description = 'Swiss Army knife for data encoding, encryption, and analysis'
+      WHERE service_name = 'nomad_cyberchef'
+    `)
+
+    await this.db.rawQuery(`
+      UPDATE services SET
+        display_order = 100
+      WHERE service_name = 'nomad_ollama'
+    `)
+  }
+
+  async down() {
+    // Revert to original names
+    await this.db.rawQuery(`
+      UPDATE services SET
+        friendly_name = 'Kiwix',
+        powered_by = NULL,
+        display_order = NULL,
+        description = 'Offline Wikipedia, eBooks, and more'
+      WHERE service_name = 'nomad_kiwix_serve'
+    `)
+
+    await this.db.rawQuery(`
+      UPDATE services SET
+        friendly_name = 'Kolibri',
+        powered_by = NULL,
+        display_order = NULL,
+        description = 'An offline-first education platform for schools and learners'
+      WHERE service_name = 'nomad_kolibri'
+    `)
+
+    await this.db.rawQuery(`
+      UPDATE services SET
+        friendly_name = 'Open WebUI',
+        powered_by = NULL,
+        display_order = NULL,
+        description = 'A web interface for interacting with local AI models served by Ollama'
+      WHERE service_name = 'nomad_open_webui'
+    `)
+
+    await this.db.rawQuery(`
+      UPDATE services SET
+        friendly_name = 'FlatNotes',
+        powered_by = NULL,
+        display_order = NULL,
+        description = 'A simple note-taking app that stores all files locally'
+      WHERE service_name = 'nomad_flatnotes'
+    `)
+
+    await this.db.rawQuery(`
+      UPDATE services SET
+        friendly_name = 'CyberChef',
+        powered_by = NULL,
+        display_order = NULL,
+        description = 'The Cyber Swiss Army Knife - a web app for encryption, encoding, and data analysis'
+      WHERE service_name = 'nomad_cyberchef'
+    `)
+
+    await this.db.rawQuery(`
+      UPDATE services SET
+        display_order = NULL
+      WHERE service_name = 'nomad_ollama'
+    `)
+  }
+}

--- a/admin/database/seeders/service_seeder.ts
+++ b/admin/database/seeders/service_seeder.ts
@@ -10,8 +10,10 @@ export default class ServiceSeeder extends BaseSeeder {
   private static DEFAULT_SERVICES: Omit<ModelAttributes<Service>, 'created_at' | 'updated_at' | 'metadata' | 'id'>[] = [
     {
       service_name: DockerService.KIWIX_SERVICE_NAME,
-      friendly_name: 'Kiwix',
-      description: 'Offline Wikipedia, eBooks, and more',
+      friendly_name: 'Information Library',
+      powered_by: 'Kiwix',
+      display_order: 1,
+      description: 'Offline access to Wikipedia, medical references, how-to guides, and encyclopedias',
       icon: 'IconBooks',
       container_image: 'ghcr.io/kiwix/kiwix-serve:3.8.1',
       container_command: '*.zim --address=all',
@@ -32,6 +34,8 @@ export default class ServiceSeeder extends BaseSeeder {
     {
       service_name: DockerService.OLLAMA_SERVICE_NAME,
       friendly_name: 'Ollama',
+      powered_by: null,
+      display_order: 100, // Dependency service, not shown directly
       description: 'Run local LLMs (AI models) with ease on your own hardware',
       icon: 'IconRobot',
       container_image: 'ollama/ollama:latest',
@@ -52,8 +56,10 @@ export default class ServiceSeeder extends BaseSeeder {
     },
     {
       service_name: DockerService.OPEN_WEBUI_SERVICE_NAME,
-      friendly_name: 'Open WebUI',
-      description: 'A web interface for interacting with local AI models served by Ollama',
+      friendly_name: 'AI Assistant',
+      powered_by: 'Open WebUI + Ollama',
+      display_order: 3,
+      description: 'Local AI chat that runs entirely on your hardware - no internet required',
       icon: 'IconWand',
       container_image: 'ghcr.io/open-webui/open-webui:main',
       container_command: null,
@@ -74,8 +80,10 @@ export default class ServiceSeeder extends BaseSeeder {
     },
     {
       service_name: DockerService.CYBERCHEF_SERVICE_NAME,
-      friendly_name: 'CyberChef',
-      description: 'The Cyber Swiss Army Knife - a web app for encryption, encoding, and data analysis',
+      friendly_name: 'Data Tools',
+      powered_by: 'CyberChef',
+      display_order: 11,
+      description: 'Swiss Army knife for data encoding, encryption, and analysis',
       icon: 'IconChefHat',
       container_image: 'ghcr.io/gchq/cyberchef:latest',
       container_command: null,
@@ -94,8 +102,10 @@ export default class ServiceSeeder extends BaseSeeder {
     },
     {
       service_name: DockerService.FLATNOTES_SERVICE_NAME,
-      friendly_name: 'FlatNotes',
-      description: 'A simple note-taking app that stores all files locally',
+      friendly_name: 'Notes',
+      powered_by: 'FlatNotes',
+      display_order: 10,
+      description: 'Simple note-taking app with local storage',
       icon: 'IconNotes',
       container_image: 'dullage/flatnotes:latest',
       container_command: null,
@@ -116,8 +126,10 @@ export default class ServiceSeeder extends BaseSeeder {
     },
     {
       service_name: DockerService.KOLIBRI_SERVICE_NAME,
-      friendly_name: 'Kolibri',
-      description: 'An offline-first education platform for schools and learners',
+      friendly_name: 'Education Platform',
+      powered_by: 'Kolibri',
+      display_order: 2,
+      description: 'Interactive learning platform with video courses and exercises',
       icon: 'IconSchool',
       container_image: 'treehouses/kolibri:latest',
       container_command: null,

--- a/admin/types/services.ts
+++ b/admin/types/services.ts
@@ -10,4 +10,6 @@ export type ServiceSlim = Pick<
   | 'friendly_name'
   | 'description'
   | 'icon'
+  | 'powered_by'
+  | 'display_order'
 > & { status?: string }


### PR DESCRIPTION
## Summary

- Updates Dashboard to use user-friendly names matching the Easy Setup Wizard
- Adds "Powered by X" subheading to give credit to open source projects
- Reorders Dashboard cards: Core Capabilities → Maps → Additional Tools → System items

**Name Changes:**
| Old Name | New Name | Attribution |
|----------|----------|-------------|
| Kiwix | Information Library | Powered by Kiwix |
| Kolibri | Education Platform | Powered by Kolibri |
| Open WebUI | AI Assistant | Powered by Open WebUI + Ollama |
| FlatNotes | Notes | Powered by FlatNotes |
| CyberChef | Data Tools | Powered by CyberChef |

## Test plan

- [ ] Run migrations: `node ace migration:run`
- [ ] Verify Dashboard shows new friendly names
- [ ] Verify "Powered by X" subheadings appear for installed apps
- [ ] Verify card ordering: Core apps first, then Additional Tools, then system items
- [ ] Verify Easy Setup Wizard Step 1 still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)