### PR TITLE
fix: add DNS delay to allow dhcpcd resolution on Debian (#557)

### DIFF
--- a/install/entrypoint.sh
+++ b/install/entrypoint.sh
@@ -21,4 +21,7 @@ node ace queue:work --all &
 
 # Start the AdonisJS application
 echo "Starting AdonisJS application..."
+    # Wait for DNS resolution (Debian dhcpcd race condition)
+    until ping -c1 8.8.8.8 >/dev/null 2>&1 || ping -c1 google.com >/dev/null 2>&1 || [ $SECONDS -gt 10 ]; do sleep 1; done
+
 exec node bin/server.js


### PR DESCRIPTION
Fixes #557. On Debian systems with dhcpcd, Docker containers can start before nameservers are written to `/etc/resolv.conf`, causing 500 errors. Added a brief delay loop to ensure DNS is ready before startup.\n\n*(Refactored using the open-source [0-editor](https://github.com/0-protocol/0-editor))*\n\n