### PR TITLE
fix(downloads): stage downloads to .tmp to prevent Kiwix loading partial files

### DIFF
--- a/admin/app/utils/downloads.ts
+++ b/admin/app/utils/downloads.ts
@@ -86,15 +86,27 @@ export async function doResumableDownload({
     headers.Range = `bytes=${startByte}-`
   }
 
-  const response = await axios.get(url, {
-    responseType: 'stream',
-    headers,
-    signal,
-    timeout,
-  })
+  const fetchStream = (hdrs: Record<string, string>) =>
+    axios.get(url, { responseType: 'stream', headers: hdrs, signal, timeout })
+
+  let response = await fetchStream(headers)
 
   if (response.status !== 200 && response.status !== 206) {
     throw new Error(`Failed to download: HTTP ${response.status}`)
+  }
+
+  // If we requested a range but the server returned 200 (ignored the Range header),
+  // appending would corrupt the .tmp file — delete it and restart from byte 0.
+  if (headers.Range && response.status === 200) {
+    response.data.destroy()
+    await deleteFileIfExists(tempPath)
+    startByte = 0
+    appendMode = false
+    delete headers.Range
+    response = await fetchStream(headers)
+    if (response.status !== 200 && response.status !== 206) {
+      throw new Error(`Failed to download: HTTP ${response.status}`)
+    }
   }
 
   return new Promise((resolve, reject) => {
@@ -149,7 +161,6 @@ export async function doResumableDownload({
       flags: appendMode ? 'a' : 'w',
     })
 
-    // Handle errors and cleanup
     const cleanup = (error?: Error) => {
       clearStallTimer()
       progressStream.destroy()
@@ -163,7 +174,6 @@ export async function doResumableDownload({
     response.data.on('error', cleanup)
     progressStream.on('error', cleanup)
     writeStream.on('error', cleanup)
-    writeStream.on('error', cleanup)
 
     signal?.addEventListener('abort', () => {
       cleanup(new Error('Download aborted'))
@@ -175,8 +185,15 @@ export async function doResumableDownload({
         // Atomically move the completed .tmp file to the final path
         await rename(tempPath, filepath)
       } catch (renameError) {
-        reject(renameError)
-        return
+        // A parallel job may have completed the same file first — treat as success
+        // if the destination already exists at the expected size.
+        const existing = await getFileStatsIfExists(filepath)
+        if (existing && Number(existing.size) === totalBytes && totalBytes > 0) {
+          // fall through to resolve
+        } else {
+          reject(renameError)
+          return
+        }
       }
       if (onProgress) {
         onProgress({
@@ -228,7 +245,7 @@ export async function doResumableDownloadWithRetry({
       })
 
       return result // return on success
-    } catch (error) {
+    } catch (error: any) {
       attempt++
       lastError = error as Error
 

--- a/admin/app/utils/downloads.ts
+++ b/admin/app/utils/downloads.ts
@@ -6,6 +6,7 @@ import axios from 'axios'
 import { Transform } from 'stream'
 import { deleteFileIfExists, ensureDirectoryExists, getFileStatsIfExists } from './fs.js'
 import { createWriteStream } from 'fs'
+import { rename } from 'fs/promises'
 import path from 'path'
 
 /**
@@ -27,13 +28,16 @@ export async function doResumableDownload({
   const dirname = path.dirname(filepath)
   await ensureDirectoryExists(dirname)
 
-  // Check if partial file exists for resume
+  // Stage download to a .tmp file so consumers (e.g. Kiwix) never see a partial file
+  const tempPath = filepath + '.tmp'
+
+  // Check if partial .tmp file exists for resume
   let startByte = 0
   let appendMode = false
 
-  const existingStats = await getFileStatsIfExists(filepath)
+  const existingStats = await getFileStatsIfExists(tempPath)
   if (existingStats && !forceNew) {
-    startByte = existingStats.size
+    startByte = Number(existingStats.size)
     appendMode = true
   }
 
@@ -55,14 +59,24 @@ export async function doResumableDownload({
     }
   }
 
-  // If file is already complete and not forcing overwrite just return filepath
-  if (startByte === totalBytes && totalBytes > 0 && !forceNew) {
+  // If final file already exists at correct size, return early (idempotent)
+  const finalFileStats = await getFileStatsIfExists(filepath)
+  if (finalFileStats && Number(finalFileStats.size) === totalBytes && totalBytes > 0 && !forceNew) {
     return filepath
   }
 
-  // If server doesn't support range requests and we have a partial file, delete it
+  // If .tmp file is already at correct size (complete but never renamed), just rename it
+  if (startByte === totalBytes && totalBytes > 0 && !forceNew) {
+    await rename(tempPath, filepath)
+    if (onComplete) {
+      await onComplete(url, filepath)
+    }
+    return filepath
+  }
+
+  // If server doesn't support range requests and we have a partial .tmp file, delete it
   if (!supportsRangeRequests && startByte > 0) {
-    await deleteFileIfExists(filepath)
+    await deleteFileIfExists(tempPath)
     startByte = 0
     appendMode = false
   }
@@ -131,7 +145,7 @@ export async function doResumableDownload({
       },
     })
 
-    const writeStream = createWriteStream(filepath, {
+    const writeStream = createWriteStream(tempPath, {
       flags: appendMode ? 'a' : 'w',
     })
 
@@ -157,6 +171,13 @@ export async function doResumableDownload({
 
     writeStream.on('finish', async () => {
       clearStallTimer()
+      try {
+        // Atomically move the completed .tmp file to the final path
+        await rename(tempPath, filepath)
+      } catch (renameError) {
+        reject(renameError)
+        return
+      }
       if (onProgress) {
         onProgress({
           downloadedBytes,


### PR DESCRIPTION
> **Note:** This PR was developed with the assistance of [Claude Code](https://claude.ai/claude-code) (Anthropic's AI coding tool). It is intended as a proposed starting point to address the issue — I'd welcome review and feedback from the maintainers before it's considered merge-ready.

## Problem

Kiwix crashes on startup when it encounters a partial or corrupt ZIM file on disk. This happens when a download is in progress (or failed mid-way) and Kiwix is restarted — it picks up the incomplete `.zim` file and fails with `Unable to add the ZIM file to the internal library`.

This was confirmed on a live installation: `gutenberg_en_lcc-t_2026-03.zim` (6.2GB, appeared complete by size but had invalid internal structure) crashed Kiwix on every restart until manually removed.

Ref #372 (also related: #429, #396 — same root cause affects `.pmtiles` map files)

## Fix

`doResumableDownload()` now writes to `filepath + '.tmp'` and only atomically renames to the final path on successful completion.

- Kiwix globs for `*.zim` — `.tmp` files are invisible to it
- `ZimService.list()` already filters `.endsWith('.zim')` — `.tmp` files are invisible here too
- `fs.rename()` is a single `rename(2)` syscall — atomic on the same filesystem
- The same fix covers `.pmtiles` map downloads, which go through the same code path

If a download is interrupted, the `.tmp` file remains on disk as a resume checkpoint (existing resume logic unchanged), but Kiwix will never see it.

## Changes

Single file modified: `admin/app/utils/downloads.ts`

- Add `import { rename } from 'fs/promises'`
- Compute `tempPath = filepath + '.tmp'` at the start of `doResumableDownload`
- Resume check now reads `getFileStatsIfExists(tempPath)` instead of `filepath`
- Add idempotency check: if final file already exists at correct size, return early
- Add `.tmp`-complete shortcut: if `.tmp` is already full size (complete but never renamed), just rename and return
- Non-range-request cleanup now deletes `tempPath` instead of `filepath`
- Write stream now targets `tempPath`
- On `finish`: atomically `rename(tempPath, filepath)` before calling `onComplete` / resolving

## Call sites audited

All 4 callers of `doResumableDownload` / `doResumableDownloadWithRetry` were reviewed:

- **`RunDownloadJob`** (ZIM + map queue downloads) — `onComplete` receives final `filepath` after rename ✅
- **`collection_update_service.ts`** (resource updates, `forceNew: true`) — bypasses early returns, downloads fresh to `.tmp`, renames correctly ✅
- **`map_service.ts` `downloadBaseAssets()`** — passes `filepath: tempTarPath`; final file lands at `tempTarPath` after rename; subsequent `getFileStatsIfExists(tempTarPath)` and `extract({ file: tempTarPath })` both work ✅
- **`docker_service.ts` Kiwix pre-install** — downloads Wikipedia ZIM to final `.zim` path; staged via `.tmp`, renamed on completion ✅

## Testing

Tested locally using a minimal `docker-compose` environment (admin built from this branch, MySQL, Redis, Kiwix 3.8.2):

- **`.tmp` staging (ZIM)** — file appears as `.zim.tmp` throughout, renamed to `.zim` on completion ✅
- **`.tmp` staging (maps)** — multiple `.pmtiles.tmp` files staged simultaneously, all renamed correctly ✅
- **Kiwix invisible to `.tmp`** — restarted Kiwix mid-download (584MB into a 4.7GB file), started cleanly with zero errors ✅
- **Content serving while downloading** — existing ZIM content accessible via Kiwix during an active download ✅
- **Multiple concurrent downloads** — two files staged simultaneously, both renamed correctly ✅
- **TypeScript compilation** — `tsc --noEmit` exit code 0 ✅

🤖 Developed with [Claude Code](https://claude.ai/claude-code)