### PR TITLE
fix(Downloads): sort active downloads by progress descending

### DIFF
--- a/admin/app/services/download_service.ts
+++ b/admin/app/services/download_service.ts
@@ -37,6 +37,9 @@ export class DownloadService {
     const allDownloads = [...fileDownloads, ...modelDownloads]
 
     // Filter by filetype if specified
-    return allDownloads.filter((job) => !filetype || job.filetype === filetype)
+    const filtered = allDownloads.filter((job) => !filetype || job.filetype === filetype)
+
+    // Sort so actively downloading items (progress > 0) appear first, then by progress descending
+    return filtered.sort((a, b) => b.progress - a.progress)
   }
 }


### PR DESCRIPTION
## Summary
- Active downloads now appear at the top of the download list instead of the bottom
- Sorts by progress percentage descending — the item furthest along is always first, queued items (0%) sink to the bottom
- One-line change in the backend `DownloadService` so all consumers (Content Explorer, etc.) benefit

## Context
During Easy Setup, the content being actively downloaded and its progress bar were at the very bottom of a long list of queued items. Users had to scroll down to see what was happening.

## Test plan
- [ ] Start multiple content downloads (e.g., via Easy Setup or Content Explorer)
- [ ] Verify the item currently downloading (with progress > 0%) appears at the top
- [ ] Verify queued items (0%) appear below active downloads
- [ ] As items complete and new ones start, verify the list reorders correctly (polls every 2 seconds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)