### PR TITLE
feat(docker): replace Redis with Valkey for open-source compliance

### DIFF
--- a/install/management_compose.yaml
+++ b/install/management_compose.yaml
@@ -41,13 +41,13 @@ services:
       - DB_PASSWORD=replaceme
       - DB_NAME=nomad
       - DB_SSL=false
-      - REDIS_HOST=redis
-      # If you change the Redis port, make sure to update this accordingly
+      - REDIS_HOST=valkey
+      # If you change the Valkey port, make sure to update this accordingly
       - REDIS_PORT=6379
     depends_on:
       mysql:
         condition: service_healthy
-      redis:
+      valkey:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/api/health"]
@@ -83,14 +83,14 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-  redis:
-    image: redis:7-alpine
-    container_name: nomad_redis
+  valkey:
+    image: valkey/valkey:8-alpine
+    container_name: nomad_valkey
     restart: unless-stopped
     volumes:
-      - /opt/project-nomad/redis:/data # Persist Redis data on the host. This path can be changed if needed, just make sure it's writable by the container. Host persistence is important for Redis to ensure your data isn't lost when the container is removed or updated.
+      - /opt/project-nomad/valkey:/data # Persist Valkey data on the host. This path can be changed if needed, just make sure it's writable by the container. Host persistence is important for Valkey to ensure your data isn't lost when the container is removed or updated.
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "valkey-cli", "ping"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/install/sidecar-updater/update-watcher.sh
+++ b/install/sidecar-updater/update-watcher.sh
@@ -71,7 +71,7 @@ perform_update() {
     log "Recreating containers individually (excluding updater)..."
     
     # List of services to update (excluding updater)
-    SERVICES_TO_UPDATE="admin mysql redis dozzle"
+    SERVICES_TO_UPDATE="admin mysql valkey dozzle"
     
     local current_progress=65
     local progress_per_service=8  # (95 - 65) / 4 services ≈ 8% per service


### PR DESCRIPTION
## Summary

Replaces `redis:7-alpine` with `valkey/valkey:8-alpine` in the management Docker Compose stack. Valkey is the Linux Foundation-backed fork that maintains BSD-3-Clause licensing after Redis moved to dual SSPL/RSAL.

## Why this matters

Redis changed its license from BSD to SSPL/RSAL in March 2024, making it no longer open-source by OSI standards. Project NOMAD positions itself as an open-source platform ([#276](https://github.com/Crosstalk-Solutions/project-nomad/issues/276), 3 comments with community support) - shipping a non-OSS dependency undermines that positioning. Valkey 8.x is API-compatible with Redis 7.x, so this is a drop-in replacement.

## Changes

2 files, 9 insertions, 9 deletions:

- **`install/management_compose.yaml`**: Swap image `redis:7-alpine` to `valkey/valkey:8-alpine`, rename service from `redis` to `valkey`, container from `nomad_redis` to `nomad_valkey`, update health check to `valkey-cli ping`, update `REDIS_HOST` env var to `valkey`, update `depends_on` reference
- **`install/sidecar-updater/update-watcher.sh`**: Update `SERVICES_TO_UPDATE` list from `redis` to `valkey`

Zero application code changes. AdonisJS reads `REDIS_HOST` from the env var, and Valkey speaks the same protocol as Redis. BullMQ job queues work identically.

## Testing

- The `valkey/valkey:8-alpine` image is available on Docker Hub with multi-arch support
- `valkey-cli ping` returns `PONG` the same as `redis-cli ping`
- Existing installations will need to migrate their data volume from `/opt/project-nomad/redis` to `/opt/project-nomad/valkey` (or create a symlink)

**Migration note for existing installs:** Users upgrading will need to either rename their data directory or copy it:
```bash
sudo mv /opt/project-nomad/redis /opt/project-nomad/valkey
```

This contribution was developed with AI assistance (Claude Code).

Fixes #276

## Video Demo
![Demo](https://files.catbox.moe/bt67cs.gif)