### PR TITLE
fix: surface actual error message when service installation fails

### DIFF
--- a/admin/app/controllers/system_controller.ts
+++ b/admin/app/controllers/system_controller.ts
@@ -35,7 +35,7 @@ export default class SystemController {
         if (result.success) {
             response.send({ success: true, message: result.message });
         } else {
-            response.status(400).send({ error: result.message });
+            response.status(400).send({ success: false, message: result.message });
         }
     }
 

--- a/admin/inertia/lib/api.ts
+++ b/admin/inertia/lib/api.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from 'axios'
+import axios, { AxiosError, AxiosInstance } from 'axios'
 import { ListRemoteZimFilesResponse, ListZimFilesResponse } from '../../types/zim'
 import { ServiceSlim } from '../../types/services'
 import { FileEntry } from '../../types/files'
@@ -25,13 +25,19 @@ class API {
   }
 
   async affectService(service_name: string, action: 'start' | 'stop' | 'restart') {
-    return catchInternal(async () => {
+    try {
       const response = await this.client.post<{ success: boolean; message: string }>(
         '/system/services/affect',
         { service_name, action }
       )
       return response.data
-    })()
+    } catch (error) {
+      if (error instanceof AxiosError && error.response?.data?.message) {
+        return { success: false, message: error.response.data.message }
+      }
+      console.error('Error affecting service:', error)
+      return undefined
+    }
   }
 
   async checkLatestVersion(force: boolean = false) {
@@ -192,13 +198,19 @@ class API {
   }
 
   async forceReinstallService(service_name: string) {
-    return catchInternal(async () => {
+    try {
       const response = await this.client.post<{ success: boolean; message: string }>(
         `/system/services/force-reinstall`,
         { service_name }
       )
       return response.data
-    })()
+    } catch (error) {
+      if (error instanceof AxiosError && error.response?.data?.message) {
+        return { success: false, message: error.response.data.message }
+      }
+      console.error('Error force reinstalling service:', error)
+      return undefined
+    }
   }
 
   async getChatSuggestions(signal?: AbortSignal) {
@@ -452,13 +464,19 @@ class API {
   }
 
   async installService(service_name: string) {
-    return catchInternal(async () => {
+    try {
       const response = await this.client.post<{ success: boolean; message: string }>(
         '/system/services/install',
         { service_name }
       )
       return response.data
-    })()
+    } catch (error) {
+      if (error instanceof AxiosError && error.response?.data?.message) {
+        return { success: false, message: error.response.data.message }
+      }
+      console.error('Error installing service:', error)
+      return undefined
+    }
   }
 
   async listCuratedMapCollections() {


### PR DESCRIPTION
## Problem

Attempting to install a service that fails preflight checks shows a generic error:

> "Failed to install service: An internal error occurred while trying to install the service."

The actual reason — already installed, installation already in progress, service not found — is never shown to the user. This makes it impossible to diagnose the root cause of failures like #307.

## Root Cause

Two issues in the error handling chain:

1. **Backend** (`system_controller.ts`): The 400 error response sent `{ error: result.message }` but the frontend expected the `message` key. The response shape was inconsistent with the success path (`{ success, message }`).

2. **Frontend** (`api.ts`): The `catchInternal` wrapper caught Axios errors from 400 responses and returned `undefined`, completely discarding the server's error message. The caller in `apps.tsx` then saw a falsy response and threw a generic "An internal error occurred" — hiding the real reason.

```
Server returns 400 { error: "Service already installed" }
  → Axios throws (400 is error status)
    → catchInternal catches, logs, returns undefined
      → installService() sees !response, throws generic error
        → User sees "An internal error occurred"
```

## Fix

**Backend**: Changed 400 response shape from `{ error: message }` to `{ success: false, message }` for consistency.

**Frontend**: Replaced `catchInternal` wrapper with direct error handling in `installService`, `affectService`, and `forceReinstallService`. On Axios errors with a response body, extracts `error.response.data.message` and returns `{ success: false, message }` so callers display the real error.

```
Server returns 400 { success: false, message: "Service already installed" }
  → Axios throws
    → API method catches, extracts message, returns { success: false, message }
      → installService() sees !response.success, shows real message
        → User sees "Failed to install service: Service already installed"
```

## Files Changed

| File | Change |
|------|--------|
| `admin/app/controllers/system_controller.ts` | Fix 400 response shape |
| `admin/inertia/lib/api.ts` | Replace `catchInternal` with direct Axios error extraction in 3 methods |

## Related

Ref #307 — this fix will surface the actual error message for that user's failed AI Assistant install, helping isolate the underlying cause.