### PR TITLE
chore: update all-maxi Wikipedia ZIM to 2026-02

### DIFF
--- a/collections/wikipedia.json
+++ b/collections/wikipedia.json
@@ -45,9 +45,9 @@
       "id": "all-maxi",
       "name": "Complete Wikipedia (Full)",
       "description": "The complete experience with all images and media.",
-      "size_mb": 102000,
-      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_maxi_2024-01.zim",
-      "version": "2024-01"
+      "size_mb": 115000,
+      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_maxi_2026-02.zim",
+      "version": "2026-02"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Fixes #358 - Update hardcoded Wikipedia ZIM URL.

## Problem
The `all-maxi` (Complete Wikipedia Full) download fails with 404 because the URL points to the outdated 2024-01 version which is no longer available.

## Solution
Update `collections/wikipedia.json` to use the latest available version:
- **URL**: `https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_maxi_2026-02.zim`
- **Version**: `2026-02` (was `2024-01`)
- **Size**: 115 GB (was 102 GB)

## Verification
```bash
curl -I https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_maxi_2026-02.zim
# HTTP/1.1 200 OK
```

## Files Changed
- `collections/wikipedia.json` (3 lines)