### PR TITLE
fix: prevent embedding retry storm when Ollama is not installed

### DIFF
--- a/admin/app/jobs/embed_file_job.ts
+++ b/admin/app/jobs/embed_file_job.ts
@@ -1,4 +1,4 @@
-import { Job } from 'bullmq'
+import { Job, UnrecoverableError } from 'bullmq'
 import { QueueService } from '#services/queue_service'
 import { EmbedJobWithProgress } from '../../types/rag.js'
 import { RagService } from '#services/rag_service'
@@ -42,7 +42,15 @@ export class EmbedFileJob {
     const ragService = new RagService(dockerService, ollamaService)
 
     try {
-      // Check if Ollama and Qdrant services are ready
+      // Check if Ollama and Qdrant services are installed and ready
+      // Use UnrecoverableError for "not installed" so BullMQ won't retry —
+      // retrying 30x when the service doesn't exist just wastes Redis connections
+      const ollamaUrl = await dockerService.getServiceURL('nomad_ollama')
+      if (!ollamaUrl) {
+        logger.warn('[EmbedFileJob] Ollama is not installed. Skipping embedding for: %s', fileName)
+        throw new UnrecoverableError('Ollama service is not installed. Install AI Assistant to enable file embeddings.')
+      }
+
       const existingModels = await ollamaService.getModels()
       if (!existingModels) {
         logger.warn('[EmbedFileJob] Ollama service not ready yet. Will retry...')
@@ -51,8 +59,8 @@ export class EmbedFileJob {
 
       const qdrantUrl = await dockerService.getServiceURL('nomad_qdrant')
       if (!qdrantUrl) {
-        logger.warn('[EmbedFileJob] Qdrant service not ready yet. Will retry...')
-        throw new Error('Qdrant service not ready yet')
+        logger.warn('[EmbedFileJob] Qdrant is not installed. Skipping embedding for: %s', fileName)
+        throw new UnrecoverableError('Qdrant service is not installed. Install AI Assistant to enable file embeddings.')
       }
 
       logger.info(`[EmbedFileJob] Services ready. Processing file: ${fileName}`)

--- a/admin/app/jobs/run_download_job.ts
+++ b/admin/app/jobs/run_download_job.ts
@@ -82,14 +82,17 @@ export class RunDownloadJob {
             const zimService = new ZimService(dockerService)
             await zimService.downloadRemoteSuccessCallback([url], true)
 
-            // Dispatch an embedding job for the downloaded ZIM file
-            try {
-              await EmbedFileJob.dispatch({
-                fileName: url.split('/').pop() || '',
-                filePath: filepath,
-              })
-            } catch (error) {
-              console.error(`[RunDownloadJob] Error dispatching EmbedFileJob for URL ${url}:`, error)
+            // Only dispatch embedding job if AI Assistant (Ollama) is installed
+            const ollamaUrl = await dockerService.getServiceURL('nomad_ollama')
+            if (ollamaUrl) {
+              try {
+                await EmbedFileJob.dispatch({
+                  fileName: url.split('/').pop() || '',
+                  filePath: filepath,
+                })
+              } catch (error) {
+                console.error(`[RunDownloadJob] Error dispatching EmbedFileJob for URL ${url}:`, error)
+              }
             }
           } else if (filetype === 'map') {
             const mapsService = new MapService()


### PR DESCRIPTION
## Summary

- Don't dispatch `file-embeddings` jobs from `RunDownloadJob` when Ollama isn't installed — no point queueing work that can't succeed
- Use BullMQ `UnrecoverableError` in `EmbedFileJob` when Ollama/Qdrant aren't installed, so any jobs that do get queued fail immediately instead of retrying 30x with 60s backoff
- Preserves existing retry behavior for transient errors (service temporarily unavailable, network issues)

## Problem

When NOMAD is deployed without Ollama (data-only setup), every ZIM download triggers an embedding job that fails with "Ollama service is not installed or running" and retries 30 times at 60-second intervals. With many ZIM files downloading in parallel, dozens of zombie jobs accumulate and cycle through retries simultaneously, eventually exhausting Redis connections with `EPIPE`, `ECONNRESET`, and `ERR max number of clients reached` errors. This degrades the healthy `downloads` queue that shares the same Redis instance.

## Changes

| File | Change |
|------|--------|
| `admin/app/jobs/run_download_job.ts` | Check `getServiceURL('nomad_ollama')` before dispatching embed jobs |
| `admin/app/jobs/embed_file_job.ts` | Import `UnrecoverableError` from BullMQ; throw it for "not installed" (permanent) vs regular `Error` for "not ready yet" (transient) |

## Test plan

- [ ] Deploy without Ollama installed, download multiple ZIM files — no embedding jobs should be dispatched
- [ ] Deploy with Ollama installed, download a ZIM file — embedding job should dispatch and process normally
- [ ] Stop Ollama temporarily while embedding job is queued — job should retry (transient error)
- [ ] Verify Redis connection count stays stable during bulk ZIM downloads without Ollama

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)