### PR TITLE
feat(content-manager): add sortable file size column

### DIFF
--- a/admin/app/services/zim_service.ts
+++ b/admin/app/services/zim_service.ts
@@ -40,7 +40,21 @@ export class ZimService {
     await ensureDirectoryExists(dirPath)
 
     const all = await listDirectoryContents(dirPath)
-    const files = all.filter((item) => item.name.endsWith('.zim'))
+    const zimEntries = all.filter((item) => item.name.endsWith('.zim'))
+
+    const files = await Promise.all(
+      zimEntries.map(async (entry) => {
+        const filePath = entry.type === 'file' ? entry.key : join(dirPath, entry.name)
+        const stats = await getFileStatsIfExists(filePath)
+        return {
+          ...entry,
+          title: null,
+          summary: null,
+          author: null,
+          size_bytes: stats ? Number(stats.size) : null,
+        }
+      })
+    )
 
     return {
       files,

--- a/admin/inertia/pages/settings/zim/index.tsx
+++ b/admin/inertia/pages/settings/zim/index.tsx
@@ -1,5 +1,6 @@
 import { Head } from '@inertiajs/react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
 import StyledTable from '~/components/StyledTable'
 import SettingsLayout from '~/layouts/SettingsLayout'
 import api from '~/lib/api'
@@ -10,11 +11,18 @@ import useServiceInstalledStatus from '~/hooks/useServiceInstalledStatus'
 import Alert from '~/components/Alert'
 import { ZimFileWithMetadata } from '../../../../types/zim'
 import { SERVICE_NAMES } from '../../../../constants/service_names'
+import { formatBytes } from '~/lib/util'
+import { IconArrowDown, IconArrowUp, IconArrowsSort } from '@tabler/icons-react'
+
+type SortKey = 'name' | 'size'
+type SortDirection = 'asc' | 'desc'
 
 export default function ZimPage() {
   const queryClient = useQueryClient()
   const { openModal, closeAllModals } = useModals()
   const { isInstalled } = useServiceInstalledStatus(SERVICE_NAMES.KIWIX)
+  const [sortKey, setSortKey] = useState<SortKey>('size')
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
   const { data, isLoading } = useQuery<ZimFileWithMetadata[]>({
     queryKey: ['zim-files'],
     queryFn: getFiles,
@@ -23,6 +31,49 @@ export default function ZimPage() {
   async function getFiles() {
     const res = await api.listZimFiles()
     return res.data.files
+  }
+
+  const sortedData = useMemo(() => {
+    if (!data) return []
+    const copy = [...data]
+    copy.sort((a, b) => {
+      let cmp = 0
+      if (sortKey === 'size') {
+        const aSize = a.size_bytes ?? 0
+        const bSize = b.size_bytes ?? 0
+        cmp = aSize - bSize
+      } else {
+        const aName = (a.title || a.name).toLowerCase()
+        const bName = (b.title || b.name).toLowerCase()
+        cmp = aName.localeCompare(bName)
+      }
+      return sortDirection === 'asc' ? cmp : -cmp
+    })
+    return copy
+  }, [data, sortKey, sortDirection])
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDirection(key === 'size' ? 'desc' : 'asc')
+    }
+  }
+
+  function renderSortHeader(label: string, key: SortKey) {
+    const active = sortKey === key
+    const Icon = !active ? IconArrowsSort : sortDirection === 'asc' ? IconArrowUp : IconArrowDown
+    return (
+      <button
+        type="button"
+        onClick={() => toggleSort(key)}
+        className="flex items-center gap-1 font-semibold text-text-primary hover:text-desert-orange"
+      >
+        {label}
+        <Icon className="size-4" />
+      </button>
+    )
   }
 
   async function confirmDeleteFile(file: ZimFileWithMetadata) {
@@ -83,7 +134,7 @@ export default function ZimPage() {
             columns={[
               {
                 accessor: 'title',
-                title: 'Title',
+                title: renderSortHeader('Title', 'name'),
                 render: (record) => (
                   <span className="font-medium">
                     {record.title || record.name}
@@ -96,6 +147,15 @@ export default function ZimPage() {
                 render: (record) => (
                   <span className="text-text-secondary text-sm line-clamp-2">
                     {record.summary || '—'}
+                  </span>
+                ),
+              },
+              {
+                accessor: 'size_bytes',
+                title: renderSortHeader('Size', 'size'),
+                render: (record) => (
+                  <span className="text-text-secondary tabular-nums">
+                    {record.size_bytes ? formatBytes(record.size_bytes, 1) : '—'}
                   </span>
                 ),
               },
@@ -117,7 +177,7 @@ export default function ZimPage() {
                 ),
               },
             ]}
-            data={data || []}
+            data={sortedData}
           />
         </main>
       </div>


### PR DESCRIPTION
## Summary

Closes #685.

Adds a **Size** column to the Content Manager table showing the on-disk size of each ZIM file, and makes both **Title** and **Size** headers sortable (asc/desc). Defaults to sorting by size descending so the largest files surface first — which is what users actually want when looking at the Content Manager (to see what's taking up space).

## Changes

**Backend** — `ZimService.list()` now stats each file and returns `size_bytes`. The metadata type (`ZimFileWithMetadata`) already had the field; it was just never populated.

**Frontend** — Content Manager page:
- New Size column with formatted bytes via the existing `formatBytes()` util
- Sortable headers for Title and Size (clickable with asc/desc arrow indicators)
- Defaults to Size descending on first load
- Sort state is local (no URL/localStorage persistence — simple and sufficient for this view)

## Test Plan

- [ ] Navigate to Settings → Content Manager
- [ ] Verify Size column displays formatted sizes (e.g., "1.2 GB", "245 MB")
- [ ] Verify default sort is by size, largest first
- [ ] Click Size header to toggle ascending, verify smallest files on top
- [ ] Click Title header to sort alphabetically
- [ ] Click it again to reverse alphabetical
- [ ] Delete a file and verify the list refreshes with updated sort intact