### PR TITLE
fix(queue): increase BullMQ lockDuration to prevent download stalls

### DIFF
--- a/admin/commands/queue/work.ts
+++ b/admin/commands/queue/work.ts
@@ -61,6 +61,7 @@ export default class QueueWork extends BaseCommand {
         {
           connection: queueConfig.connection,
           concurrency: this.getConcurrencyForQueue(queueName),
+          lockDuration: 300000,
           autorun: true,
         }
       )


### PR DESCRIPTION
## Summary
- Increases BullMQ worker `lockDuration` from the default 30s to 300s (5 minutes)
- Prevents download jobs from being killed as stalled before data starts flowing
- Fixes the root cause behind multiple reported download failures on slower hardware

Closes #601