### PR TITLE
docs: add installation guide link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ sudo apt-get update && sudo apt-get install -y curl && curl -fsSL https://raw.gi
 
 Project N.O.M.A.D. is now installed on your device! Open a browser and navigate to `http://localhost:8080` (or `http://DEVICE_IP:8080`) to start exploring!
 
+For a complete step-by-step walkthrough (including Ubuntu installation), see the [Installation Guide](https://www.projectnomad.us/install).
+
 ### Advanced Installation
 For more control over the installation process, copy and paste the [Docker Compose template](https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/main/install/management_compose.yml) into a `docker-compose.yml` file and customize it to your liking (be sure to replace any placeholders with your actual values). Then, run `docker compose up -d` to start the Command Center and its dependencies. Note: this method is recommended for advanced users only, as it requires familiarity with Docker and manual configuration before starting.
 


### PR DESCRIPTION
## Summary
- Adds a link to the full step-by-step installation guide at projectnomad.us/install below the Quick Install command
- Helps users who need Ubuntu setup walkthrough before running the install script

## Test plan
- [ ] Verify link renders correctly in GitHub README preview
- [ ] Confirm https://www.projectnomad.us/install loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)