### PR TITLE
fix(collections): update Full Wikipedia URL to current Kiwix mirror

### DIFF
--- a/collections/wikipedia.json
+++ b/collections/wikipedia.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "2026-02-11",
+  "spec_version": "2026-03-23",
   "options": [
     {
       "id": "none",
@@ -45,9 +45,9 @@
       "id": "all-maxi",
       "name": "Complete Wikipedia (Full)",
       "description": "The complete experience with all images and media.",
-      "size_mb": 102000,
-      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_maxi_2024-01.zim",
-      "version": "2024-01"
+      "size_mb": 115000,
+      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_maxi_2026-02.zim",
+      "version": "2026-02"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- The `all_maxi_2024-01` ZIM file was removed from Kiwix mirrors, causing silent 404 failures when users selected "Complete Wikipedia (Full)"
- Updated to `all_maxi_2026-02` (115 GB) which is live on Kiwix mirrors
- Updated `spec_version` to `2026-03-23`
- All other Wikipedia options (`top_mini`, `top_nopic`, `all_mini`, `all_nopic`) verified working at their current URLs

Closes #216

## Test plan
- [ ] Verify "Complete Wikipedia (Full)" option downloads successfully from the new URL
- [ ] Confirm size displays correctly (~115 GB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)