### PR TITLE
fix(UI): replace WikiHow reference with DIY repair guides

### DIFF
--- a/admin/inertia/pages/easy-setup/index.tsx
+++ b/admin/inertia/pages/easy-setup/index.tsx
@@ -43,7 +43,7 @@ function buildCoreCapabilities(aiAssistantName: string): Capability[] {
       features: [
         'Complete Wikipedia offline',
         'Medical references and first aid guides',
-        'WikiHow articles and tutorials',
+        'DIY repair guides and how-to content',
         'Project Gutenberg books and literature',
       ],
       services: [SERVICE_NAMES.KIWIX],


### PR DESCRIPTION
## Summary
- WikiHow ZIM files were [deprecated by Kiwix](https://kiwix.org/en/wikihow-content-has-been-deprecated/) after WikiHow requested removal to protect content from LLM training harvesting
- Replaces "WikiHow articles and tutorials" with "DIY repair guides and how-to content" in the Easy Setup wizard's Information Library feature list
- This accurately reflects the iFixit, Stack Exchange DIY, and other how-to content available in NOMAD's curated collections

## Test plan
- [ ] Verify Easy Setup wizard Step 1 shows "DIY repair guides and how-to content" under Information Library features

🤖 Generated with [Claude Code](https://claude.com/claude-code)