### PR TITLE
fix: prefer real block devices over tmpfs for storage display

### DIFF
--- a/admin/inertia/pages/easy-setup/index.tsx
+++ b/admin/inertia/pages/easy-setup/index.tsx
@@ -318,7 +318,19 @@ export default function EasySetupWizard(props: { system: { services: ServiceSlim
   }
 
   const primaryDisk = getPrimaryDisk()
-  const primaryFs = systemInfo?.fsSize?.[0]
+  // When falling back to fsSize (systeminformation), prefer real block devices
+  // over virtual filesystems like tmpfs which report misleading capacity.
+  const getPrimaryFs = () => {
+    if (!systemInfo?.fsSize || systemInfo.fsSize.length === 0) return null
+    const realDevices = systemInfo.fsSize.filter((fs) => fs.fs.startsWith('/dev/'))
+    if (realDevices.length > 0) {
+      return realDevices.reduce((largest, current) =>
+        current.size > largest.size ? current : largest
+      )
+    }
+    return systemInfo.fsSize[0]
+  }
+  const primaryFs = getPrimaryFs()
   const storageInfo = primaryDisk
     ? { totalSize: primaryDisk.totalSize, totalUsed: primaryDisk.totalUsed }
     : primaryFs

--- a/install/sidecar-disk-collector/collect-disk-info.sh
+++ b/install/sidecar-disk-collector/collect-disk-info.sh
@@ -50,6 +50,22 @@ while true; do
         FS_JSON+="{\"fs\":\"${dev}\",\"size\":${size},\"used\":${used},\"available\":${avail},\"use\":${pct},\"mount\":\"${mountpoint}\"}"
         FIRST=0
     done < /host/proc/1/mounts
+
+    # Fallback: if no real filesystems were found from the host mount table
+    # (e.g. /host/proc/1/mounts was unreadable), try the /storage mount directly.
+    # The disk-collector container always has /storage bind-mounted from the host,
+    # so df on /storage reflects the actual backing device and its capacity.
+    if [[ "$FIRST" -eq 1 ]] && mountpoint -q /storage 2>/dev/null; then
+        STATS=$(df -B1 /storage 2>/dev/null | awk 'NR==2{print $1,$2,$3,$4,$5}')
+        if [[ -n "$STATS" ]]; then
+            read -r dev size used avail pct <<< "$STATS"
+            pct="${pct/\%/}"
+            FS_JSON+="{\"fs\":\"${dev}\",\"size\":${size},\"used\":${used},\"available\":${avail},\"use\":${pct},\"mount\":\"/storage\"}"
+            FIRST=0
+            log "Used /storage mount as fallback for filesystem info."
+        fi
+    fi
+
     FS_JSON+="]"
 
     # Use a tmp file for atomic update


### PR DESCRIPTION
## Summary

Fixes #373 — storage display shows tmpfs capacity (~1.5 GB) instead of the actual storage mount (~915 GB).

**Root cause:** When `disk-collector` can't read `/host/proc/1/mounts` (or it yields no real filesystem entries), the admin UI falls back to `systeminformation`'s `fsSize`, which includes container-visible tmpfs mounts. The fallback blindly picks the first entry, which can be tmpfs `/run`.

**Two minimal changes:**

- **`collect-disk-info.sh`**: After iterating host mounts, if no real filesystems were found, fall back to `df /storage` directly. The `/storage` bind-mount always reflects the actual backing block device and its capacity, so this is a safe fallback.

- **`easy-setup/index.tsx`**: When falling back to `systeminformation` `fsSize` (used when the disk-collector JSON has no valid disks), filter for `/dev/` block devices and prefer the largest one instead of taking `fsSize[0]` which may be tmpfs.

## Test plan

- [ ] On a system with `/storage` on a separate drive (e.g., `/dev/sdb1`), verify the storage display shows the correct capacity
- [ ] On a single-disk system, verify storage display still works correctly
- [ ] Verify the disk-collector fallback logs "Used /storage mount as fallback" only when `/host/proc/1/mounts` yields no results
- [ ] Verify the easy-setup storage projection bar shows real disk capacity, not tmpfs