### PR TITLE
Fix download retry config and abort handling for large files

### DIFF
--- a/admin/app/jobs/run_download_job.ts
+++ b/admin/app/jobs/run_download_job.ts
@@ -67,7 +67,7 @@ export class RunDownloadJob {
         if (val) {
           await cancelRedis.del(RunDownloadJob.cancelKey(job.id!))
           userCancelled = true
-          abortController.abort()
+          abortController.abort('user-cancel')
         }
       } catch {
         // Redis errors are non-fatal; in-process AbortController covers same-process cancels
@@ -184,7 +184,8 @@ export class RunDownloadJob {
     } catch (error: any) {
       // Only prevent retries for user-initiated cancellations. BullMQ lock mismatches
       // can also abort the stream, and those should be retried with backoff.
-      if (userCancelled) {
+      // Check both the flag (Redis poll) and abort reason (in-process cancel).
+      if (userCancelled || abortController.signal.reason === 'user-cancel') {
         throw new UnrecoverableError(`Download cancelled: ${error.message}`)
       }
       throw error

--- a/admin/app/jobs/run_download_job.ts
+++ b/admin/app/jobs/run_download_job.ts
@@ -54,6 +54,11 @@ export class RunDownloadJob {
       totalBytes: 0,
     }
 
+    // Track whether cancellation was explicitly requested by the user (via Redis signal
+    // or in-process AbortController). BullMQ lock mismatches can also abort the download
+    // stream, but those should be retried — only user-initiated cancels are unrecoverable.
+    let userCancelled = false
+
     // Poll Redis for cancel signal every 2s — independent of progress events so cancellation
     // works even when the stream is stalled and no onProgress ticks are firing.
     let cancelPollInterval: ReturnType<typeof setInterval> | null = setInterval(async () => {
@@ -61,6 +66,7 @@ export class RunDownloadJob {
         const val = await cancelRedis.get(RunDownloadJob.cancelKey(job.id!))
         if (val) {
           await cancelRedis.del(RunDownloadJob.cancelKey(job.id!))
+          userCancelled = true
           abortController.abort()
         }
       } catch {
@@ -176,8 +182,9 @@ export class RunDownloadJob {
         filepath,
       }
     } catch (error: any) {
-      // If this was a cancellation abort, don't let BullMQ retry
-      if (error?.message?.includes('aborted') || error?.message?.includes('cancelled')) {
+      // Only prevent retries for user-initiated cancellations. BullMQ lock mismatches
+      // can also abort the stream, and those should be retried with backoff.
+      if (userCancelled) {
         throw new UnrecoverableError(`Download cancelled: ${error.message}`)
       }
       throw error

--- a/admin/app/jobs/run_download_job.ts
+++ b/admin/app/jobs/run_download_job.ts
@@ -228,8 +228,8 @@ export class RunDownloadJob {
     try {
       const job = await queue.add(this.key, params, {
         jobId,
-        attempts: 3,
-        backoff: { type: 'exponential', delay: 2000 },
+        attempts: 10,
+        backoff: { type: 'exponential', delay: 30000 },
         removeOnComplete: true,
       })
 

--- a/admin/app/services/download_service.ts
+++ b/admin/app/services/download_service.ts
@@ -125,7 +125,7 @@ export class DownloadService {
     await RunDownloadJob.signalCancel(jobId)
 
     // Also try in-memory abort (works if worker is in same process)
-    RunDownloadJob.abortControllers.get(jobId)?.abort()
+    RunDownloadJob.abortControllers.get(jobId)?.abort('user-cancel')
     RunDownloadJob.abortControllers.delete(jobId)
 
     // Poll for terminal state (up to 4s at 250ms intervals) — cooperates with BullMQ's lifecycle


### PR DESCRIPTION
## Summary
- Increase retry attempts (3→10) with exponential backoff (30s base) for large file downloads like global maps that experience CDN stalls
- Fix `UnrecoverableError` being thrown on BullMQ lock mismatches — only user-initiated cancels should prevent retries

## Testing
Tested a full global map download (~126GB) on a test server. The download hit two "aborted" errors mid-transfer from lock mismatches and retried through both successfully.

Closes #627