### PR TITLE
feat: Improve curated collections UX with persistent tier selection

### DIFF
--- a/admin/app/controllers/zim_controller.ts
+++ b/admin/app/controllers/zim_controller.ts
@@ -3,6 +3,7 @@ import {
   downloadCollectionValidator,
   filenameParamValidator,
   remoteDownloadValidator,
+  saveInstalledTierValidator,
 } from '#validators/common'
 import { listRemoteZimValidator } from '#validators/zim'
 import { inject } from '@adonisjs/core'
@@ -52,6 +53,12 @@ export default class ZimController {
   async fetchLatestCollections({}: HttpContext) {
     const success = await this.zimService.fetchLatestCollections()
     return { success }
+  }
+
+  async saveInstalledTier({ request }: HttpContext) {
+    const payload = await request.validateUsing(saveInstalledTierValidator)
+    await this.zimService.saveInstalledTier(payload.categorySlug, payload.tierSlug)
+    return { success: true }
   }
 
   async delete({ request, response }: HttpContext) {

--- a/admin/app/models/installed_tier.ts
+++ b/admin/app/models/installed_tier.ts
@@ -1,0 +1,21 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, SnakeCaseNamingStrategy } from '@adonisjs/lucid/orm'
+
+export default class InstalledTier extends BaseModel {
+  static namingStrategy = new SnakeCaseNamingStrategy()
+
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare category_slug: string
+
+  @column()
+  declare tier_slug: string
+
+  @column.dateTime({ autoCreate: true })
+  declare created_at: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updated_at: DateTime
+}

--- a/admin/app/validators/common.ts
+++ b/admin/app/validators/common.ts
@@ -36,3 +36,10 @@ export const downloadCollectionValidator = vine.compile(
     slug: vine.string(),
   })
 )
+
+export const saveInstalledTierValidator = vine.compile(
+  vine.object({
+    categorySlug: vine.string().trim().minLength(1),
+    tierSlug: vine.string().trim().minLength(1),
+  })
+)

