### PR TITLE
feat: Update Settings nomenclature and add tiered content collections

### DIFF
--- a/admin/inertia/layouts/SettingsLayout.tsx
+++ b/admin/inertia/layouts/SettingsLayout.tsx
@@ -16,24 +16,19 @@ import StyledSidebar from '~/components/StyledSidebar'
 import { getServiceLink } from '~/lib/navigation'
 
 const navigation = [
+  { name: 'AI Model Manager', href: '/settings/models', icon: IconDatabaseStar, current: false },
   { name: 'Apps', href: '/settings/apps', icon: CommandLineIcon, current: false },
   { name: 'Benchmark', href: '/settings/benchmark', icon: ChartBarIcon, current: false },
+  { name: 'Content Explorer', href: '/settings/zim/remote-explorer', icon: MagnifyingGlassIcon, current: false },
+  { name: 'Content Manager', href: '/settings/zim', icon: FolderIcon, current: false },
   { name: 'Legal Notices', href: '/settings/legal', icon: IconGavel, current: false },
   { name: 'Maps Manager', href: '/settings/maps', icon: IconMapRoute, current: false },
-  { name: 'Models Manager', href: '/settings/models', icon: IconDatabaseStar, current: false },
   {
     name: 'Service Logs & Metrics',
     href: getServiceLink('9999'),
     icon: IconDashboard,
     current: false,
     target: '_blank',
-  },
-  { name: 'ZIM Manager', href: '/settings/zim', icon: FolderIcon, current: false },
-  {
-    name: 'Zim Remote Explorer',
-    href: '/settings/zim/remote-explorer',
-    icon: MagnifyingGlassIcon,
-    current: false,
   },
   {
     name: 'Check for Updates',

--- a/admin/inertia/pages/settings/models.tsx
+++ b/admin/inertia/pages/settings/models.tsx
@@ -79,10 +79,10 @@ export default function ModelsPage(props: {
 
   return (
     <SettingsLayout>
-      <Head title="App Settings" />
+      <Head title="AI Model Manager | Project N.O.M.A.D." />
       <div className="xl:pl-72 w-full">
         <main className="px-12 py-6">
-          <h1 className="text-4xl font-semibold mb-4">Models</h1>
+          <h1 className="text-4xl font-semibold mb-4">AI Model Manager</h1>
           <p className="text-gray-500 mb-4">
             Easily manage the AI models available for Open WebUI. We recommend starting with smaller
             models first to see how they perform on your system before moving on to larger ones.

--- a/admin/inertia/pages/settings/zim/index.tsx
+++ b/admin/inertia/pages/settings/zim/index.tsx
@@ -55,14 +55,14 @@ export default function ZimPage() {
 
   return (
     <SettingsLayout>
-      <Head title="ZIM Manager | Project N.O.M.A.D." />
+      <Head title="Content Manager | Project N.O.M.A.D." />
       <div className="xl:pl-72 w-full">
         <main className="px-12 py-6">
           <div className="flex items-center justify-between">
             <div className="flex flex-col">
-              <h1 className="text-4xl font-semibold mb-2">ZIM Manager</h1>
+              <h1 className="text-4xl font-semibold mb-2">Content Manager</h1>
               <p className="text-gray-500">
-                Manage your stored ZIM files.
+                Manage your stored content files.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Rename **Models Manager** → **AI Model Manager**
- Rename **ZIM Manager** → **Content Manager**  
- Rename **ZIM Remote Explorer** → **Content Explorer**
- Rename **Curated ZIM Collections** → **Curated Content Collections**
- Add tiered category collections (Essential/Standard/Comprehensive) to Content Explorer, matching the Easy Setup Wizard Step 3 for UI consistency
- Reorganize Settings sidebar alphabetically

## Changes

### Settings Sidebar (`SettingsLayout.tsx`)
- Updated menu item names
- Reorganized alphabetically for easier navigation

### AI Model Manager (`settings/models.tsx`)
- Page title: "Models" → "AI Model Manager"
- Head title updated accordingly

### Content Manager (`settings/zim/index.tsx`)
- Page title: "ZIM Manager" → "Content Manager"
- Description: "Manage your stored ZIM files." → "Manage your stored content files."

### Content Explorer (`settings/zim/remote-explorer.tsx`)
- Page title: "ZIM Remote Explorer" → "Content Explorer"
- Section header: "Curated ZIM Collections" → "Curated Content Collections"
- Added tiered category collections using `CategoryCard` and `TierSelectionModal` components (same as Easy Setup Wizard)
- Legacy flat collections shown as fallback if tiered categories unavailable

## Test plan

- [ ] Verify Settings sidebar shows updated names in alphabetical order
- [ ] Verify AI Model Manager page title and functionality
- [ ] Verify Content Manager page title and functionality
- [ ] Verify Content Explorer shows tiered categories with Essential/Standard/Comprehensive tiers
- [ ] Verify clicking a category opens the tier selection modal
- [ ] Verify selecting a tier initiates downloads for all resources in that tier
- [ ] Verify fallback to legacy flat collections if no categories available

🤖 Generated with [Claude Code](https://claude.com/claude-code)