### PR TITLE
fix(install): correct NVIDIA runtime detection in install script

### DIFF
--- a/install/install_nomad.sh
+++ b/install/install_nomad.sh
@@ -510,7 +510,7 @@ verify_gpu_setup() {
   fi
   
   # Check if Docker has NVIDIA runtime
-  if docker info 2>/dev/null | grep -q \"nvidia\"; then
+  if docker info 2>/dev/null | grep -q "nvidia"; then
     echo -e "${GREEN}✓${RESET} Docker NVIDIA runtime configured\\n"
   else
     echo -e "${YELLOW}○${RESET} Docker NVIDIA runtime not detected\\n"
@@ -526,11 +526,11 @@ verify_gpu_setup() {
   echo -e "${YELLOW}===========================================${RESET}\\n"
   
   # Summary
-  if command -v nvidia-smi &> /dev/null && docker info 2>/dev/null | grep -q \"nvidia\"; then
+  if command -v nvidia-smi &> /dev/null && docker info 2>/dev/null | grep -q "nvidia"; then
     echo -e "${GREEN}#${RESET} GPU acceleration is properly configured! The AI Assistant will use your GPU.\\n"
   else
     echo -e "${YELLOW}#${RESET} GPU acceleration not detected. The AI Assistant will run in CPU-only mode.\\n"
-    if command -v nvidia-smi &> /dev/null && ! docker info 2>/dev/null | grep -q \"nvidia\"; then
+    if command -v nvidia-smi &> /dev/null && ! docker info 2>/dev/null | grep -q "nvidia"; then
       echo -e "${YELLOW}#${RESET} Tip: Your GPU is detected but Docker runtime is not configured.\\n"
       echo -e "${YELLOW}#${RESET} Try restarting Docker: ${WHITE_R}sudo systemctl restart docker${RESET}\\n"
     fi


### PR DESCRIPTION
## Summary

Fixes NVIDIA GPU runtime detection failing in `print_system_summary()` during installation, causing false "GPU acceleration not detected" messages even when NVIDIA GPU and runtime are properly configured.

## Root Cause

Three `grep` commands in `print_system_summary()` (lines 513, 529, 533) use escaped quotes `\"nvidia\"` which makes grep search for the literal string `"nvidia"` (with quotes). The `docker info` output lists runtimes without quotes, so the match never succeeds.

The same check in `setup_nvidia_container_toolkit()` (line 327) already uses the correct form: `grep -q "nvidia"`.

## Fix

Replace `grep -q \"nvidia\"` with `grep -q "nvidia"` in all 3 occurrences in `print_system_summary()`.

## Test Plan
- [ ] Install on a system with NVIDIA GPU and `nvidia-container-toolkit` configured
- [ ] Verify `print_system_summary()` correctly shows "Docker NVIDIA runtime configured"
- [ ] Verify summary shows "GPU acceleration is properly configured!"

Closes #500