### PR TITLE
fix(UI): constrain install activity feed height with auto-scroll

### DIFF
--- a/admin/inertia/components/InstallActivityFeed.tsx
+++ b/admin/inertia/components/InstallActivityFeed.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import { IconCircleCheck, IconCircleX } from '@tabler/icons-react'
 import classNames from '~/lib/classNames'
 
@@ -30,10 +31,18 @@ export type InstallActivityFeedProps = {
 }
 
 const InstallActivityFeed: React.FC<InstallActivityFeedProps> = ({ activity, className, withHeader = false }) => {
+  const listRef = useRef<HTMLUListElement>(null)
+
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight
+    }
+  }, [activity])
+
   return (
     <div className={classNames('bg-surface-primary shadow-sm rounded-lg p-6', className)}>
       {withHeader && <h2 className="text-lg font-semibold text-text-primary">Installation Activity</h2>}
-      <ul role="list" className={classNames("space-y-6 text-desert-green", withHeader ? 'mt-6' : '')}>
+      <ul ref={listRef} role="list" className={classNames("space-y-6 text-desert-green max-h-[400px] overflow-y-auto scroll-smooth", withHeader ? 'mt-6' : '')}>
         {activity.map((activityItem, activityItemIdx) => (
           <li key={activityItem.timestamp} className="relative flex gap-x-4">
             <div


### PR DESCRIPTION
## Summary
- Caps the App Installation Activity list on the Easy Setup complete page to ~8 visible items (400px max height) with overflow scrolling
- Auto-scrolls to the bottom when new activity arrives, keeping the latest status visible
- Prevents Active Downloads section from being pushed off-screen during app installations

## Test plan
- [ ] Run Easy Setup wizard, select multiple apps + content tiers, complete wizard
- [ ] Verify activity feed becomes scrollable after ~8 items
- [ ] Verify newest items stay visible (auto-scroll to bottom)
- [ ] Verify user can manually scroll up to see older items
- [ ] Verify Active Downloads section remains visible below the feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)