### PR TITLE
fix(install): add gpg as a required dependency

### DIFF
--- a/install/install_nomad.sh
+++ b/install/install_nomad.sh
@@ -94,6 +94,11 @@ ensure_dependencies_installed() {
     missing_deps+=("curl")
   fi
 
+  # Check for gpg (required for NVIDIA container toolkit keyring)
+  if ! command -v gpg &> /dev/null; then
+    missing_deps+=("gpg")
+  fi
+
   # Check for whiptail (used for dialogs, though not currently active)
   # if ! command -v whiptail &> /dev/null; then
   #   missing_deps+=("whiptail")


### PR DESCRIPTION
## Summary
- Adds `gpg` to the dependency check in `install_nomad.sh` alongside `curl`
- The NVIDIA container toolkit setup requires `gpg --dearmor` to add the keyring, but minimal Debian/Ubuntu installs may not have it present
- Without `gpg`, the NVIDIA toolkit install silently fails and GPU acceleration doesn't get set up

Closes #522

## Test plan
- [ ] Fresh install on minimal Ubuntu without `gpg` pre-installed — verify it gets installed automatically
- [ ] Fresh install on standard Ubuntu with `gpg` already present — verify no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)