### PR TITLE
fix(docs): use download-then-run install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,9 @@ Project N.O.M.A.D. can be installed on any Debian-based operating system (we rec
 
 *Note: sudo/root privileges are required to run the install script*
 
-#### One-liner (recommended for fresh Ubuntu installs)
+#### Quick Install
 ```bash
-sudo apt-get update && sudo apt-get install -y curl && curl -fsSL https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/master/install/install_nomad.sh | sudo bash
-```
-
-#### Two-step install (if you already have curl)
-```bash
-curl -fsSL https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/master/install/install_nomad.sh -o install_nomad.sh
-```
-
-```bash
-sudo bash install_nomad.sh
+sudo apt-get update && sudo apt-get install -y curl && curl -fsSL https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/master/install/install_nomad.sh -o install_nomad.sh && sudo bash install_nomad.sh
 ```
 
 Project N.O.M.A.D. is now installed on your device! Open a browser and navigate to `http://localhost:8080` (or `http://DEVICE_IP:8080`) to start exploring!


### PR DESCRIPTION
## Summary
- Replaced the pipe-based one-liner (`curl ... | sudo bash`) with a download-then-run command that preserves stdin
- The install script has interactive prompts (`read -p` for install confirmation and license acceptance) that fail silently when stdin is consumed by the pipe, exiting with "Invalid Response - User chose not to continue with the installation"
- Consolidated the old "One-liner" and "Two-step install" sections into a single "Quick Install" command

## Test plan
- [ ] Copy the new install command from the README and run it on a fresh Ubuntu machine
- [ ] Verify the install confirmation prompt appears and accepts `y` input
- [ ] Verify the license acceptance prompt appears and accepts `y` input
- [ ] Verify full installation completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)