### PR TITLE
fix(rag): fall back to any available model for query rewriting

### DIFF
--- a/admin/app/controllers/ollama_controller.ts
+++ b/admin/app/controllers/ollama_controller.ts
@@ -10,6 +10,7 @@ import { inject } from '@adonisjs/core'
 import type { HttpContext } from '@adonisjs/core/http'
 import { DEFAULT_QUERY_REWRITE_MODEL, RAG_CONTEXT_LIMITS, SYSTEM_PROMPTS } from '../../constants/ollama.js'
 import { SERVICE_NAMES } from '../../constants/service_names.js'
+import { selectRewriteModel } from '../utils/rag_utils.js'
 import logger from '@adonisjs/core/services/logger'
 type Message = { role: 'system' | 'user' | 'assistant'; content: string }
 
@@ -336,17 +337,20 @@ export default class OllamaController {
         })
         .join('\n')
 
-      const installedModels = await this.ollamaService.getModels(true)
-      const rewriteModelAvailable = installedModels?.some(model => model.name === DEFAULT_QUERY_REWRITE_MODEL)
-      if (!rewriteModelAvailable) {
-        logger.warn(`[RAG] Query rewrite model "${DEFAULT_QUERY_REWRITE_MODEL}" not available. Skipping query rewriting.`)
+      const installedModels = await this.ollamaService.getModels(false)
+      const { model: rewriteModel, isFallback } = selectRewriteModel(installedModels ?? [], DEFAULT_QUERY_REWRITE_MODEL)
+      if (!rewriteModel) {
+        logger.warn('[RAG] No models available for query rewriting. Skipping query rewriting.')
         const lastUserMessage = [...messages].reverse().find(msg => msg.role === 'user')
         return lastUserMessage?.content || null
       }
 
-      // FUTURE ENHANCEMENT: allow the user to specify which model to use for rewriting
+      if (isFallback) {
+        logger.info(`[RAG] Query rewrite model "${DEFAULT_QUERY_REWRITE_MODEL}" not available. Falling back to "${rewriteModel}".`)
+      }
+
       const response = await this.ollamaService.chat({
-        model: DEFAULT_QUERY_REWRITE_MODEL,
+        model: rewriteModel,
         messages: [
           {
             role: 'system',

--- a/admin/app/utils/rag_utils.ts
+++ b/admin/app/utils/rag_utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Select the model to use for RAG query rewriting.
+ *
+ * Prefers `preferredModelName` when available; falls back to the first model
+ * in the list so that query rewriting works regardless of which model the user
+ * has installed. Returns `undefined` only when no models are available at all.
+ */
+export function selectRewriteModel(
+  installedModels: { name: string }[],
+  preferredModelName: string
+): { model: string | undefined; isFallback: boolean } {
+  const preferred = installedModels.find((m) => m.name === preferredModelName)
+  if (preferred) {
+    return { model: preferred.name, isFallback: false }
+  }
+  const fallback = installedModels[0]?.name
+  return { model: fallback, isFallback: true }
+}

--- a/admin/tests/unit/rag_utils.spec.ts
+++ b/admin/tests/unit/rag_utils.spec.ts
@@ -1,0 +1,32 @@
+import { test } from '@japa/runner'
+import { selectRewriteModel } from '../../app/utils/rag_utils.js'
+import { DEFAULT_QUERY_REWRITE_MODEL } from '../../constants/ollama.js'
+
+test.group('selectRewriteModel', () => {
+  test('returns preferred model when it is installed', ({ assert }) => {
+    const models = [{ name: DEFAULT_QUERY_REWRITE_MODEL }, { name: 'llama3.2:8b' }]
+    const result = selectRewriteModel(models, DEFAULT_QUERY_REWRITE_MODEL)
+    assert.equal(result.model, DEFAULT_QUERY_REWRITE_MODEL)
+    assert.isFalse(result.isFallback)
+  })
+
+  test('returns first available model when preferred is not installed', ({ assert }) => {
+    const models = [{ name: 'llama3.2:8b' }, { name: 'mistral:7b' }]
+    const result = selectRewriteModel(models, DEFAULT_QUERY_REWRITE_MODEL)
+    assert.equal(result.model, 'llama3.2:8b')
+    assert.isTrue(result.isFallback)
+  })
+
+  test('returns undefined when no models are installed', ({ assert }) => {
+    const result = selectRewriteModel([], DEFAULT_QUERY_REWRITE_MODEL)
+    assert.isUndefined(result.model)
+    assert.isTrue(result.isFallback)
+  })
+
+  test('preferred model wins even when other models appear first in the list', ({ assert }) => {
+    const models = [{ name: 'llama3.2:8b' }, { name: DEFAULT_QUERY_REWRITE_MODEL }]
+    const result = selectRewriteModel(models, DEFAULT_QUERY_REWRITE_MODEL)
+    assert.equal(result.model, DEFAULT_QUERY_REWRITE_MODEL)
+    assert.isFalse(result.isFallback)
+  })
+})

--- a/admin/tests/unit/rag_utils_verify.ts
+++ b/admin/tests/unit/rag_utils_verify.ts
@@ -1,0 +1,48 @@
+/**
+ * Standalone verification script for selectRewriteModel.
+ * Run with: npx tsx tests/unit/rag_utils_verify.ts
+ * Does NOT require AdonisJS, Redis, or MySQL.
+ */
+import { selectRewriteModel } from '../../app/utils/rag_utils.js'
+
+const PREFERRED = 'qwen2.5:3b'
+
+let passed = 0
+let failed = 0
+
+function check(description: string, actual: unknown, expected: unknown) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected)
+  console.log(`  ${ok ? '✓' : '✗'} ${description}`)
+  if (!ok) {
+    console.log(`      expected: ${JSON.stringify(expected)}`)
+    console.log(`      actual:   ${JSON.stringify(actual)}`)
+    failed++
+  } else {
+    passed++
+  }
+}
+
+console.log('\nselectRewriteModel\n')
+
+// 1. Preferred model is available
+let r = selectRewriteModel([{ name: PREFERRED }, { name: 'llama3.2:8b' }], PREFERRED)
+check('uses preferred model when available', r, { model: PREFERRED, isFallback: false })
+
+// 2. Preferred not available — falls back to first
+r = selectRewriteModel([{ name: 'llama3.2:8b' }, { name: 'mistral:7b' }], PREFERRED)
+check('falls back to first model when preferred missing', r, { model: 'llama3.2:8b', isFallback: true })
+
+// 3. No models at all
+r = selectRewriteModel([], PREFERRED)
+check('returns undefined model when list is empty', r, { model: undefined, isFallback: true })
+
+// 4. Preferred appears later in the list
+r = selectRewriteModel([{ name: 'llama3.2:8b' }, { name: PREFERRED }], PREFERRED)
+check('finds preferred even when not first in list', r, { model: PREFERRED, isFallback: false })
+
+// 5. Single model, not preferred
+r = selectRewriteModel([{ name: 'mistral:7b' }], PREFERRED)
+check('single non-preferred model used as fallback', r, { model: 'mistral:7b', isFallback: true })
+
+console.log(`\n${passed} passed, ${failed} failed\n`)
+if (failed > 0) process.exit(1)


### PR DESCRIPTION
## Problem

When `qwen2.5:3b` is not installed — common in remote Ollama or LM Studio setups where a different model is configured — query rewriting is silently skipped entirely. The code logs a warning and falls back to the raw user message, meaning RAG retrieval quality degrades without any indication to the user.

The code even acknowledged this gap with a comment: `// FUTURE ENHANCEMENT: allow the user to specify which model to use for rewriting`.

Also, `getModels(true)` (include embeddings) was being used to find the rewrite model, meaning embedding models could theoretically be selected as the rewrite candidate — which would produce garbage output.

## Fix

- Falls back to the first available non-embedding model when `qwen2.5:3b` isn't installed
- Preferred model (`qwen2.5:3b`) is still used first when available — no behaviour change for default setups
- Extracts model selection into `selectRewriteModel()` in `app/utils/rag_utils.ts` — a pure function with unit tests that run without requiring the full AdonisJS/database stack

## Behaviour

| Scenario | Before | After |
|---|---|---|
| `qwen2.5:3b` installed | Uses `qwen2.5:3b` ✅ | Uses `qwen2.5:3b` ✅ |
| Only other model available | Skips rewriting ⚠️ | Falls back to available model ✅ |
| No models available | Skips rewriting | Skips rewriting (unchanged) |

## Testing

Unit tests added in `tests/unit/rag_utils.spec.ts` covering all three scenarios above plus edge cases. A standalone verification script (`tests/unit/rag_utils_verify.ts`) can be run without AdonisJS/Redis/MySQL:

```
npx tsx tests/unit/rag_utils_verify.ts
```

Tested on a live remote LM Studio setup — confirmed via logs that the fallback kicks in correctly and RAG retrieval proceeds with the available model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)