### PR TITLE
fix: default LOG_LEVEL to info in production

### DIFF
--- a/install/management_compose.yaml
+++ b/install/management_compose.yaml
@@ -19,7 +19,7 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=8080
-      - LOG_LEVEL=debug
+      - LOG_LEVEL=info
       - APP_KEY=replaceme
       - HOST=0.0.0.0
       - URL=replaceme


### PR DESCRIPTION
## Summary
- Changes `LOG_LEVEL=debug` to `LOG_LEVEL=info` in the management compose template
- Debug logging in production is noisy and unnecessary for most users
- Users who need debug output can still override in their local compose.yml

Closes #285

## Test plan
- [ ] Fresh install: verify admin container starts with info-level logging
- [ ] Verify no missing log output that users/support depend on

🤖 Generated with [Claude Code](https://claude.com/claude-code)