### PR TITLE
fix(Wikipedia): prevent loading spinner overlay during download

### DIFF
--- a/admin/inertia/components/WikipediaSelector.tsx
+++ b/admin/inertia/components/WikipediaSelector.tsx
@@ -48,7 +48,7 @@ const WikipediaSelector: React.FC<WikipediaSelectorProps> = ({
       {/* Downloading status message */}
       {isDownloading && (
         <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg flex items-center gap-2">
-          <LoadingSpinner className='size-5' />
+          <LoadingSpinner fullscreen={false} iconOnly className="size-5" />
           <span className="text-sm text-blue-700">
             Downloading Wikipedia... This may take a while for larger packages.
           </span>


### PR DESCRIPTION
## Summary
- Fixes overlapping "Loading" text on the Wikipedia downloading status banner
- Changes LoadingSpinner to inline mode instead of fullscreen overlay mode

## Problem
When downloading Wikipedia, a blue status banner displays "Downloading Wikipedia..." with a spinner. However, the `LoadingSpinner` component was using its default `fullscreen={true}` mode, which renders a Semantic UI dimmer overlay with black "Loading" text that overlapped with the banner.

## Solution
Added `fullscreen={false} iconOnly` props to the LoadingSpinner to render just the spinner icon inline within the banner.

## Test plan
- [ ] Start a Wikipedia download from Content Explorer
- [ ] Verify the blue banner shows only the spinner icon and "Downloading Wikipedia..." text
- [ ] Verify no black "Loading" text overlay appears

🤖 Generated with [Claude Code](https://claude.ai/code)