### PR TITLE
fix(EasySetup): scroll to top when navigating between steps

### DIFF
--- a/admin/inertia/pages/easy-setup/index.tsx
+++ b/admin/inertia/pages/easy-setup/index.tsx
@@ -453,6 +453,11 @@ export default function EasySetupWizard(props: { system: { services: ServiceSlim
     },
   })
 
+  // Scroll to top when step changes
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [currentStep])
+
   // Auto-fetch latest collections if the list is empty
   useEffect(() => {
     if (mapCollections && mapCollections.length === 0 && !fetchLatestMapCollections.isPending) {


### PR DESCRIPTION
## Summary
- Adds scroll-to-top behavior when clicking Next/Back in the Easy Setup Wizard
- Uses smooth scrolling animation for better UX
- Ensures users always see the beginning of each step content

## Problem
When navigating between wizard steps, the browser window remained scrolled at its current position. On steps with lots of content, clicking "Next" would leave the user looking at the middle or bottom of the new step instead of the top.

## Solution
Added a `useEffect` hook that triggers `window.scrollTo({ top: 0, behavior: 'smooth' })` whenever `currentStep` changes.

## Test plan
- [ ] Go through Easy Setup Wizard
- [ ] On each step, scroll down
- [ ] Click "Next" and verify the page scrolls to top
- [ ] Click "Back" and verify the page scrolls to top

🤖 Generated with [Claude Code](https://claude.ai/code)