### PR TITLE
feat(UI): add Installed Models section to AI Assistant settings

### DIFF
--- a/admin/inertia/pages/settings/models.tsx
+++ b/admin/inertia/pages/settings/models.tsx
@@ -17,6 +17,7 @@ import StyledSectionHeader from '~/components/StyledSectionHeader'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import Input from '~/components/inputs/Input'
 import { IconSearch, IconRefresh } from '@tabler/icons-react'
+import { formatBytes } from '~/lib/util'
 import useDebounce from '~/hooks/useDebounce'
 import ActiveModelDownloads from '~/components/ActiveModelDownloads'
 import { useSystemInfo } from '~/hooks/useSystemInfo'
@@ -323,6 +324,64 @@ export default function ModelsPage(props: {
               />
             </div>
           </div>
+
+          <StyledSectionHeader title="Installed Models" className="mt-12 mb-4" />
+          <div className="bg-surface-primary rounded-lg border-2 border-border-subtle p-6">
+            {props.models.installedModels.length === 0 ? (
+              <p className="text-text-muted">
+                No models installed. Browse the model catalog below to get started.
+              </p>
+            ) : (
+              <table className="min-w-full divide-y divide-border-subtle">
+                <thead>
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-text-muted uppercase tracking-wider">
+                      Model
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-text-muted uppercase tracking-wider">
+                      Parameters
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-text-muted uppercase tracking-wider">
+                      Disk Size
+                    </th>
+                    <th className="px-4 py-3 text-right text-xs font-medium text-text-muted uppercase tracking-wider">
+                      Action
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border-subtle">
+                  {props.models.installedModels.map((model) => (
+                    <tr key={model.name} className="hover:bg-surface-secondary">
+                      <td className="px-4 py-3">
+                        <span className="text-sm font-medium text-text-primary">{model.name}</span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="text-sm text-text-secondary">
+                          {model.details.parameter_size || 'N/A'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="text-sm text-text-secondary">
+                          {formatBytes(model.size)}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <StyledButton
+                          variant="danger"
+                          size="sm"
+                          onClick={() => confirmDeleteModel(model.name)}
+                          icon="IconTrash"
+                        >
+                          Delete
+                        </StyledButton>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+
           <StyledSectionHeader title="Remote Connection" className="mt-8 mb-4" />
           <div className="bg-surface-primary rounded-lg border-2 border-border-subtle p-6">
             <p className="text-sm text-text-secondary mb-4">


### PR DESCRIPTION
## Summary
- Adds a dedicated "Installed Models" section to the AI Assistant settings page
- Surfaces all installed models in a clean table with model name, parameter count, and disk size
- Each row has a Delete button that reuses the existing delete confirmation flow
- Section sits between Settings and Active Model Downloads for easy access
- Shows an empty state message when no models are installed

Previously, users had to expand each model family in the catalog and hunt for Delete buttons to find what was installed. This makes it immediately visible.

## Test plan
- [x] Verified on NOMAD3 (192.168.200.183) -- 7 installed models display correctly
- [x] Confirm Delete button triggers confirmation modal and removes model
- [ ] Confirm empty state renders when no models installed
- [x] Verify dark mode styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)