### PR TITLE
fix(System): use available memory for usage calculation

### DIFF
--- a/admin/inertia/pages/settings/system.tsx
+++ b/admin/inertia/pages/settings/system.tsx
@@ -17,8 +17,13 @@ export default function SettingsPage(props: {
     initialData: props.system.info,
   })
 
+  // Use (total - available) to reflect actual memory pressure.
+  // mem.used includes reclaimable buff/cache on Linux, which inflates the number.
+  const memoryUsed = info?.mem.total && info?.mem.available != null
+    ? info.mem.total - info.mem.available
+    : info?.mem.used || 0
   const memoryUsagePercent = info?.mem.total
-    ? ((info.mem.used / info.mem.total) * 100).toFixed(1)
+    ? ((memoryUsed / info.mem.total) * 100).toFixed(1)
     : 0
 
   const swapUsagePercent = info?.mem.swaptotal
@@ -118,7 +123,7 @@ export default function SettingsPage(props: {
                   label="Memory Usage"
                   size="lg"
                   variant="memory"
-                  subtext={`${formatBytes(info?.mem.used || 0)} / ${formatBytes(info?.mem.total || 0)}`}
+                  subtext={`${formatBytes(memoryUsed)} / ${formatBytes(info?.mem.total || 0)}`}
                   icon={<IconDatabase className="w-8 h-8" />}
                 />
               </div>
@@ -202,7 +207,7 @@ export default function SettingsPage(props: {
                 </div>
                 <div className="text-center">
                   <div className="text-3xl font-bold text-desert-green mb-1">
-                    {formatBytes(info?.mem.used || 0)}
+                    {formatBytes(memoryUsed)}
                   </div>
                   <div className="text-sm text-desert-stone-dark uppercase tracking-wide">
                     Used RAM
@@ -210,10 +215,10 @@ export default function SettingsPage(props: {
                 </div>
                 <div className="text-center">
                   <div className="text-3xl font-bold text-desert-green mb-1">
-                    {formatBytes(info?.mem.free || 0)}
+                    {formatBytes(info?.mem.available || 0)}
                   </div>
                   <div className="text-sm text-desert-stone-dark uppercase tracking-wide">
-                    Free RAM
+                    Available RAM
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- The System Information page showed **97% memory usage** on a 64GB machine with only ~9GB actually in use by applications, triggering a false "Very High Memory Usage Detected" warning banner
- Root cause: `si.mem().used` on Linux includes reclaimable buff/cache (56GB of disk cache counted as "used")
- Now uses `total - available` which reflects actual memory pressure (~14% instead of 97%)
- Renames "Free RAM" to "Available RAM" using `mem.available` instead of `mem.free`, since `free` excludes reclaimable cache and shows a misleadingly small number

## Before / After (NOMAD3 - 64GB RAM)
| Metric | Before | After |
|--------|--------|-------|
| Gauge | 97% (60.5 / 62.5 GB) | ~14% (9.6 / 62.5 GB) |
| Warning banner | Visible (>90%) | Hidden |
| "Used RAM" | 60.5 GB | 9.6 GB |
| "Free RAM" | 2.0 GB | — |
| "Available RAM" | — | 53 GB |

## Context
This supersedes the memory fix from PR #163 (`812d13c`), which changed the calculation from `(total - available) / total` to `used / total` to make the percentage match the displayed "Used" number. Both values were wrong — `mem.used` includes buff/cache on Linux. The correct fix is to use `total - available` for **both** the percentage and the displayed number.

## Test plan
- [ ] Verify gauge shows actual memory pressure (~14% on NOMAD3) instead of buff/cache-inflated value (~97%)
- [ ] Verify warning banner does not appear when available memory is sufficient
- [ ] Verify "Available RAM" shows realistic value (~53GB on NOMAD3)
- [ ] Verify gauge subtext matches the "Used RAM" number in Memory Allocation section

🤖 Generated with [Claude Code](https://claude.com/claude-code)