### PR TITLE
fix(security): remove MySQL and Redis port exposure to host

### DIFF
--- a/install/management_compose.yaml
+++ b/install/management_compose.yaml
@@ -58,8 +58,6 @@ services:
     image: mysql:8.0
     container_name: nomad_mysql
     restart: unless-stopped
-    ports:
-      - "3306:3306"
     environment:
       - MYSQL_ROOT_PASSWORD=replaceme
       - MYSQL_DATABASE=nomad
@@ -76,8 +74,6 @@ services:
     image: redis:7-alpine
     container_name: nomad_redis
     restart: unless-stopped
-    ports:
-      - "6379:6379"
     volumes:
       - /opt/project-nomad/redis:/data
     healthcheck:


### PR DESCRIPTION
## Summary
- Removes `ports:` mappings for MySQL (3306) and Redis (6379) from the compose template
- Both services are only accessed by the admin container via Docker's internal network (service names `mysql` and `redis`)
- Redis has no authentication, so LAN exposure was unnecessary risk

Closes #279

## Test plan
- [ ] Fresh install: verify admin container connects to MySQL and Redis normally
- [ ] Verify MySQL and Redis ports are no longer accessible from the host network
- [ ] Verify all NOMAD features work (downloads, benchmarks, AI chat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)