### PR TITLE
fix: block IPv4-mapped IPv6 and IPv6 all-zeros in SSRF check

### DIFF
--- a/admin/app/validators/common.ts
+++ b/admin/app/validators/common.ts
@@ -22,6 +22,8 @@ export function assertNotPrivateUrl(urlString: string): void {
     /^169\.254\.\d+\.\d+$/, // Link-local / cloud metadata
     /^\[::1\]$/,
     /^\[?fe80:/i, // IPv6 link-local
+    /^\[::ffff:/i, // IPv4-mapped IPv6 (e.g. [::ffff:7f00:1] = 127.0.0.1)
+    /^\[::\]$/, // IPv6 all-zeros (equivalent to 0.0.0.0)
   ]
 
   if (blockedPatterns.some((re) => re.test(hostname))) {


### PR DESCRIPTION
## Vulnerability Summary

**CWE:** [CWE-918](https://cwe.mitre.org/data/definitions/918.html) — Server-Side Request Forgery (SSRF)
**Severity:** Medium (defense-in-depth; LAN-only appliance context reduces practical impact)
**Affected file:** `admin/app/validators/common.ts` — `assertNotPrivateUrl()`

### Data Flow

1. User-supplied URL arrives via POST body to unauthenticated endpoints:
   - `/api/zim/download-remote` (`zim_controller.ts:29`)
   - `/api/maps/download-remote` (`maps_controller.ts:29,36,58`)
   - `/api/collection-updates/apply` (`collection_updates_controller.ts:17,25`)
2. URL is validated by VineJS (`vine.string().url({ require_tld: false })`)
3. Hostname is checked against `assertNotPrivateUrl()` blocklist
4. URL is passed to `doResumableDownload()` → `axios.head()` / `axios.get()`

### The Bypass

The existing blocklist correctly covers IPv4 loopback (`127.x.x.x`), `localhost`, `0.0.0.0`, `[::1]`, and `fe80:` link-local addresses. However, it does **not** block:

- **IPv4-mapped IPv6 addresses** — e.g. `[::ffff:7f00:1]` which is equivalent to `127.0.0.1`
- **IPv6 all-zeros** — `[::]` which is equivalent to `0.0.0.0` and binds/resolves to localhost

These representations bypass every regex in the existing blocklist while resolving to loopback addresses when the server makes the outbound request.

### Proof of Bypass (pre-fix)

```bash
# IPv4-mapped IPv6 loopback — bypasses all existing patterns:
curl -X POST http://NOMAD_IP:8080/api/zim/download-remote \
  -H "Content-Type: application/json" \
  -d '{"url": "http://[::ffff:7f00:1]:8080/api/system/debug-info"}'

# IPv6 all-zeros — also bypasses:
curl -X POST http://NOMAD_IP:8080/api/zim/download-remote \
  -H "Content-Type: application/json" \
  -d '{"url": "http://[::]:8080/api/system/debug-info"}'
```

Both pass `assertNotPrivateUrl()` pre-fix and cause the server to make an internal request to itself.

---

## Fix Description

Added two regex patterns to the `blockedPatterns` array in `assertNotPrivateUrl()`:

```typescript
/^\[::ffff:/i,  // IPv4-mapped IPv6 (e.g. [::ffff:7f00:1] = 127.0.0.1)
/^\[::\]$/,     // IPv6 all-zeros (equivalent to 0.0.0.0)
```

### Rationale

- **`/^\[::ffff:/i`** — Blocks all IPv4-mapped IPv6 addresses. These are represented as `[::ffff:x.x.x.x]` or `[::ffff:HHHH:HHHH]` and map directly to IPv4 addresses. Since the function already blocks loopback and link-local IPv4, blocking the IPv6-mapped equivalents closes the bypass. This is intentionally broad (blocks all `::ffff:` prefixes including mapped RFC1918) because the URL constructor normalizes these to bracket notation and the risk of SSRF outweighs the edge case of users providing LAN URLs in IPv4-mapped IPv6 form.
- **`/^\[::\]$/`** — Blocks the IPv6 unspecified address, which behaves like `0.0.0.0` (already blocked in IPv4 form).

### What this does NOT change

- RFC1918 private ranges (`10.x`, `172.16-31.x`, `192.168.x`) remain **allowed** — this is by design for the LAN appliance use case.
- No changes to validation logic, download logic, or any other files.

---

## Test Results

### Unit-level verification

All blocked patterns were tested against the bypass addresses:

| Input Hostname | Pre-fix Result | Post-fix Result |
|---|---|---|
| `[::ffff:7f00:1]` | ✅ PASSED (not blocked) | ❌ BLOCKED |
| `[::ffff:127.0.0.1]` | ✅ PASSED (not blocked) | ❌ BLOCKED |
| `[::ffff:a9fe:fea9]` (169.254.x) | ✅ PASSED (not blocked) | ❌ BLOCKED |
| `[::]` | ✅ PASSED (not blocked) | ❌ BLOCKED |
| `localhost` | ❌ BLOCKED | ❌ BLOCKED (unchanged) |
| `127.0.0.1` | ❌ BLOCKED | ❌ BLOCKED (unchanged) |
| `192.168.1.100` | ✅ PASSED (allowed) | ✅ PASSED (still allowed) |
| `10.0.0.5` | ✅ PASSED (allowed) | ✅ PASSED (still allowed) |
| `my-nas.local` | ✅ PASSED (allowed) | ✅ PASSED (still allowed) |

No regressions to legitimate LAN URL use cases.

---

## Disprove Analysis

We performed a thorough adversarial review to stress-test this finding before submitting:

### Authentication Check
No authentication exists on any of the affected routes. `kernel.ts` exports `middleware = router.named({})` (empty). All download endpoints are fully unauthenticated. This **supports** the finding — anyone on the LAN can trigger SSRF.

### Network / CORS / CSRF Check
- CORS is configured with `origin: ['*']` and `credentials: true`
- CSRF protection is **disabled** (`shield.ts: csrf.enabled = false`)
- App binds to `0.0.0.0:8080`

This means a malicious website visited by a LAN user could trigger cross-origin SSRF requests.

### Deployment Context
NOMAD runs in Docker via docker-compose as a LAN appliance (offline-first). The admin container has the Docker socket mounted (`/var/run/docker.sock`), but that's Unix-only and unreachable via HTTP SSRF. MySQL and Redis use Docker DNS names (`mysql`, `redis`), not `localhost`.

### Caller Trace (confirmed)
`assertNotPrivateUrl()` is called in `zim_controller.ts`, `maps_controller.ts`, and `collection_updates_controller.ts`. All accept user-supplied URLs that flow directly to `axios.head()`/`axios.get()` via `doResumableDownload()`.

### Prior Awareness
Issue #211 ("Security audit: 5 medium-priority hardening items") already lists "Content Update URL Injection" (item #3). The maintainer has been actively iterating on SSRF protections (commits `75106a8`, `5d3c659`).

### Mitigations Found
1. **LAN-only deployment** — reduces remote attack surface
2. **Limited localhost targets** — within Docker, localhost only reaches the admin server itself
3. **Docker socket is Unix-only** — unreachable via HTTP SSRF
4. **axios mime-type validation** — `doResumableDownload` has `allowedMimeTypes` checks for some callers
5. **VineJS URL validation** — requires valid URL format

### Verdict
**CONFIRMED_VALID** at **medium confidence**. The bypass is technically real and exploitable, but practical impact is limited because NOMAD is a LAN appliance with no authentication — an attacker on the LAN already has direct access to all endpoints. The fix is a legitimate defense-in-depth improvement.

---

## Additional Recommendations (out of scope for this PR)

For awareness, during disprove analysis we identified additional SSRF bypass vectors that are **not** addressed by this PR and may warrant separate consideration:

1. **HTTP redirect following** — `axios` follows redirects by default. `http://attacker.com/redir` → `302 Location: http://localhost:8080/...` bypasses all hostname checks. Consider adding `maxRedirects: 0` to axios calls in `doResumableDownload()`.
2. **DNS rebinding** — `http://127.0.0.1.nip.io` resolves to `127.0.0.1` but passes hostname regex checks. Consider resolving the hostname and checking the IP *after* DNS resolution.
3. **Docker internal hostnames** — `http://mysql:3306/` and `http://redis:6379/` are reachable from within the container and not blocked.

These are mentioned for completeness, not as criticism — the current SSRF protections are already ahead of many similar projects.

---