### PR TITLE
fix(security): rotate benchmark HMAC signing secret

### DIFF
--- a/admin/app/services/benchmark_service.ts
+++ b/admin/app/services/benchmark_service.ts
@@ -32,7 +32,7 @@ import Dockerode from 'dockerode'
 // This provides basic protection against casual API abuse.
 // Note: Since NOMAD is open source, a determined attacker could extract this.
 // For stronger protection, see challenge-response authentication.
-const BENCHMARK_HMAC_SECRET = 'nomad-benchmark-v1-2026'
+const BENCHMARK_HMAC_SECRET = '778ba65d0bc0e23119e5ffce4b3716648a7d071f0a47ec3f'
 
 // Re-export default weights for use in service
 const SCORE_WEIGHTS = {


### PR DESCRIPTION
## Summary
- Rotate the HMAC signing secret used for benchmark leaderboard submissions
- A fake entry was submitted to the community leaderboard using the old hardcoded secret (claimed to be running on LLNL's El Capitan supercomputer with 43,808 GPUs)
- Leaderboard-side changes already deployed: builder tag format validation, semver version validation, tighter AI plausibility limits (500 → 250 tok/s), and the fake entry has been removed

## Test plan
- [ ] Verify benchmark submission still works after both sides are deployed with the new secret
- [ ] Confirm existing NOMAD installations will get proper error message if they try to submit with old secret (they'll see "Invalid HMAC signature. Please update to the latest version of NOMAD.")

🤖 Generated with [Claude Code](https://claude.com/claude-code)