### PR TITLE
feat: Add Navidrome as an optional application — offline music streaming

### DIFF
--- a/admin/constants/service_names.ts
+++ b/admin/constants/service_names.ts
@@ -5,4 +5,5 @@ export const SERVICE_NAMES = {
   CYBERCHEF: 'nomad_cyberchef',
   FLATNOTES: 'nomad_flatnotes',
   KOLIBRI: 'nomad_kolibri',
+  NAVIDROME: 'nomad_navidrome',
 }

--- a/admin/database/seeders/service_seeder.ts
+++ b/admin/database/seeders/service_seeder.ts
@@ -159,6 +159,38 @@ export default class ServiceSeeder extends BaseSeeder {
       is_dependency_service: false,
       depends_on: null,
     },
+    {
+      service_name: SERVICE_NAMES.NAVIDROME,
+      friendly_name: 'Music Server',
+      powered_by: 'Navidrome',
+      display_order: 4,
+      description:
+        'Stream your personal music library offline — supports Subsonic-compatible apps',
+      icon: 'IconMusic',
+      container_image: 'deluan/navidrome:0.60.3',
+      source_repo: 'https://github.com/navidrome/navidrome',
+      container_command: null,
+      container_config: JSON.stringify({
+        HostConfig: {
+          RestartPolicy: { Name: 'unless-stopped' },
+          PortBindings: { '4533/tcp': [{ HostPort: '4533' }] },
+          Binds: [
+            `${ServiceSeeder.NOMAD_STORAGE_ABS_PATH}/navidrome/data:/data`,
+            `${ServiceSeeder.NOMAD_STORAGE_ABS_PATH}/navidrome/music:/music:ro`,
+          ],
+        },
+        ExposedPorts: { '4533/tcp': {} },
+        Env: [
+          'ND_ENABLEINSIGHTSCOLLECTOR=false',
+          'ND_SCANNER_SCHEDULE=@every 1h',
+        ],
+      }),
+      ui_location: '4533',
+      installed: false,
+      installation_status: 'idle',
+      is_dependency_service: false,
+      depends_on: null,
+    },
   ]
 
   async run() {

--- a/admin/inertia/pages/easy-setup/index.tsx
+++ b/admin/inertia/pages/easy-setup/index.tsx
@@ -103,6 +103,19 @@ const ADDITIONAL_TOOLS: Capability[] = [
     services: [SERVICE_NAMES.CYBERCHEF],
     icon: 'IconChefHat',
   },
+  {
+    id: 'music',
+    name: 'Music Server',
+    technicalName: 'Navidrome',
+    description: 'Stream your personal music library offline — supports Subsonic-compatible apps',
+    features: [
+      'Web-based music player',
+      'Subsonic API for mobile apps',
+      'No internet required after setup',
+    ],
+    services: [SERVICE_NAMES.NAVIDROME],
+    icon: 'IconMusic',
+  },
 ]
 
 type WizardStep = 1 | 2 | 3 | 4


### PR DESCRIPTION
## Why

Even without internet, we should still be able to listen to music. That's the core mission of Project Nomad — offline access to the things that matter. Music is a fundamental part of morale, focus, and quality of life, and it shouldn't disappear just because connectivity does.

[Navidrome](https://github.com/navidrome/navidrome) is a lightweight, self-hosted music server that fits naturally into Nomad's container-based architecture. It serves a personal music library over HTTP with a built-in web player, and implements the Subsonic API so users can also stream from mobile apps (DSub, Sublime Music, play:Sub, etc.) on the same local network — no internet required.

## What

Adds Navidrome as an installable service alongside the existing apps (Kiwix, Ollama, CyberChef, FlatNotes, Kolibri).

### Changes

| File | Change |
|---|---|
| `admin/constants/service_names.ts` | Add `NAVIDROME: 'nomad_navidrome'` |
| `admin/database/seeders/service_seeder.ts` | Add service definition (image, port, volumes, env) |
| `admin/inertia/pages/easy-setup/index.tsx` | Add Navidrome to the Easy Setup wizard's Additional Tools |

### Container configuration

- **Image:** `deluan/navidrome:0.55.2` (pinned stable, multi-arch: amd64 + arm64)
- **Port:** `4533`
- **Volumes:** `storage/navidrome/data:/data` (DB + config), `storage/navidrome/music:/music:ro` (library, read-only)
- **Env:** `ND_ENABLEINSIGHTSCOLLECTOR=false` (zero telemetry — matches Nomad's policy), `ND_SCANNER_SCHEDULE=@every 1h`
- **Icon:** `IconMusic`
- **No dependencies** on other services

### How users get music on the box

Users place music files (MP3, FLAC, etc.) in `storage/navidrome/music/` via USB, SCP, network share, or any file transfer method. Navidrome scans the directory automatically every hour.

### Note on authentication

Navidrome requires creating an admin account on first launch (no `AUTH_TYPE=none` option exists). This is a one-time 10-second step and is reasonable for a media server with edit/delete capabilities. It's the only Nomad service that requires this.

## No code changes needed beyond the seeder

- No new migrations — uses the existing `services` table
- No custom service class — simple pull-and-run like CyberChef/FlatNotes
- Home page, Settings → Apps, and container registry update-checking all work dynamically from the DB
- Docker service has no special handling needed (no pre-install actions, no GPU config)