### PR TITLE
fix(GPU): persist GPU type to KV store for reliable passthrough

### DIFF
--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -691,6 +691,7 @@ export class DockerService {
         const runtimes = dockerInfo.Runtimes || {}
         if ('nvidia' in runtimes) {
           logger.info('[DockerService] NVIDIA container runtime detected via Docker API')
+          await this._persistGPUType('nvidia')
           return { type: 'nvidia' }
         }
       } catch (error) {
@@ -722,10 +723,24 @@ export class DockerService {
         )
         if (amdCheck.trim()) {
           logger.info('[DockerService] AMD GPU detected via lspci')
+          await this._persistGPUType('amd')
           return { type: 'amd' }
         }
       } catch (error) {
         // lspci not available, continue
+      }
+
+      // Last resort: check if we previously detected a GPU and it's likely still present.
+      // This handles cases where live detection fails transiently (e.g., Docker daemon
+      // hiccup, runtime temporarily unavailable) but the hardware hasn't changed.
+      try {
+        const savedType = await KVStore.getValue('gpu.type')
+        if (savedType === 'nvidia' || savedType === 'amd') {
+          logger.info(`[DockerService] No GPU detected live, but KV store has '${savedType}' from previous detection. Using saved value.`)
+          return { type: savedType as 'nvidia' | 'amd' }
+        }
+      } catch {
+        // KV store not available, continue
       }
 
       logger.info('[DockerService] No GPU detected')
@@ -733,6 +748,15 @@ export class DockerService {
     } catch (error) {
       logger.warn(`[DockerService] Error detecting GPU type: ${error.message}`)
       return { type: 'none' }
+    }
+  }
+
+  private async _persistGPUType(type: 'nvidia' | 'amd'): Promise<void> {
+    try {
+      await KVStore.setValue('gpu.type', type)
+      logger.info(`[DockerService] Persisted GPU type '${type}' to KV store`)
+    } catch (error) {
+      logger.warn(`[DockerService] Failed to persist GPU type: ${error.message}`)
     }
   }
 

--- a/admin/types/kv_store.ts
+++ b/admin/types/kv_store.ts
@@ -9,6 +9,7 @@ export const KV_STORE_SCHEMA = {
   'ui.hasVisitedEasySetup':     'boolean',
   'ui.theme':                   'string',
   'ai.assistantCustomName':     'string',
+  'gpu.type':                   'string',
 } as const
 
 type KVTagToType<T extends string> = T extends 'boolean' ? boolean : string


### PR DESCRIPTION
## Summary
- Persists GPU detection results (`nvidia` or `amd`) to KV store key `gpu.type` after successful detection
- Falls back to saved GPU type when live detection returns nothing
- Adds `gpu.type` to the KV store schema

## Problem
GPU config is only applied at container creation time via `_detectGPUType()`. If live detection fails transiently (Docker daemon hiccup, nvidia runtime temporarily unavailable after a reboot), Ollama silently falls back to CPU-only. Users see 10-40x slower AI performance with no indication of why. The only fix was force-reinstalling the AI Assistant.

## How it works
1. When `_detectGPUType()` successfully detects NVIDIA or AMD, it persists the result to the KV store
2. If live detection (Docker API + lspci) finds nothing, it checks the KV store for a previously saved GPU type
3. If a saved type exists, it uses that value, ensuring GPU passthrough survives transient detection failures
4. The KV store value is overwritten on every successful detection, so it always reflects the latest hardware state

## Test plan
- [ ] Install AI Assistant on a machine with NVIDIA GPU, verify `gpu.type` is set in KV store
- [ ] Restart the admin container and verify GPU passthrough is maintained
- [ ] On a machine without GPU, verify no KV store entry is created and behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)