### PR TITLE
feat: add geolocation and viewport search to maps

### DIFF
--- a/admin/app/controllers/maps_controller.ts
+++ b/admin/app/controllers/maps_controller.ts
@@ -83,7 +83,8 @@ export default class MapsController {
       })
     }
 
-    const styles = await this.mapService.generateStylesJSON(request.host(), request.protocol())
+    const protocol = request.header('X-Forwarded-Proto') || request.protocol()
+    const styles = await this.mapService.generateStylesJSON(request.host(), protocol)
     return response.json(styles)
   }
 

--- a/admin/inertia/components/maps/MapComponent.tsx
+++ b/admin/inertia/components/maps/MapComponent.tsx
@@ -1,12 +1,28 @@
-import Map, { FullscreenControl, NavigationControl, MapProvider } from 'react-map-gl/maplibre'
+import Map, {
+  FullscreenControl,
+  GeolocateControl,
+  NavigationControl,
+  MapProvider,
+  Marker,
+  useMap,
+} from 'react-map-gl/maplibre'
 import maplibregl from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 import { Protocol } from 'pmtiles'
-import { useEffect } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import MapSearchControl from './MapSearchControl'
+
+interface SearchResult {
+  name: string
+  kind: string
+  sourceLayer: string
+  coordinates: [number, number]
+}
 
 export default function MapComponent() {
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([])
+  const [selectedResult, setSelectedResult] = useState<SearchResult | null>(null)
 
-  // Add the PMTiles protocol to maplibre-gl
   useEffect(() => {
     let protocol = new Protocol()
     maplibregl.addProtocol('pmtiles', protocol.tile)
@@ -18,6 +34,7 @@ export default function MapComponent() {
   return (
     <MapProvider>
       <Map
+        id="nomad-map"
         reuseMaps
         style={{
           width: '100%',
@@ -33,7 +50,174 @@ export default function MapComponent() {
       >
         <NavigationControl style={{ marginTop: '110px', marginRight: '36px' }} />
         <FullscreenControl style={{ marginTop: '30px', marginRight: '36px' }} />
+        <GeolocateControl
+          positionOptions={{ enableHighAccuracy: true }}
+          trackUserLocation
+          showUserHeading
+          style={{ marginTop: '190px', marginRight: '36px' }}
+        />
+        {selectedResult && (
+          <Marker
+            longitude={selectedResult.coordinates[0]}
+            latitude={selectedResult.coordinates[1]}
+            color="#ef4444"
+          />
+        )}
+        <MapSearchInner
+          onResults={setSearchResults}
+          searchResults={searchResults}
+          onSelect={setSelectedResult}
+        />
       </Map>
     </MapProvider>
+  )
+}
+
+function MapSearchInner({
+  onResults,
+  searchResults,
+  onSelect,
+}: {
+  onResults: (results: SearchResult[]) => void
+  searchResults: SearchResult[]
+  onSelect: (result: SearchResult | null) => void
+}) {
+  const { 'nomad-map': map } = useMap()
+
+  const handleSearch = useCallback(
+    (query: string) => {
+      if (!map || !query.trim()) {
+        onResults([])
+        return
+      }
+
+      const mapInstance = map.getMap()
+      const results: SearchResult[] = []
+      const seen = new Set<string>()
+      const lowerQuery = query.toLowerCase()
+
+      // First: query rendered features (what's visible on screen)
+      const renderedFeatures = mapInstance.queryRenderedFeatures()
+      for (const feature of renderedFeatures) {
+        const name = feature.properties?.name || feature.properties?.['pgf:name']
+        if (!name) continue
+        if (!name.toLowerCase().includes(lowerQuery)) continue
+
+        const sl = feature.sourceLayer || ''
+        const key = `${name}-${sl}-${feature.properties?.kind}`
+        if (seen.has(key)) continue
+        seen.add(key)
+
+        let coords: [number, number] | null = null
+        if (feature.geometry.type === 'Point') {
+          coords = feature.geometry.coordinates as [number, number]
+        } else if (feature.geometry.type === 'Polygon' || feature.geometry.type === 'MultiPolygon') {
+          const bounds = new maplibregl.LngLatBounds()
+          const flatCoords =
+            feature.geometry.type === 'Polygon'
+              ? feature.geometry.coordinates[0]
+              : feature.geometry.coordinates[0][0]
+          for (const coord of flatCoords) {
+            bounds.extend(coord as [number, number])
+          }
+          const center = bounds.getCenter()
+          coords = [center.lng, center.lat]
+        }
+
+        if (coords) {
+          results.push({
+            name,
+            kind: feature.properties?.kind || sl || 'place',
+            sourceLayer: sl,
+            coordinates: coords,
+          })
+        }
+      }
+
+      // Second: also query source features from all loaded tiles
+      const sourceIds = Object.keys(mapInstance.getStyle().sources)
+      for (const sourceId of sourceIds) {
+        for (const sourceLayer of ['places', 'pois']) {
+          let features
+          try {
+            features = mapInstance.querySourceFeatures(sourceId, { sourceLayer })
+          } catch {
+            continue
+          }
+
+          for (const feature of features) {
+            const name = feature.properties?.name || feature.properties?.['pgf:name']
+            if (!name) continue
+            if (!name.toLowerCase().includes(lowerQuery)) continue
+
+            const key = `${name}-${sourceLayer}-${feature.properties?.kind}`
+            if (seen.has(key)) continue
+            seen.add(key)
+
+            let coords: [number, number] | null = null
+            if (feature.geometry.type === 'Point') {
+              coords = feature.geometry.coordinates as [number, number]
+            } else if (feature.geometry.type === 'Polygon' || feature.geometry.type === 'MultiPolygon') {
+              const bounds = new maplibregl.LngLatBounds()
+              const flatCoords =
+                feature.geometry.type === 'Polygon'
+                  ? feature.geometry.coordinates[0]
+                  : feature.geometry.coordinates[0][0]
+              for (const coord of flatCoords) {
+                bounds.extend(coord as [number, number])
+              }
+              const center = bounds.getCenter()
+              coords = [center.lng, center.lat]
+            }
+
+            if (coords) {
+              results.push({
+                name,
+                kind: feature.properties?.kind || sourceLayer,
+                sourceLayer,
+                coordinates: coords,
+              })
+            }
+          }
+        }
+      }
+
+      results.sort((a, b) => {
+        const aExact = a.name.toLowerCase() === query.toLowerCase()
+        const bExact = b.name.toLowerCase() === query.toLowerCase()
+        if (aExact && !bExact) return -1
+        if (!aExact && bExact) return 1
+        return a.name.localeCompare(b.name)
+      })
+
+      onResults(results.slice(0, 50))
+    },
+    [map, onResults]
+  )
+
+  const handleSelect = useCallback(
+    (result: SearchResult) => {
+      onSelect(result)
+      if (map) {
+        map.flyTo({
+          center: result.coordinates,
+          zoom: result.kind === 'city' || result.kind === 'state' ? 10 : 14,
+          duration: 1500,
+        })
+      }
+    },
+    [map, onSelect]
+  )
+
+  return (
+    <MapSearchControl
+      onSearch={handleSearch}
+      results={searchResults}
+      onSelect={handleSelect}
+      onClear={() => {
+        onResults([])
+        onSelect(null)
+      }}
+    />
   )
 }

--- a/admin/inertia/components/maps/MapSearchControl.tsx
+++ b/admin/inertia/components/maps/MapSearchControl.tsx
@@ -1,0 +1,143 @@
+import { useState, useRef, useEffect } from 'react'
+import { IconSearch, IconX } from '@tabler/icons-react'
+
+interface SearchResult {
+  name: string
+  kind: string
+  sourceLayer: string
+  coordinates: [number, number]
+}
+
+const KIND_LABELS: Record<string, string> = {
+  city: 'City',
+  town: 'Town',
+  village: 'Village',
+  hamlet: 'Hamlet',
+  neighbourhood: 'Neighborhood',
+  macrohood: 'Area',
+  state: 'State',
+  country: 'Country',
+  locality: 'Locality',
+  suburb: 'Suburb',
+  pois: 'Point of Interest',
+}
+
+export default function MapSearchControl({
+  onSearch,
+  results,
+  onSelect,
+  onClear,
+}: {
+  onSearch: (query: string) => void
+  results: SearchResult[]
+  onSelect: (result: SearchResult) => void
+  onClear: () => void
+}) {
+  const [query, setQuery] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>()
+  const skipNextSearch = useRef(false)
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  function handleChange(value: string) {
+    setQuery(value)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+
+    if (skipNextSearch.current) {
+      skipNextSearch.current = false
+      return
+    }
+
+    if (!value.trim()) {
+      onClear()
+      setIsOpen(false)
+      return
+    }
+
+    debounceRef.current = setTimeout(() => {
+      onSearch(value)
+      setIsOpen(true)
+    }, 300)
+  }
+
+  function handleSelectResult(result: SearchResult) {
+    skipNextSearch.current = true
+    setQuery(result.name)
+    setIsOpen(false)
+    onSelect(result)
+  }
+
+  function handleClear() {
+    setQuery('')
+    onClear()
+    setIsOpen(false)
+    inputRef.current?.focus()
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="absolute top-20 left-4 z-40"
+      style={{ width: '320px' }}
+    >
+      <div className="relative">
+        <IconSearch
+          size={18}
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
+        />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => handleChange(e.target.value)}
+          onFocus={() => query.trim() && results.length > 0 && setIsOpen(true)}
+          placeholder="Search places..."
+          className="w-full pl-10 pr-10 py-2.5 rounded-lg bg-white shadow-lg border border-gray-200 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        />
+        {query && (
+          <button
+            onClick={handleClear}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+          >
+            <IconX size={18} />
+          </button>
+        )}
+      </div>
+
+      {isOpen && results.length > 0 && (
+        <ul className="mt-1 max-h-72 overflow-y-auto rounded-lg bg-white shadow-lg border border-gray-200">
+          {results.map((result, i) => (
+            <li key={`${result.name}-${result.kind}-${i}`}>
+              <button
+                onClick={() => handleSelectResult(result)}
+                className="w-full text-left px-4 py-2.5 hover:bg-gray-50 border-b border-gray-100 last:border-b-0"
+              >
+                <div className="text-sm font-medium text-gray-900">{result.name}</div>
+                <div className="text-xs text-gray-500">
+                  {KIND_LABELS[result.kind] || result.kind}
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {isOpen && query.trim() && results.length === 0 && (
+        <div className="mt-1 px-4 py-3 rounded-lg bg-white shadow-lg border border-gray-200 text-sm text-gray-500">
+          No places found. Try zooming in or panning to load more map data.
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds GeolocateControl for browser-based location tracking on the maps page
- Adds search bar that queries visible map features (places, POIs, roads)
- Fly-to animation with red marker on search result selection
- Respects X-Forwarded-Proto header for correct HTTPS tile URLs behind reverse proxies

Note: Geolocation requires a secure context (HTTPS or localhost) to work in browsers.

## Test plan
- [ ] Navigate to Maps page, verify geolocation button appears (bottom-right area)
- [ ] Click geolocation button — browser should prompt for location permission
- [ ] Type a city name visible on the map (e.g., "Portland") in the search bar
- [ ] Select a result — map should fly to location with a red marker
- [ ] Clear search — marker should disappear
- [ ] Zoom into a region and search for smaller places — more results should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)