--- a/admin/database/migrations/1769400000001_create_installed_tiers_table.ts
+++ b/admin/database/migrations/1769400000001_create_installed_tiers_table.ts
@@ -1,0 +1,19 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'installed_tiers'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').primary()
+      table.string('category_slug').notNullable().unique()
+      table.string('tier_slug').notNullable()
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/admin/inertia/components/CategoryCard.tsx
+++ b/admin/inertia/components/CategoryCard.tsx
@@ -29,6 +29,9 @@ const CategoryCard: React.FC<CategoryCardProps> = ({ category, selectedTier, onC
   const minSize = getTierTotalSize(category.tiers[0], category.tiers)
   const maxSize = getTierTotalSize(category.tiers[category.tiers.length - 1], category.tiers)
 
+  // Determine which tier to highlight: selectedTier (wizard) > installedTierSlug (persisted)
+  const highlightedTierSlug = selectedTier?.slug || category.installedTierSlug
+
   return (
     <div
       className={classNames(
@@ -59,23 +62,28 @@ const CategoryCard: React.FC<CategoryCardProps> = ({ category, selectedTier, onC
       <div className="mt-4 pt-4 border-t border-white/20">
         <p className="text-sm text-gray-300 mb-2">
           {category.tiers.length} tiers available
+          {!highlightedTierSlug && (
+            <span className="text-gray-400"> - Click to choose</span>
+          )}
         </p>
         <div className="flex flex-wrap gap-2">
-          {category.tiers.map((tier) => (
-            <span
-              key={tier.slug}
-              className={classNames(
-                'text-xs px-2 py-1 rounded',
-                tier.recommended
-                  ? 'bg-lime-500/30 text-lime-200'
-                  : 'bg-white/10 text-gray-300',
-                selectedTier?.slug === tier.slug && 'ring-2 ring-lime-400'
-              )}
-            >
-              {tier.name}
-              {tier.recommended && ' *'}
-            </span>
-          ))}
+          {category.tiers.map((tier) => {
+            const isInstalled = tier.slug === highlightedTierSlug
+            return (
+              <span
+                key={tier.slug}
+                className={classNames(
+                  'text-xs px-2 py-1 rounded',
+                  isInstalled
+                    ? 'bg-lime-500/30 text-lime-200'
+                    : 'bg-white/10 text-gray-300',
+                  selectedTier?.slug === tier.slug && 'ring-2 ring-lime-400'
+                )}
+              >
+                {tier.name}
+              </span>
+            )
+          })}
         </div>
         <p className="text-gray-300 text-xs mt-3">
           Size: {formatBytes(minSize, 1)} - {formatBytes(maxSize, 1)}

--- a/admin/inertia/lib/api.ts
+++ b/admin/inertia/lib/api.ts
@@ -212,6 +212,16 @@ class API {
     })()
   }
 
+  async saveInstalledTier(categorySlug: string, tierSlug: string) {
+    return catchInternal(async () => {
+      const response = await this.client.post<{ success: boolean }>('/zim/save-installed-tier', {
+        categorySlug,
+        tierSlug,
+      })
+      return response.data
+    })()
+  }
+
   async listDocs() {
     return catchInternal(async () => {
       const response = await this.client.get<Array<{ title: string; slug: string }>>('/docs/list')

--- a/admin/inertia/pages/easy-setup/index.tsx
+++ b/admin/inertia/pages/easy-setup/index.tsx
@@ -392,6 +392,12 @@ export default function EasySetupWizard(props: { system: { services: ServiceSlim
 
       await Promise.all(downloadPromises)
 
+      // Save installed tiers for each selected category
+      const tierSavePromises = Array.from(selectedTiers.entries()).map(
+        ([categorySlug, tier]) => api.saveInstalledTier(categorySlug, tier.slug)
+      )
+      await Promise.all(tierSavePromises)
+
       addNotification({
         type: 'success',
         message: 'Setup wizard completed! Your selections are being processed.',
@@ -945,7 +951,9 @@ export default function EasySetupWizard(props: { system: { services: ServiceSlim
                   onClose={closeTierModal}
                   category={activeCategory}
                   selectedTierSlug={
-                    activeCategory ? selectedTiers.get(activeCategory.slug)?.slug : null
+                    activeCategory
+                      ? selectedTiers.get(activeCategory.slug)?.slug || activeCategory.installedTierSlug
+                      : null
                   }
                   onSelectTier={handleTierSelect}
                 />

--- a/admin/inertia/pages/settings/zim/remote-explorer.tsx
+++ b/admin/inertia/pages/settings/zim/remote-explorer.tsx
@@ -222,16 +222,23 @@ export default function ZimRemoteExplorer() {
     // Get all resources for this tier (including inherited ones)
     const resources = getAllResourcesForTier(tier, category.tiers)
 
-    // Download each resource
+    // Download each resource and save the installed tier
     try {
       for (const resource of resources) {
         await api.downloadRemoteZimFile(resource.url)
       }
+
+      // Save the installed tier
+      await api.saveInstalledTier(category.slug, tier.slug)
+
       addNotification({
         message: `Started downloading ${resources.length} files from "${category.name} - ${tier.name}"`,
         type: 'success',
       })
       invalidateDownloads()
+
+      // Refresh categories to update the installed tier display
+      queryClient.invalidateQueries({ queryKey: [CURATED_CATEGORIES_KEY] })
     } catch (error) {
       console.error('Error downloading tier resources:', error)
       addNotification({
@@ -239,8 +246,6 @@ export default function ZimRemoteExplorer() {
         type: 'error',
       })
     }
-
-    closeTierModal()
   }
 
   const closeTierModal = () => {
@@ -322,7 +327,7 @@ export default function ZimRemoteExplorer() {
                 isOpen={tierModalOpen}
                 onClose={closeTierModal}
                 category={activeCategory}
-                selectedTierSlug={null}
+                selectedTierSlug={activeCategory?.installedTierSlug}
                 onSelectTier={handleTierSelect}
               />
             </>

--- a/admin/start/routes.ts
+++ b/admin/start/routes.ts
@@ -120,6 +120,7 @@ router
     router.post('/fetch-latest-collections', [ZimController, 'fetchLatestCollections'])
     router.post('/download-remote', [ZimController, 'downloadRemote'])
     router.post('/download-collection', [ZimController, 'downloadCollection'])
+    router.post('/save-installed-tier', [ZimController, 'saveInstalledTier'])
     router.delete('/:filename', [ZimController, 'delete'])
   })
   .prefix('/api/zim')

--- a/admin/types/downloads.ts
+++ b/admin/types/downloads.ts
@@ -84,6 +84,7 @@ export type CuratedCategory = {
   description: string
   language: string
   tiers: CategoryTier[]
+  installedTierSlug?: string
 }
 
 export type CuratedCategoriesFile = {


### PR DESCRIPTION
## Summary

- Improves the curated content collections UX in both Content Explorer and Easy Setup Wizard
- Makes tier selection more intuitive with a two-step process (select, then confirm)
- Persists the user's installed tier choice so it's highlighted on future visits
- Removes confusing "Recommended" badge and asterisk (*) markers

## Changes

### Database
- New `installed_tiers` table to persist which tier a user has installed per category
- Run migration after deploying: `node ace migration:run`

### UX Improvements
- **TierSelectionModal**: Clicking a tier now highlights it locally. User must click "Submit" to confirm their choice (previously, clicking immediately started downloads in Content Explorer)
- **CategoryCard**: Shows "Click to choose" when no tier is installed. Installed tier gets lime highlighting instead of "recommended" tier
- **Removed**: Asterisk (*) and "Recommended" badge - these were confusing users

### Persistence
- After installing a tier (from Content Explorer or Easy Setup), the selection is saved
- On next visit, the installed tier is pre-selected in the modal and highlighted on the card

## Test plan

- [ ] Run migration: `node ace migration:run`
- [ ] Go to Content Explorer → Curated Collections → Click a category
- [ ] Verify: Modal opens, no tier is pre-selected (first time)
- [ ] Verify: Clicking a tier highlights it but doesn't start download
- [ ] Verify: Clicking Submit starts downloads and closes modal
- [ ] Verify: Category card now shows the installed tier highlighted
- [ ] Verify: Re-opening the modal shows the installed tier pre-selected
- [ ] Test same flow in Easy Setup Wizard Step 3
- [ ] Verify: Completing wizard saves the tier selections

🤖 Generated with [Claude Code](https://claude.com/claude-code)