### PR TITLE
fix: benchmark UI displaying 0.0% for CPU and Disk Write scores

### DIFF
--- a/admin/app/services/benchmark_service.ts
+++ b/admin/app/services/benchmark_service.ts
@@ -571,10 +571,10 @@ export class BenchmarkService {
    */
   private _normalizeScore(value: number, reference: number): number {
     if (value <= 0) return 0
-    // Log scale: score = 50 * (1 + log2(value/reference))
-    // This gives 50 at reference value, scales logarithmically
+    // Log scale with widened range: dividing log2 by 3 prevents scores from
+    // clamping to 0% for below-average hardware. Gives 50% at reference value.
     const ratio = value / reference
-    const score = 50 * (1 + Math.log2(Math.max(0.01, ratio)))
+    const score = 50 * (1 + Math.log2(Math.max(0.01, ratio)) / 3)
     return Math.min(100, Math.max(0, score)) / 100
   }
 
@@ -583,9 +583,9 @@ export class BenchmarkService {
    */
   private _normalizeScoreInverse(value: number, reference: number): number {
     if (value <= 0) return 1
-    // Inverse: lower values = higher scores
+    // Inverse: lower values = higher scores, with widened log range
     const ratio = reference / value
-    const score = 50 * (1 + Math.log2(Math.max(0.01, ratio)))
+    const score = 50 * (1 + Math.log2(Math.max(0.01, ratio)) / 3)
     return Math.min(100, Math.max(0, score)) / 100
   }
 
@@ -619,6 +619,7 @@ export class BenchmarkService {
     const eventsMatch = output.match(/events per second:\s*([\d.]+)/i)
     const totalTimeMatch = output.match(/total time:\s*([\d.]+)s/i)
     const totalEventsMatch = output.match(/total number of events:\s*(\d+)/i)
+    logger.debug(`[BenchmarkService] CPU output parsing - events/s: ${eventsMatch?.[1]}, total_time: ${totalTimeMatch?.[1]}, total_events: ${totalEventsMatch?.[1]}`)
 
     return {
       events_per_second: eventsMatch ? parseFloat(eventsMatch[1]) : 0,


### PR DESCRIPTION
## Summary
- Fixes #415 — Benchmark UI shows CPU Score and Disk Write scores as 0.0% despite sysbench returning valid results
- **Root cause:** The `_normalizeScore` formula `50 * (1 + log2(ratio))` produces negative values (clamped to 0) whenever the measured value is less than half the reference. For example, 1993 events/sec against a 5000 reference gives `log2(0.4) = -1.32`, yielding a score of -16 which gets clamped to 0%. Same issue affects Disk Write (179 MB/s vs 400 reference).
- **Fix:** Divide the `log2` term by 3 to widen the scoring range: `50 * (1 + log2(ratio) / 3)`. This preserves 50% at the reference value while giving below-average hardware proportional non-zero scores (~28% CPU, ~31% Disk Write for the reporter's hardware).
- Also adds debug logging for CPU sysbench output parsing, consistent with existing disk read/write logging.

## Score range comparison

| Ratio to reference | Old formula | New formula |
|---|---|---|
| 0.25x | 0% | 16.7% |
| 0.5x | 0% | 33.3% |
| 1x | 50% | 50% |
| 2x | 100% | 66.7% |
| 4x | 100% | 83.3% |
| 8x | 100% | 100% |

## Test plan
- Verified the formula fix produces correct scores for the reporter's hardware values (CPU 1993 eps → 27.9%, Disk Write 179 MB/s → 30.8%)
- Confirmed reference-value scores remain at 50%
- Confirmed the same fix is applied to `_normalizeScoreInverse` for consistency