### PR TITLE
fix(collections): correct devdocs ZIM filenames in Computing & Technology

### DIFF
--- a/collections/kiwix-categories.json
+++ b/collections/kiwix-categories.json
@@ -409,25 +409,25 @@
             {
               "title": "Python Documentation",
               "description": "Complete Python language reference and tutorials",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs.io_en_python_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_python_2026-01.zim",
               "size_mb": 4
             },
             {
               "title": "JavaScript Documentation",
               "description": "MDN JavaScript reference and guides",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs.io_en_javascript_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_javascript_2026-01.zim",
               "size_mb": 3
             },
             {
               "title": "HTML Documentation",
               "description": "MDN HTML elements and attributes reference",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs.io_en_html_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_html_2026-01.zim",
               "size_mb": 2
             },
             {
               "title": "CSS Documentation",
               "description": "MDN CSS properties and selectors reference",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs.io_en_css_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_css_2026-01.zim",
               "size_mb": 5
             }
           ]
@@ -453,19 +453,19 @@
             {
               "title": "Node.js Documentation",
               "description": "Node.js API reference and guides",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs.io_en_node_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_node_2026-01.zim",
               "size_mb": 1
             },
             {
               "title": "React Documentation",
               "description": "React library reference and tutorials",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs.io_en_react_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_react_2026-01.zim",
               "size_mb": 3
             },
             {
               "title": "Git Documentation",
               "description": "Git version control reference",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs.io_en_git_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_git_2026-01.zim",
               "size_mb": 1
             }
           ]
@@ -491,13 +491,13 @@
             {
               "title": "Docker Documentation",
               "description": "Docker container reference and guides",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs.io_en_docker_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_docker_2026-01.zim",
               "size_mb": 2
             },
             {
               "title": "Linux Documentation",
               "description": "Linux command reference and system administration",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs.io_en_bash_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_bash_2026-01.zim",
               "size_mb": 1
             }
           ]


### PR DESCRIPTION
## Summary
- Fixed 9 broken download URLs in the Computing & Technology category
- Kiwix renamed devdocs files from `devdocs.io_en_*` to `devdocs_en_*` — the old filenames return 404
- Affects all 3 tiers: Essential (Python, JS, HTML, CSS), Standard (Node.js, React, Git), Comprehensive (Docker, Linux/Bash)

## Context
During Easy Setup on a fresh NOMAD install, selecting a tier for Computing & Technology appeared to work but all devdocs downloads silently failed with 404 errors. Only `freecodecamp_en_all_2025-11.zim` (which uses the correct filename format) downloaded successfully. The category card then showed "Click to choose" instead of highlighting the installed tier because not all resources were present on disk.

Relates to #127

## Test plan
- [ ] Run `curl -sI` against each of the 9 updated URLs to verify they return 302 (redirect to mirror)
- [ ] Select a Computing & Technology tier in Content Explorer and verify all files download successfully
- [ ] After downloads complete, verify the tier highlights correctly on the category card

🤖 Generated with [Claude Code](https://claude.com/claude-code)