### PR TITLE
fix(queue): increase BullMQ lockDuration to prevent download stalls

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -59,6 +59,10 @@ All of NOMAD's containers are prefixed with `nomad_` in their names, so they can
 
 See [What technologies is NOMAD built with?](#what-technologies-is-nomad-built-with)
 
+## Can I use any AI models?
+NOMAD by default uses Ollama inside of a docker container to run LLM Models for the AI Assistant. So if you find a model on HuggingFace for example, you won't be able to use that model in NOMAD. The list of available models in the AI Assistant settings (/settings/models) may not show all of the models you are looking for. If you found a model from https://ollama.com/search that you'd like to try and its not in the settings page, you can use a curl command to download the model.  
+`curl -X POST -H "Content-Type: application/json" -d '{"model":"MODEL_NAME_HERE"}' http://localhost:8080/api/ollama/models` replacing MODEL_NAME_HERE with the model name from whats in the ollama website.
+
 ## Do I have to install the AI features in NOMAD?
 
 No, the AI features in NOMAD (Ollama, Qdrant, custom RAG pipeline, etc.) are all optional and not required to use the core functionality of NOMAD.

--- a/admin/commands/queue/work.ts
+++ b/admin/commands/queue/work.ts
@@ -61,6 +61,7 @@ export default class QueueWork extends BaseCommand {
         {
           connection: queueConfig.connection,
           concurrency: this.getConcurrencyForQueue(queueName),
+          lockDuration: 300000,
           autorun: true,
         }
       )


### PR DESCRIPTION
## Summary
- Increases BullMQ worker `lockDuration` from the default 30s to 300s (5 minutes)
- Prevents download jobs from being killed as stalled before data starts flowing
- Fixes the root cause behind multiple reported download failures on slower hardware

Closes #601