### PR TITLE
feat(rag): make Knowledge Base upload size limit configurable

### DIFF
--- a/admin/inertia/components/chat/KnowledgeBaseModal.tsx
+++ b/admin/inertia/components/chat/KnowledgeBaseModal.tsx
@@ -10,6 +10,7 @@ import { IconX } from '@tabler/icons-react'
 import { useModals } from '~/context/ModalContext'
 import StyledModal from '../StyledModal'
 import ActiveEmbedJobs from '~/components/ActiveEmbedJobs'
+import { useSystemSetting } from '~/hooks/useSystemSetting'
 
 interface KnowledgeBaseModalProps {
   aiAssistantName?: string
@@ -28,6 +29,13 @@ export default function KnowledgeBaseModal({ aiAssistantName = "AI Assistant", o
   const fileUploaderRef = useRef<React.ComponentRef<typeof FileUploader>>(null)
   const { openModal, closeModal } = useModals()
   const queryClient = useQueryClient()
+
+  const DEFAULT_MAX_FILE_SIZE_MB = 100
+  const { data: maxFileSizeSetting } = useSystemSetting({ key: 'rag.maxFileSizeMB' })
+  const maxFileSizeMB = maxFileSizeSetting?.value
+    ? Number(maxFileSizeSetting.value)
+    : DEFAULT_MAX_FILE_SIZE_MB
+  const maxFileSize = maxFileSizeMB * 1024 * 1024
 
   const { data: storedFiles = [], isLoading: isLoadingFiles } = useQuery({
     queryKey: ['storedFiles'],
@@ -134,6 +142,7 @@ export default function KnowledgeBaseModal({ aiAssistantName = "AI Assistant", o
                 ref={fileUploaderRef}
                 minFiles={1}
                 maxFiles={1}
+                maxFileSize={maxFileSize}
                 onUpload={(uploadedFiles) => {
                   setFiles(Array.from(uploadedFiles))
                 }}

--- a/admin/inertia/components/file-uploader/index.tsx
+++ b/admin/inertia/components/file-uploader/index.tsx
@@ -29,7 +29,7 @@ const FileUploader = forwardRef<FileUploaderRef, FileUploaderProps>((props, ref)
   const {
     minFiles = 0,
     maxFiles = 1,
-    maxFileSize = 10485760, // default to 10MB
+    maxFileSize = 104857600, // default to 100MB
     fileTypes,
     disabled = false,
     onUpload,

--- a/admin/types/kv_store.ts
+++ b/admin/types/kv_store.ts
@@ -8,6 +8,7 @@ export const KV_STORE_SCHEMA = {
   'system.earlyAccess':         'boolean',
   'ui.hasVisitedEasySetup':     'boolean',
   'ai.assistantCustomName':     'string',
+  'rag.maxFileSizeMB':          'string',
 } as const
 
 type KVTagToType<T extends string> = T extends 'boolean' ? boolean : string


### PR DESCRIPTION
## Summary

Increases the Knowledge Base file upload size limit from 10MB to 100MB and makes it configurable via the existing KV store settings system.

## Changes

- **`admin/inertia/components/file-uploader/index.tsx`** — Default `maxFileSize` increased from 10MB (10485760) to 100MB (104857600)
- **`admin/types/kv_store.ts`** — Added `rag.maxFileSizeMB` setting key
- **`admin/inertia/components/chat/KnowledgeBaseModal.tsx`** — Reads `rag.maxFileSizeMB` from system settings via `useSystemSetting` hook and passes it to `FileUploader`. Falls back to 100MB if not configured.

## Why

Technical PDFs and reference manuals (O'Reilly books, field guides, repair manuals) are typically 15-50MB, making the previous 10MB default too restrictive for the Knowledge Base's primary use case.

The configurable setting via KV store is ready for integration into the planned Advanced Features settings UI.

## Testing

- Verified upload of 30MB+ PDFs succeeds with the new default
- Setting `rag.maxFileSizeMB` via `PATCH /api/system/settings` correctly adjusts the limit
- Fallback to 100MB default works when no setting is configured

Closes #259