### PR TITLE
fix(UI): clear stale update banner after successful update

### DIFF
--- a/admin/inertia/pages/settings/update.tsx
+++ b/admin/inertia/pages/settings/update.tsx
@@ -258,7 +258,13 @@ export default function SystemUpdatePage(props: { system: Props }) {
 
         // Check if update is complete or errored
         if (response.stage === 'complete') {
-          // Give a moment for the new container to fully start
+          // Re-check version so the KV store clears the stale "update available" flag
+          // before we reload, otherwise the banner shows "current → current"
+          try {
+            await api.checkLatestVersion(true)
+          } catch {
+            // Non-critical - page reload will still work
+          }
           setTimeout(() => {
             window.location.reload()
           }, 2000)


### PR DESCRIPTION
## Summary
- After an update completes, triggers a version re-check before the page reload
- Prevents the confusing "Current 1.30.0-rc.1 → New 1.30.0-rc.1" banner

## Problem
When an update finishes, the polling detects `stage: 'complete'` and reloads the page. But the KV store still has `system.updateAvailable = true` from the pre-update check. The reloaded page reads this stale value and shows an update banner pointing to the version you just installed.

## Fix
Call `api.checkLatestVersion(true)` when the update completes, before the 2-second reload delay. This updates the KV store with the correct version info so the reload shows "System Up to Date."

## Test plan
- [ ] Trigger an update from Settings > Check for Updates
- [ ] After update completes and page reloads, verify no "Update Available" banner is shown
- [ ] Verify the current version displayed matches the newly installed version

🤖 Generated with [Claude Code](https://claude.com/claude-code)