### PR TITLE
fix(install): Handle missing curl dependency on fresh Ubuntu installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Project N.O.M.A.D. can be installed on any Debian-based operating system (we rec
 
 *Note: sudo/root privileges are required to run the install script*
 
+#### One-liner (recommended for fresh Ubuntu installs)
+```bash
+sudo apt-get update && sudo apt-get install -y curl && curl -fsSL https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/master/install/install_nomad.sh | sudo bash
+```
+
+#### Two-step install (if you already have curl)
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/master/install/install_nomad.sh -o install_nomad.sh
 ```

--- a/install/install_nomad.sh
+++ b/install/install_nomad.sh
@@ -92,6 +92,37 @@ check_is_debian_based() {
     echo -e "${GREEN}#${RESET} This script is running on a Debian-based system.\\n"
 }
 
+ensure_dependencies_installed() {
+  local missing_deps=()
+
+  # Check for curl
+  if ! command -v curl &> /dev/null; then
+    missing_deps+=("curl")
+  fi
+
+  # Check for whiptail (used for dialogs, though not currently active)
+  # if ! command -v whiptail &> /dev/null; then
+  #   missing_deps+=("whiptail")
+  # fi
+
+  if [[ ${#missing_deps[@]} -gt 0 ]]; then
+    echo -e "${YELLOW}#${RESET} Installing required dependencies: ${missing_deps[*]}...\\n"
+    sudo apt-get update
+    sudo apt-get install -y "${missing_deps[@]}"
+
+    # Verify installation
+    for dep in "${missing_deps[@]}"; do
+      if ! command -v "$dep" &> /dev/null; then
+        echo -e "${RED}#${RESET} Failed to install $dep. Please install it manually and try again."
+        exit 1
+      fi
+    done
+    echo -e "${GREEN}#${RESET} Dependencies installed successfully.\\n"
+  else
+    echo -e "${GREEN}#${RESET} All required dependencies are already installed.\\n"
+  fi
+}
+
 check_is_debug_mode(){
   # Check if the script is being run in debug mode
   if [[ "${script_option_debug}" == 'true' ]]; then
@@ -401,6 +432,7 @@ success_message() {
 check_is_debian_based
 check_is_bash
 check_has_sudo
+ensure_dependencies_installed
 check_is_debug_mode
 
 # Main install


### PR DESCRIPTION
## Summary
- Add `ensure_dependencies_installed` function that checks for and installs curl before the script needs it
- Update README with one-liner install command for fresh Ubuntu systems
- Function is extensible for future dependency requirements (e.g., whiptail for dialogs)

## Problem
Fresh Ubuntu 24.04 LTS Desktop installs don't have curl installed by default. Users trying to run the install command get:
```
Command 'curl' not found, but can be installed with:
sudo apt install curl
```

## Solution
Two-pronged fix:
1. **Script-level**: Added `ensure_dependencies_installed()` that runs early in pre-flight checks to install curl if missing
2. **README**: Added a one-liner that handles curl installation inline for users who can't even download the script

## Test plan
- [ ] Test install on fresh Ubuntu 24.04 LTS Desktop without curl
- [ ] Test one-liner install command
- [ ] Verify existing installs (with curl already present) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)