### PR TITLE
add x-forwarded-proto support to handle https termination

### DIFF
--- a/admin/app/controllers/maps_controller.ts
+++ b/admin/app/controllers/maps_controller.ts
@@ -83,7 +83,13 @@ export default class MapsController {
       })
     }
 
-    const styles = await this.mapService.generateStylesJSON(request.host(), request.protocol())
+    const forwardedProto = request.headers()['x-forwarded-proto'];
+
+    const protocol: string = forwardedProto
+      ? (typeof forwardedProto === 'string' ? forwardedProto : request.protocol())
+      : request.protocol();
+
+    const styles = await this.mapService.generateStylesJSON(request.host(), protocol)
     return response.json(styles)
   }
 

--- a/admin/app/services/map_service.ts
+++ b/admin/app/services/map_service.ts
@@ -446,8 +446,20 @@ export class MapService implements IMapService {
       }
     }
 
-    const host = specifiedHost || getHost()
-    const withProtocol = host.startsWith('http') ? host : `${protocol}://${host}`
+    function specifiedHostOrDefault() {
+      if(specifiedHost === null) {
+        return getHost()
+      }
+      try {
+        const specifiedUrl = new URL(specifiedHost)
+        return specifiedUrl.host
+      } catch (error) {
+        return getHost()
+      }
+    }
+
+    const host = specifiedHostOrDefault();
+    const withProtocol = `${protocol}://${host}`
     const baseUrlPath =
       process.env.NODE_ENV === 'production' ? childPath : urlJoin(this.mapStoragePath, childPath)
 


### PR DESCRIPTION
This fixes the remaining issues with https://github.com/Crosstalk-Solutions/project-nomad/issues/360

Nginx reverse proxy ssl termination results in `request.protocol()` saying `http` because the nginx->backend is http, but the user->nginx was https, so this checks for the `x-forwarded-proto` header, and sets the protocl if the header is present.