### PR TITLE
fix(security): disable Dozzle web shell access

### DIFF
--- a/install/management_compose.yaml
+++ b/install/management_compose.yaml
@@ -52,7 +52,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # Allows Dozzle to read logs from the Host's Docker daemon
     environment:
-      - DOZZLE_ENABLE_ACTIONS=true # Enables the action buttons (restart, stop, etc.)
+      - DOZZLE_ENABLE_ACTIONS=false # Disabled — unauthenticated container stop/restart on LAN
       - DOZZLE_ENABLE_SHELL=false  # Disabled — shell access + Docker socket = privilege escalation
   mysql:
     image: mysql:8.0


### PR DESCRIPTION
## Summary
- Disables `DOZZLE_ENABLE_SHELL` in the management compose template
- Disables `DOZZLE_ENABLE_ACTIONS` in the management compose template
- Shell access + Docker socket mount = privilege escalation path to host root
- Actions on an unauthenticated port allow anyone on LAN to stop/restart containers
- NOMAD already manages containers through its own admin UI — Dozzle only needs log viewing

Closes #278

## Test plan
- [ ] Verify Dozzle UI still shows container logs on port 9999
- [ ] Verify shell access is no longer available in Dozzle UI
- [ ] Verify container action buttons (start/stop/restart) are no longer available

🤖 Generated with [Claude Code](https://claude.com/claude-code)