### PR TITLE
feat(ContentManager): Display friendly names instead of filenames

### DIFF
--- a/admin/app/controllers/zim_controller.ts
+++ b/admin/app/controllers/zim_controller.ts
@@ -2,7 +2,7 @@ import { ZimService } from '#services/zim_service'
 import {
   downloadCollectionValidator,
   filenameParamValidator,
-  remoteDownloadValidator,
+  remoteDownloadWithMetadataValidator,
   saveInstalledTierValidator,
   selectWikipediaValidator,
 } from '#validators/common'
@@ -25,8 +25,8 @@ export default class ZimController {
   }
 
   async downloadRemote({ request }: HttpContext) {
-    const payload = await request.validateUsing(remoteDownloadValidator)
-    const { filename, jobId } = await this.zimService.downloadRemote(payload.url)
+    const payload = await request.validateUsing(remoteDownloadWithMetadataValidator)
+    const { filename, jobId } = await this.zimService.downloadRemote(payload.url, payload.metadata)
 
     return {
       message: 'Download started successfully',

--- a/admin/app/models/zim_file_metadata.ts
+++ b/admin/app/models/zim_file_metadata.ts
@@ -1,0 +1,30 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, SnakeCaseNamingStrategy } from '@adonisjs/lucid/orm'
+
+export default class ZimFileMetadata extends BaseModel {
+  static namingStrategy = new SnakeCaseNamingStrategy()
+
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare filename: string
+
+  @column()
+  declare title: string
+
+  @column()
+  declare summary: string | null
+
+  @column()
+  declare author: string | null
+
+  @column()
+  declare size_bytes: number | null
+
+  @column.dateTime({ autoCreate: true })
+  declare created_at: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updated_at: DateTime
+}

--- a/admin/app/validators/common.ts
+++ b/admin/app/validators/common.ts
@@ -11,6 +11,25 @@ export const remoteDownloadValidator = vine.compile(
   })
 )
 
