### PR TITLE
fix(collections): update stale React devdocs ZIM URL

### DIFF
--- a/collections/kiwix-categories.json
+++ b/collections/kiwix-categories.json
@@ -557,10 +557,10 @@
             },
             {
               "id": "devdocs_en_react",
-              "version": "2026-01",
+              "version": "2026-02",
               "title": "React Documentation",
               "description": "React library reference and tutorials",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_react_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_react_2026-02.zim",
               "size_mb": 3
             },
             {


### PR DESCRIPTION
## Summary
- Kiwix skipped the January 2026 build of `devdocs_en_react` — the `2026-01` URL returns 404
- Updated to `2026-02` which exists and resolves correctly
- Same class of bug as PR #166 (devdocs URL renames)

Closes #269

## Test plan
- [ ] Verified `devdocs_en_react_2026-02.zim` returns HTTP 302 from Kiwix servers
- [ ] Select Computing & Technology → Standard or Comprehensive and confirm React docs download successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)