### PR TITLE
fix(UI): hide 'Start here!' badge after Easy Setup is completed

### DIFF
--- a/admin/inertia/pages/home.tsx
+++ b/admin/inertia/pages/home.tsx
@@ -97,7 +97,7 @@ export default function Home(props: {
   const { data: easySetupVisited } = useSystemSetting({
     key: 'ui.hasVisitedEasySetup'
   })
-  const shouldHighlightEasySetup = easySetupVisited?.value ? easySetupVisited?.value !== 'true' : false
+  const shouldHighlightEasySetup = easySetupVisited?.value ? String(easySetupVisited.value) !== 'true' : false
 
   // Add installed services (non-dependency services only)
   props.system.services


### PR DESCRIPTION
## Summary
- One-line fix: the "Start here!" badge on the Easy Setup dashboard card persists even after the user has completed Easy Setup

## Root Cause
Type mismatch: the API returns `ui.hasVisitedEasySetup` as boolean `true`, but the comparison checked against string `'true'`. Since `true !== 'true'` in JavaScript, `shouldHighlightEasySetup` was always `true`.

## Fix
Coerce the value to string before comparison: `String(easySetupVisited.value) !== 'true'`

## Test plan
- [ ] Complete Easy Setup wizard, return to dashboard
- [ ] Verify "Start here!" badge is no longer shown on the Easy Setup card
- [ ] On a fresh install (before Easy Setup), verify the badge still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)