### PR TITLE
feat: add arm64 (linux/arm64) support to Docker build workflows

### DIFF
--- a/.github/workflows/build-disk-collector.yml
+++ b/.github/workflows/build-disk-collector.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -45,6 +49,7 @@ jobs:
         with:
           context: install/sidecar-disk-collector
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/crosstalk-solutions/project-nomad-disk-collector:${{ inputs.version }}
             ghcr.io/crosstalk-solutions/project-nomad-disk-collector:v${{ inputs.version }}

--- a/.github/workflows/build-primary-image.yml
+++ b/.github/workflows/build-primary-image.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -44,6 +48,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/crosstalk-solutions/project-nomad:${{ inputs.version }}
             ghcr.io/crosstalk-solutions/project-nomad:v${{ inputs.version }}


### PR DESCRIPTION
## Summary

- Add `setup-qemu-action` and `setup-buildx-action` steps to both image build workflows
- Set `platforms: linux/amd64,linux/arm64` in both `build-primary-image.yml` and `build-disk-collector.yml`

Both base images (`node:22-slim` and `alpine:3.20`) already have full multiarch support, so only the CI/CD workflows needed updating.

## Motivation

Project N.O.M.A.D. currently builds Docker images only for `linux/amd64`. All individual tool dependencies (Ollama, Qdrant, Kiwix, Kolibri, ProtoMaps, FlatNotes, CyberChef) support arm64, making arm64 hosts (Raspberry Pi 5, Apple Silicon servers, AWS Graviton) viable targets once the main images are built multiarch.

## Test plan

- [ ] Trigger `Build Primary Docker Image` workflow and verify both `linux/amd64` and `linux/arm64` layers appear in GHCR
- [ ] Trigger `Build Disk Collector Image` workflow and verify same
- [ ] Run install script on an arm64 Debian-based system

🤖 Generated with [Claude Code](https://claude.com/claude-code)