### PR TITLE
Add model download to FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -59,6 +59,10 @@ All of NOMAD's containers are prefixed with `nomad_` in their names, so they can
 
 See [What technologies is NOMAD built with?](#what-technologies-is-nomad-built-with)
 
+## Can I use any AI models?
+NOMAD by default uses Ollama inside of a docker container to run LLM Models for the AI Assistant. So if you find a model on HuggingFace for example, you won't be able to use that model in NOMAD. The list of available models in the AI Assistant settings (/settings/models) may not show all of the models you are looking for. If you found a model from https://ollama.com/search that you'd like to try and its not in the settings page, you can use a curl command to download the model.  
+`curl -X POST -H "Content-Type: application/json" -d '{"model":"MODEL_NAME_HERE"}' http://localhost:8080/api/ollama/models` replacing MODEL_NAME_HERE with the model name from whats in the ollama website.
+
 ## Do I have to install the AI features in NOMAD?
 
 No, the AI features in NOMAD (Ollama, Qdrant, custom RAG pipeline, etc.) are all optional and not required to use the core functionality of NOMAD.


### PR DESCRIPTION
Sometimes there are models that don't show up in the model search, provided an example how to download a model using curl. It seems like most models do show up but the abliterated ones in particular don't show up at all. for example `huihui_ai/qwen3-vl-abliterated`