### PR TITLE
feat(collections): add Entertainment & Recreation category

### DIFF
--- a/collections/kiwix-categories.json
+++ b/collections/kiwix-categories.json
@@ -614,6 +614,87 @@
           ]
         }
       ]
+    },
+    {
+      "name": "Entertainment & Recreation",
+      "slug": "entertainment",
+      "icon": "IconDeviceGamepad2",
+      "description": "Tabletop RPG knowledge, board game rules, chess strategy, sci-fi lore, and gaming guides for offline entertainment.",
+      "language": "en",
+      "tiers": [
+        {
+          "name": "Essential",
+          "slug": "entertainment-essential",
+          "description": "Tabletop RPG and board game knowledge \u2014 rules Q&A, strategy, and chess. Start here.",
+          "recommended": true,
+          "resources": [
+            {
+              "id": "rpg.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "RPG Stack Exchange",
+              "description": "Q&A for D&D, Pathfinder, FATE, and hundreds of tabletop RPG systems \u2014 rules, mechanics, GMing advice",
+              "url": "https://download.kiwix.org/zim/stack_exchange/rpg.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 321
+            },
+            {
+              "id": "boardgames.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "Board Games Stack Exchange",
+              "description": "Rules clarifications and strategy for hundreds of board and card games",
+              "url": "https://download.kiwix.org/zim/stack_exchange/boardgames.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 102
+            },
+            {
+              "id": "chess.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "Chess Stack Exchange",
+              "description": "Chess strategy, openings, endgames, puzzles, and engine analysis",
+              "url": "https://download.kiwix.org/zim/stack_exchange/chess.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 77
+            }
+          ]
+        },
+        {
+          "name": "Standard",
+          "slug": "entertainment-standard",
+          "description": "Adds worldbuilding and sci-fi/fantasy reference. Includes everything in Essential.",
+          "includesTier": "entertainment-essential",
+          "resources": [
+            {
+              "id": "worldbuilding.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "Worldbuilding Stack Exchange",
+              "description": "Setting design, lore creation, and fiction worldbuilding Q&A",
+              "url": "https://download.kiwix.org/zim/stack_exchange/worldbuilding.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 797
+            },
+            {
+              "id": "scifi.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "Sci-Fi & Fantasy Stack Exchange",
+              "description": "Encyclopedic Q&A covering sci-fi and fantasy books, films, TV, and games",
+              "url": "https://download.kiwix.org/zim/stack_exchange/scifi.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 1200
+            }
+          ]
+        },
+        {
+          "name": "Comprehensive",
+          "slug": "entertainment-comprehensive",
+          "description": "Full entertainment reference including video game guides. Includes everything in Standard.",
+          "includesTier": "entertainment-standard",
+          "resources": [
+            {
+              "id": "gaming.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "Gaming Stack Exchange (Arqade)",
+              "description": "Video game walkthroughs, tips, and technical troubleshooting",
+              "url": "https://download.kiwix.org/zim/stack_exchange/gaming.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 771
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Partially addresses #306

## Summary

Adds an **Entertainment & Recreation** category to the Kiwix content catalog with three tiers of offline entertainment resources.

## What's included

All resources are pre-built ZIM files already hosted on `download.kiwix.org` — no custom ZIM generation needed.

| Tier | Content | Cumulative Size |
|---|---|---|
| **Essential** | RPG SE (D&D, Pathfinder, FATE Q&A), Board Games SE, Chess SE | ~500 MB |
| **Standard** | + Worldbuilding SE, Sci-Fi & Fantasy SE | ~2.5 GB |
| **Comprehensive** | + Gaming SE (Arqade — video game guides) | ~3.3 GB |

## How this relates to #306

Issue #306 requests TTRPG SRD websites (5esrd.com, fate-srd.com, etc.) packaged for offline use. Those sites don't have pre-built ZIM files on Kiwix's servers, so they can't be added using the current content architecture.

However, the **RPG Stack Exchange** (321 MB, 60k+ answered questions) covers the same rule systems — D&D 5e, Pathfinder 2e, FATE, Dungeon World, and hundreds of others — with detailed rules Q&A, mechanics breakdowns, and GMing advice. For offline game nights, this is arguably more useful than the raw SRD text.

Archiving the actual SRD websites would require a `zimit` integration (Kiwix's web-to-ZIM tool) — a larger feature that could be its own issue.

## Changes

One file: `collections/kiwix-categories.json` — added new category entry following the existing spec format. No code changes.