### PR TITLE
fix(ai): surface model download errors and prevent silent retry loops

### DIFF
--- a/admin/app/jobs/download_model_job.ts
+++ b/admin/app/jobs/download_model_job.ts
@@ -1,4 +1,4 @@
-import { Job } from 'bullmq'
+import { Job, UnrecoverableError } from 'bullmq'
 import { QueueService } from '#services/queue_service'
 import { createHash } from 'crypto'
 import logger from '@adonisjs/core/services/logger'
@@ -63,6 +63,10 @@ export class DownloadModelJob {
       logger.error(
         `[DownloadModelJob] Failed to initiate download for model ${modelName}: ${result.message}`
       )
+      // Don't retry errors that will never succeed (e.g., Ollama version too old)
+      if (result.retryable === false) {
+        throw new UnrecoverableError(result.message)
+      }
       throw new Error(`Failed to initiate download for model: ${result.message}`)
     }
 
@@ -85,6 +89,15 @@ export class DownloadModelJob {
     const queue = queueService.getQueue(this.queue)
     const jobId = this.getJobId(params.modelName)
 
+    // Clear any previous failed job so a fresh attempt can be dispatched
+    const existing = await queue.getJob(jobId)
+    if (existing) {
+      const state = await existing.getState()
+      if (state === 'failed') {
+        await existing.remove()
+      }
+    }
+
     try {
       const job = await queue.add(this.key, params, {
         jobId,
@@ -104,9 +117,9 @@ export class DownloadModelJob {
       }
     } catch (error) {
       if (error.message.includes('job already exists')) {
-        const existing = await queue.getJob(jobId)
+        const active = await queue.getJob(jobId)
         return {
-          job: existing,
+          job: active,
           created: false,
           message: `Job already exists for model ${params.modelName}`,
         }

--- a/admin/app/services/ollama_service.ts
+++ b/admin/app/services/ollama_service.ts
@@ -51,7 +51,7 @@ export class OllamaService {
    * @param model Model name to download
    * @returns Success status and message
    */
-  async downloadModel(model: string, progressCallback?: (percent: number) => void): Promise<{ success: boolean; message: string }> {
+  async downloadModel(model: string, progressCallback?: (percent: number) => void): Promise<{ success: boolean; message: string; retryable?: boolean }> {
     try {
       await this._ensureDependencies()
       if (!this.ollama) {
@@ -86,11 +86,21 @@ export class OllamaService {
       logger.info(`[OllamaService] Model "${model}" downloaded successfully.`)
       return { success: true, message: 'Model downloaded successfully.' }
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
       logger.error(
-        `[OllamaService] Failed to download model "${model}": ${error instanceof Error ? error.message : error
-        }`
+        `[OllamaService] Failed to download model "${model}": ${errorMessage}`
       )
-      return { success: false, message: 'Failed to download model.' }
+
+      // Check for version mismatch (Ollama 412 response)
+      const isVersionMismatch = errorMessage.includes('newer version of Ollama')
+      const userMessage = isVersionMismatch
+        ? 'This model requires a newer version of Ollama. Please update AI Assistant from the Apps page.'
+        : `Failed to download model: ${errorMessage}`
+
+      // Broadcast failure to connected clients so UI can show the error
+      this.broadcastDownloadError(model, userMessage)
+
+      return { success: false, message: userMessage, retryable: !isVersionMismatch }
     }
   }
 
@@ -377,6 +387,15 @@ export class OllamaService {
     })
 
     return models
+  }
+
+  private broadcastDownloadError(model: string, error: string) {
+    transmit.broadcast(BROADCAST_CHANNELS.OLLAMA_MODEL_DOWNLOAD, {
+      model,
+      percent: -1,
+      error,
+      timestamp: new Date().toISOString(),
+    })
   }
 
   private broadcastDownloadProgress(model: string, percent: number) {

--- a/admin/inertia/components/ActiveModelDownloads.tsx
+++ b/admin/inertia/components/ActiveModelDownloads.tsx
@@ -1,6 +1,7 @@
 import useOllamaModelDownloads from '~/hooks/useOllamaModelDownloads'
 import HorizontalBarChart from './HorizontalBarChart'
 import StyledSectionHeader from './StyledSectionHeader'
+import { IconAlertTriangle } from '@tabler/icons-react'
 
 interface ActiveModelDownloadsProps {
     withHeader?: boolean
@@ -17,19 +18,31 @@ const ActiveModelDownloads = ({ withHeader = false }: ActiveModelDownloadsProps)
                     downloads.map((download) => (
                         <div
                             key={download.model}
-                            className="bg-desert-white rounded-lg p-4 border border-desert-stone-light shadow-sm hover:shadow-lg transition-shadow"
+                            className={`bg-desert-white rounded-lg p-4 border shadow-sm hover:shadow-lg transition-shadow ${
+                                download.error ? 'border-red-400' : 'border-desert-stone-light'
+                            }`}
                         >
-                            <HorizontalBarChart
-                                items={[
-                                    {
-                                        label: download.model,
-                                        value: download.percent,
-                                        total: '100%',
-                                        used: `${download.percent.toFixed(1)}%`,
-                                        type: 'ollama-model',
-                                    },
-                                ]}
-                            />
+                            {download.error ? (
+                                <div className="flex items-start gap-3">
+                                    <IconAlertTriangle className="text-red-500 flex-shrink-0 mt-0.5" size={20} />
+                                    <div>
+                                        <p className="font-medium text-text-primary">{download.model}</p>
+                                        <p className="text-sm text-red-600 mt-1">{download.error}</p>
+                                    </div>
+                                </div>
+                            ) : (
+                                <HorizontalBarChart
+                                    items={[
+                                        {
+                                            label: download.model,
+                                            value: download.percent,
+                                            total: '100%',
+                                            used: `${download.percent.toFixed(1)}%`,
+                                            type: 'ollama-model',
+                                        },
+                                    ]}
+                                />
+                            )}
                         </div>
                     ))
                 ) : (

--- a/admin/inertia/hooks/useOllamaModelDownloads.ts
+++ b/admin/inertia/hooks/useOllamaModelDownloads.ts
@@ -5,6 +5,7 @@ export type OllamaModelDownload = {
     model: string
     percent: number
     timestamp: string
+    error?: string
 }
 
 export default function useOllamaModelDownloads() {
@@ -17,7 +18,19 @@ export default function useOllamaModelDownloads() {
             setDownloads((prev) => {
                 const updated = new Map(prev)
 
-                if (data.percent >= 100) {
+                if (data.percent === -1) {
+                    // Download failed — show error state, auto-remove after 15 seconds
+                    updated.set(data.model, data)
+                    const errorTimeout = setTimeout(() => {
+                        timeoutsRef.current.delete(errorTimeout)
+                        setDownloads((current) => {
+                            const next = new Map(current)
+                            next.delete(data.model)
+                            return next
+                        })
+                    }, 15000)
+                    timeoutsRef.current.add(errorTimeout)
+                } else if (data.percent >= 100) {
                     // If download is complete, keep it for a short time before removing to allow UI to show 100% progress
                     updated.set(data.model, data)
                     const timeout = setTimeout(() => {


### PR DESCRIPTION
## Summary
- Model downloads that fail (e.g., Ollama version too old for a model) now show the actual error in the Active Model Downloads UI instead of silently failing
- Version mismatch errors (Ollama 412) use `UnrecoverableError` to fail immediately instead of retrying 40 times over 40 minutes
- Stale failed jobs are cleared from Redis on retry so users aren't permanently blocked from re-attempting a download

## Context
When a user tries to download a model that requires a newer Ollama version, Ollama returns a 412 with a clear error message. Previously, `ollama_service.ts` swallowed this and returned a generic "Failed to download model" message. The BullMQ job would then retry 40 times (once per minute) before giving up, and nothing was ever shown to the user.

## Changes
| File | Change |
|------|--------|
| `ollama_service.ts` | Pass through actual error message, detect version mismatch, broadcast errors via SSE |
| `download_model_job.ts` | `UnrecoverableError` for non-retryable failures, clear stale failed jobs before dispatch |
| `useOllamaModelDownloads.ts` | Handle `percent: -1` as error state, auto-dismiss after 15 seconds |
| `ActiveModelDownloads.tsx` | Show failed downloads with red border, warning icon, and error message |

## Test plan
- [ ] Try downloading a model that requires a newer Ollama version — error should appear in Active Model Downloads with red border
- [ ] Error auto-dismisses after ~15 seconds
- [ ] Retry the same model — should dispatch a fresh job (not get stuck on stale failed job)
- [ ] Normal model downloads still work and show progress bar as before
- [ ] Update Ollama from Apps page, then retry — download should succeed

Tested on NOMAD1 (192.168.200.199) with `qwen3.5:latest` on Ollama 0.15.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)