+export const remoteDownloadWithMetadataValidator = vine.compile(
+  vine.object({
+    url: vine
+      .string()
+      .url({
+        require_tld: false, // Allow local URLs
+      })
+      .trim(),
+    metadata: vine
+      .object({
+        title: vine.string().trim().minLength(1),
+        summary: vine.string().trim().optional(),
+        author: vine.string().trim().optional(),
+        size_bytes: vine.number().optional(),
+      })
+      .optional(),
+  })
+)
+
 export const remoteDownloadValidatorOptional = vine.compile(
   vine.object({
     url: vine

--- a/admin/database/migrations/1769700000001_create_zim_file_metadata_table.ts
+++ b/admin/database/migrations/1769700000001_create_zim_file_metadata_table.ts
@@ -1,0 +1,22 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'zim_file_metadata'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').primary()
+      table.string('filename').notNullable().unique()
+      table.string('title').notNullable()
+      table.text('summary').nullable()
+      table.string('author').nullable()
+      table.bigInteger('size_bytes').nullable()
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/admin/inertia/lib/api.ts
+++ b/admin/inertia/lib/api.ts
@@ -99,11 +99,14 @@ class API {
     })()
   }
 
-  async downloadRemoteZimFile(url: string) {
+  async downloadRemoteZimFile(
+    url: string,
+    metadata?: { title: string; summary?: string; author?: string; size_bytes?: number }
+  ) {
     return catchInternal(async () => {
       const response = await this.client.post<{ message: string; filename: string; url: string }>(
         '/zim/download-remote',
-        { url }
+        { url, metadata }
       )
       return response.data
     })()

--- a/admin/inertia/pages/settings/zim/index.tsx
+++ b/admin/inertia/pages/settings/zim/index.tsx
@@ -8,14 +8,14 @@ import { useModals } from '~/context/ModalContext'
 import StyledModal from '~/components/StyledModal'
 import useServiceInstalledStatus from '~/hooks/useServiceInstalledStatus'
 import Alert from '~/components/Alert'
-import { FileEntry } from '../../../../types/files'
+import { ZimFileWithMetadata } from '../../../../types/zim'
 import { SERVICE_NAMES } from '../../../../constants/service_names'
 
 export default function ZimPage() {
   const queryClient = useQueryClient()
   const { openModal, closeAllModals } = useModals()
   const { isInstalled } = useServiceInstalledStatus(SERVICE_NAMES.KIWIX)
-  const { data, isLoading } = useQuery<FileEntry[]>({
+  const { data, isLoading } = useQuery<ZimFileWithMetadata[]>({
     queryKey: ['zim-files'],
     queryFn: getFiles,
   })
@@ -25,7 +25,7 @@ export default function ZimPage() {
     return res.data.files
   }
 
-  async function confirmDeleteFile(file: FileEntry) {
+  async function confirmDeleteFile(file: ZimFileWithMetadata) {
     openModal(
       <StyledModal
         title="Confirm Delete?"
@@ -48,7 +48,7 @@ export default function ZimPage() {
   }
 
   const deleteFileMutation = useMutation({
-    mutationFn: async (file: FileEntry) => api.deleteZimFile(file.name.replace('.zim', '')),
+    mutationFn: async (file: ZimFileWithMetadata) => api.deleteZimFile(file.name.replace('.zim', '')),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['zim-files'] })
     },
@@ -75,13 +75,30 @@ export default function ZimPage() {
               className="!mt-6"
             />
           )}
-          <StyledTable<FileEntry & { actions?: any }>
+          <StyledTable<ZimFileWithMetadata & { actions?: any }>
             className="font-semibold mt-4"
             rowLines={true}
             loading={isLoading}
             compact
             columns={[
-              { accessor: 'name', title: 'Name' },
+              {
+                accessor: 'title',
+                title: 'Title',
+                render: (record) => (
+                  <span className="font-medium">
+                    {record.title || record.name}
+                  </span>
+                ),
+              },
+              {
+                accessor: 'summary',
+                title: 'Summary',
+                render: (record) => (
+                  <span className="text-gray-600 text-sm line-clamp-2">
+                    {record.summary || '—'}
+                  </span>
+                ),
+              },
               {
                 accessor: 'actions',
                 title: 'Actions',

--- a/admin/inertia/pages/settings/zim/remote-explorer.tsx
+++ b/admin/inertia/pages/settings/zim/remote-explorer.tsx
@@ -209,7 +209,12 @@ export default function ZimRemoteExplorer() {
 
   async function downloadFile(record: RemoteZimFileEntry) {
     try {
-      await api.downloadRemoteZimFile(record.download_url)
+      await api.downloadRemoteZimFile(record.download_url, {
+        title: record.title,
+        summary: record.summary,
+        author: record.author,
+        size_bytes: record.size_bytes,
+      })
       invalidateDownloads()
     } catch (error) {
       console.error('Error downloading file:', error)

--- a/admin/types/zim.ts
+++ b/admin/types/zim.ts
@@ -1,7 +1,14 @@
 import { FileEntry } from './files.js'
 
+export type ZimFileWithMetadata = FileEntry & {
+  title: string | null
+  summary: string | null
+  author: string | null
+  size_bytes: number | null
+}
+
 export type ListZimFilesResponse = {
-  files: FileEntry[]
+  files: ZimFileWithMetadata[]
   next?: string
 }
 


### PR DESCRIPTION
## Summary
- Content Manager now shows **Title** and **Summary** columns from Kiwix metadata instead of raw filenames
- Metadata is captured when files are downloaded from Content Explorer and stored in a new `zim_file_metadata` table
- Existing files without metadata gracefully fall back to showing the filename

## Changes
- Add `zim_file_metadata` table and model for storing title, summary, author, size_bytes
- Add `remoteDownloadWithMetadataValidator` to accept optional metadata on download
- Update `ZimService.downloadRemote()` to store metadata when provided
- Update `ZimService.list()` to return enriched data with metadata
- Update `ZimService.delete()` to clean up metadata when files are deleted
- Update Content Manager UI to display Title and Summary columns
- Update Content Explorer to pass metadata when downloading files

## Screenshots
Content Manager now shows friendly names:

| Before | After |
|--------|-------|
| `wikipedia_en_100_mini_2025-06.zim` | Wikipedia (English) - Top 100,000 articles |

## Test plan
- [ ] Run migration: `node ace migration:run`
- [ ] Download a new ZIM file from Content Explorer
- [ ] Verify Title and Summary appear in Content Manager
- [ ] Delete the file and verify metadata is cleaned up
- [ ] Verify existing files without metadata show filename as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)