### PR TITLE
fix: hide global map download banner when installed

### DIFF
--- a/admin/inertia/lib/global_map_banner.ts
+++ b/admin/inertia/lib/global_map_banner.ts
@@ -1,0 +1,10 @@
+export function hasDownloadedGlobalMap(
+  globalMapKey: string | null | undefined,
+  storedMapFiles: Array<{ name: string }>
+): boolean {
+  if (!globalMapKey) {
+    return false
+  }
+
+  return storedMapFiles.some((file) => file.name === globalMapKey)
+}

--- a/admin/inertia/pages/settings/maps.tsx
+++ b/admin/inertia/pages/settings/maps.tsx
@@ -17,6 +17,7 @@ import type { CollectionWithStatus } from '../../../types/collections'
 import ActiveDownloads from '~/components/ActiveDownloads'
 import Alert from '~/components/Alert'
 import { formatBytes } from '~/lib/util'
+import { hasDownloadedGlobalMap } from '~/lib/global_map_banner'
 
 const CURATED_COLLECTIONS_KEY = 'curated-map-collections'
 const GLOBAL_MAP_INFO_KEY = 'global-map-info'
@@ -45,6 +46,7 @@ export default function MapsManager(props: {
     queryFn: () => api.getGlobalMapInfo(),
     refetchOnWindowFocus: false,
   })
+  const globalMapAlreadyDownloaded = hasDownloadedGlobalMap(globalMapInfo?.key, props.maps.regionFiles)
 
   const downloadGlobalMap = useMutation({
     mutationFn: () => api.downloadGlobalMap(),
@@ -251,7 +253,7 @@ export default function MapsManager(props: {
               }}
             />
           )}
-          {globalMapInfo && (
+          {globalMapInfo && !globalMapAlreadyDownloaded && (
             <Alert
               title="Global Map Coverage Available"
               message={`Download a complete worldwide map from Protomaps (${formatBytes(globalMapInfo.size, 1)}, build ${globalMapInfo.date}). This is a large file but covers the entire planet — no individual region downloads needed.`}

--- a/admin/tests/unit/global_map_banner.spec.ts
+++ b/admin/tests/unit/global_map_banner.spec.ts
@@ -1,0 +1,27 @@
+import * as assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { hasDownloadedGlobalMap } from '../../inertia/lib/global_map_banner.js'
+
+test('returns true when the global map key already exists on disk', () => {
+  assert.equal(
+    hasDownloadedGlobalMap('20260402.pmtiles', [
+      { name: '20260402.pmtiles' },
+      { name: 'california.pmtiles' },
+    ]),
+    true
+  )
+})
+
+test('returns false when the global map key is missing', () => {
+  assert.equal(
+    hasDownloadedGlobalMap('20260402.pmtiles', [
+      { name: 'california.pmtiles' },
+    ]),
+    false
+  )
+})
+
+test('returns false when there is no global map info', () => {
+  assert.equal(hasDownloadedGlobalMap(undefined, [{ name: '20260402.pmtiles' }]), false)
+})


### PR DESCRIPTION
## Summary
- hide the global Protomaps download banner once the advertised global map file is already present in stored map files
- keep the existing banner behavior for users who have not downloaded the global map yet
- add a small standalone unit test covering the banner decision logic

Fixes #633.

## Testing
- `cd admin && node --import ts-node-maintained/register/esm --test tests/unit/global_map_banner.spec.ts`
- `cd admin && PORT=3333 APP_KEY=12345678901234567890123456789012 HOST=127.0.0.1 URL=http://127.0.0.1:3333 LOG_LEVEL=info DB_HOST=127.0.0.1 DB_PORT=3306 DB_USER=test DB_DATABASE=test REDIS_HOST=127.0.0.1 REDIS_PORT=6379 npm run build`