### PR TITLE
fix(zim): add missing deleteZimFile method in API client

### DIFF
--- a/admin/inertia/lib/api.ts
+++ b/admin/inertia/lib/api.ts
@@ -518,6 +518,13 @@ class API {
     })()
   }
 
+  async deleteZimFile(filename: string) {
+    return catchInternal(async () => {
+      const response = await this.client.delete<{ message: string }>(`/zim/${filename}`)
+      return response.data
+    })()
+  }
+
   async listZimFiles() {
     return catchInternal(async () => {
       return await this.client.get<ListZimFilesResponse>('/zim/list')


### PR DESCRIPTION
## Summary

Fixes the Content Manager's inability to delete ZIM files. The browser console error was:

```
Uncaught (in promise) TypeError: (intermediate value).deleteZimFile is not a function
```

## Root Cause

`admin/inertia/pages/settings/zim/index.tsx:51` calls `api.deleteZimFile()`, but this method was never implemented in the API client class (`admin/inertia/lib/api.ts`).

The backend route `DELETE /api/zim/:filename` and `ZimController.delete` already exist and work correctly — only the frontend API client method was missing.

## Fix

Added the `deleteZimFile(filename: string)` method to the API class, which calls `DELETE /api/zim/${filename}`.

## Test Plan
- [ ] Navigate to Settings > Content Manager
- [ ] Click delete on any ZIM file
- [ ] Confirm deletion in the modal
- [ ] Verify the file is removed from the list
- [ ] Verify no console errors

Closes #372