### PR TITLE
feat(collections): add Project Gutenberg ZIMs and fix broken education entry

### DIFF
--- a/collections/kiwix-categories.json
+++ b/collections/kiwix-categories.json
@@ -156,7 +156,7 @@
         {
           "name": "Comprehensive",
           "slug": "survival-comprehensive",
-          "description": "Complete prepper video library with long-term food storage strategies. Includes everything in Standard.",
+          "description": "Complete prepper library with food storage strategies and classic military strategy. Includes everything in Standard.",
           "includesTier": "survival-standard",
           "resources": [
             {
@@ -166,6 +166,14 @@
               "description": "Long-term food storage and survival meal preparation",
               "url": "https://download.kiwix.org/zim/videos/canadian_prepper_preppingfood_en_2025-09.zim",
               "size_mb": 2160
+            },
+            {
+              "id": "gutenberg_en_lcc-u",
+              "version": "2026-03",
+              "title": "Project Gutenberg: Military Science",
+              "description": "Classic military strategy, tactics, and field manuals",
+              "url": "https://download.kiwix.org/zim/gutenberg/gutenberg_en_lcc-u_2026-03.zim",
+              "size_mb": 1200
             }
           ]
         }
@@ -247,14 +255,6 @@
               "description": "Biology courses and textbooks",
               "url": "https://download.kiwix.org/zim/libretexts/libretexts.org_en_bio_2025-01.zim",
               "size_mb": 2240
-            },
-            {
-              "id": "gutenberg_en_education",
-              "version": "2025-12",
-              "title": "Project Gutenberg: Education",
-              "description": "Classic educational texts and resources",
-              "url": "https://download.kiwix.org/zim/gutenberg/gutenberg_en_education_2025-12.zim",
-              "size_mb": 606
             }
           ]
         },
@@ -447,7 +447,7 @@
         {
           "name": "Comprehensive",
           "slug": "agriculture-comprehensive",
-          "description": "Complete self-sufficiency with homesteading videos and advanced techniques. Includes Standard.",
+          "description": "Complete self-sufficiency with homesteading videos, classic agricultural texts, and advanced techniques. Includes Standard.",
           "includesTier": "agriculture-standard",
           "resources": [
             {
@@ -457,6 +457,14 @@
               "description": "Beekeeping, animal husbandry, and sustainable living practices",
               "url": "https://download.kiwix.org/zim/videos/lrnselfreliance_en_all_2025-12.zim",
               "size_mb": 3970
+            },
+            {
+              "id": "gutenberg_en_lcc-s",
+              "version": "2026-03",
+              "title": "Project Gutenberg: Agriculture",
+              "description": "Classic texts on farming, animal husbandry, plant cultivation, and food preservation",
+              "url": "https://download.kiwix.org/zim/gutenberg/gutenberg_en_lcc-s_2026-03.zim",
+              "size_mb": 4300
             }
           ]
         }


### PR DESCRIPTION
## Summary
- Add **Project Gutenberg: Agriculture** (LCC-S, 4.3 GB) to Agriculture & Food Comprehensive tier — classic texts on farming, animal husbandry, plant cultivation, and food preservation
- Add **Project Gutenberg: Military Science** (LCC-U, 1.2 GB) to Survival & Preparedness Comprehensive tier — classic military strategy, tactics, and field manuals
- Remove broken `gutenberg_en_education` entry from Education Standard tier — URL returned 404 (Kiwix only publishes LCC-coded Gutenberg ZIMs, not topic-named ones)

### Why these specific Gutenberg ZIMs?
Kiwix organizes Project Gutenberg into ~30 categories using Library of Congress Classification codes. Most contain pre-1928 public domain books. We evaluated all categories and selected only those with **still-relevant content**:

| LCC Code | Subject | Size | Decision |
|----------|---------|------|----------|
| S | Agriculture | 4.3 GB | **Added** — farming, food preservation techniques are timeless |
| U | Military Science | 1.2 GB | **Added** — classic strategy and tactics fit prepper audience |
| R | Medicine | 1.9 GB | Skipped — pre-1928 medical advice could be harmful |
| T | Technology | 12 GB | Skipped — too large, mostly obsolete |
| Q | Science | 17 GB | Skipped — too large for a single resource |
| L | Education | 600 MB | Skipped — educational philosophy not practical enough |

### Size impact
- Agriculture Comprehensive: +4,300 MB (tier total now ~9.5 GB additional)
- Survival Comprehensive: +1,200 MB (tier total now ~3.4 GB additional)
- Education Standard: -606 MB (removed broken entry that was never downloadable)

## Test plan
- [ ] Verify both new Gutenberg download URLs resolve (302 redirect confirmed)
- [ ] Verify `gutenberg_en_education` removal doesn't break existing installs
- [ ] Test Easy Setup flow with Agriculture Comprehensive and Survival Comprehensive tiers selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)