### PR TITLE
fix(benchmark): Detect Intel Arc Graphics on Core Ultra processors

### DIFF
--- a/admin/app/services/benchmark_service.ts
+++ b/admin/app/services/benchmark_service.ts
@@ -269,13 +269,22 @@ export class BenchmarkService {
         gpuModel = discreteGpu?.model || graphics.controllers[0]?.model || null
       }
 
-      // Fallback: Extract integrated GPU from CPU model name (common for AMD APUs)
-      // e.g., "AMD Ryzen AI 9 HX 370 w/ Radeon 890M" -> "Radeon 890M"
+      // Fallback: Extract integrated GPU from CPU model name
       if (!gpuModel) {
         const cpuFullName = `${cpu.manufacturer} ${cpu.brand}`
+
+        // AMD APUs: e.g., "AMD Ryzen AI 9 HX 370 w/ Radeon 890M" -> "Radeon 890M"
         const radeonMatch = cpuFullName.match(/w\/\s*(Radeon\s+\d+\w*)/i)
         if (radeonMatch) {
           gpuModel = radeonMatch[1]
+        }
+
+        // Intel Core Ultra: These have Intel Arc Graphics integrated
+        // e.g., "Intel Core Ultra 9 285HX" -> "Intel Arc Graphics (Integrated)"
+        if (!gpuModel && cpu.manufacturer?.toLowerCase().includes('intel')) {
+          if (cpu.brand?.toLowerCase().includes('core ultra')) {
+            gpuModel = 'Intel Arc Graphics (Integrated)'
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

- Adds fallback detection for Intel integrated graphics when Docker can't see host GPU
- Intel Core Ultra processors (Meteor Lake, Arrow Lake like 285HX) now show "Intel Arc Graphics (Integrated)" instead of "Not detected"
- Follows the same pattern we use for AMD APUs with Radeon graphics

## Context

When running NOMAD in Docker, the `systeminformation` library cannot access `/sys/class/drm` to detect GPU hardware. This caused systems with Intel Core Ultra processors (which have Intel Arc Graphics integrated) to show "GPU: Not detected" in benchmarks.

This is a display-only fix - Ollama doesn't support Intel integrated graphics for AI acceleration, so the AI benchmark still runs on CPU. But at least users can see their GPU is recognized.

## Test plan

- [ ] Run benchmark on Intel Core Ultra system - GPU should show "Intel Arc Graphics (Integrated)"
- [ ] Verify AMD APU detection still works (Radeon fallback unchanged)
- [ ] Verify discrete GPU detection still takes priority

🤖 Generated with [Claude Code](https://claude.com/claude-code)