### PR TITLE
docs(readme): format Quick Install command as multiline bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ Project N.O.M.A.D. can be installed on any Debian-based operating system (we rec
 
 ### Quick Install (Debian-based OS Only)
 ```bash
-sudo apt-get update && sudo apt-get install -y curl && curl -fsSL https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/main/install/install_nomad.sh -o install_nomad.sh && sudo bash install_nomad.sh
+sudo apt-get update && \
+sudo apt-get install -y curl && \
+curl -fsSL https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/main/install/install_nomad.sh \
+  -o install_nomad.sh && \
+sudo bash install_nomad.sh
 ```
 
 Project N.O.M.A.D. is now installed on your device! Open a browser and navigate to `http://localhost:8080` (or `http://DEVICE_IP:8080`) to start exploring!


### PR DESCRIPTION
Closes #568 
The Quick Install one-liner is hard to read. This reformats it using `\` continuations.
Functionally identical, easier to read.