### PR TITLE
fix(admin): only hide global map banner after download

### DIFF
--- a/admin/inertia/lib/global_map_banner.ts
+++ b/admin/inertia/lib/global_map_banner.ts
@@ -1,0 +1,10 @@
+export function hasDownloadedGlobalMap(
+  globalMapKey: string | null | undefined,
+  storedMapFiles: Array<{ name: string }>
+): boolean {
+  if (!globalMapKey) {
+    return false
+  }
+
+  return storedMapFiles.some((file) => file.name === globalMapKey)
+}

--- a/admin/inertia/lib/global_map_banner.ts
+++ b/admin/inertia/lib/global_map_banner.ts
@@ -6,5 +6,5 @@ export function hasDownloadedGlobalMap(
     return false
   }
 
-  return storedMapFiles.some((file) => file.name === globalMapKey)
+  return storedMapFiles.some((file) => file.name === globalMapKey || /^\d{8}\.pmtiles$/.test(file.name))
 }

--- a/admin/inertia/pages/settings/maps.tsx
+++ b/admin/inertia/pages/settings/maps.tsx
@@ -253,6 +253,22 @@ export default function MapsManager(props: {
               }}
             />
           )}
+          {globalMapInfo && globalMapAlreadyDownloaded && (
+            <Alert
+              title="Global Map Installed"
+              message={`Your global map build ${globalMapInfo.date} (${formatBytes(globalMapInfo.size, 1)}) is stored locally and ready for offline use.`}
+              type="success"
+              variant="bordered"
+              className="mt-8"
+              icon="IconCircleCheck"
+              buttonProps={{
+                variant: 'secondary',
+                children: 'Download latest build',
+                icon: 'IconRefresh',
+                onClick: () => confirmGlobalMapDownload(),
+              }}
+            />
+          )}
           {globalMapInfo && !globalMapAlreadyDownloaded && (
             <Alert
               title="Global Map Coverage Available"

--- a/admin/inertia/pages/settings/maps.tsx
+++ b/admin/inertia/pages/settings/maps.tsx
@@ -17,6 +17,7 @@ import type { CollectionWithStatus } from '../../../types/collections'
 import ActiveDownloads from '~/components/ActiveDownloads'
 import Alert from '~/components/Alert'
 import { formatBytes } from '~/lib/util'
+import { hasDownloadedGlobalMap } from '~/lib/global_map_banner'
 
 const CURATED_COLLECTIONS_KEY = 'curated-map-collections'
 const GLOBAL_MAP_INFO_KEY = 'global-map-info'
@@ -45,6 +46,7 @@ export default function MapsManager(props: {
     queryFn: () => api.getGlobalMapInfo(),
     refetchOnWindowFocus: false,
   })
+  const globalMapAlreadyDownloaded = hasDownloadedGlobalMap(globalMapInfo?.key, props.maps.regionFiles)
 
   const downloadGlobalMap = useMutation({
     mutationFn: () => api.downloadGlobalMap(),
@@ -251,7 +253,7 @@ export default function MapsManager(props: {
               }}
             />
           )}
-          {globalMapInfo && (
+          {globalMapInfo && !globalMapAlreadyDownloaded && (
             <Alert
               title="Global Map Coverage Available"
               message={`Download a complete worldwide map from Protomaps (${formatBytes(globalMapInfo.size, 1)}, build ${globalMapInfo.date}). This is a large file but covers the entire planet — no individual region downloads needed.`}

--- a/admin/tests/unit/global_map_banner.spec.ts
+++ b/admin/tests/unit/global_map_banner.spec.ts
@@ -1,0 +1,27 @@
+import * as assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { hasDownloadedGlobalMap } from '../../inertia/lib/global_map_banner.js'
+
+test('returns true when the global map key already exists on disk', () => {
+  assert.equal(
+    hasDownloadedGlobalMap('20260402.pmtiles', [
+      { name: '20260402.pmtiles' },
+      { name: 'california.pmtiles' },
+    ]),
+    true
+  )
+})
+
+test('returns false when the global map key is missing', () => {
+  assert.equal(
+    hasDownloadedGlobalMap('20260402.pmtiles', [
+      { name: 'california.pmtiles' },
+    ]),
+    false
+  )
+})
+
+test('returns false when there is no global map info', () => {
+  assert.equal(hasDownloadedGlobalMap(undefined, [{ name: '20260402.pmtiles' }]), false)
+})

--- a/admin/tests/unit/global_map_banner.spec.ts
+++ b/admin/tests/unit/global_map_banner.spec.ts
@@ -22,6 +22,16 @@ test('returns false when the global map key is missing', () => {
   )
 })
 
+test('returns true when an older global map build is already on disk', () => {
+  assert.equal(
+    hasDownloadedGlobalMap('20260402.pmtiles', [
+      { name: '20260315.pmtiles' },
+      { name: 'california.pmtiles' },
+    ]),
+    true
+  )
+})
+
 test('returns false when there is no global map info', () => {
   assert.equal(hasDownloadedGlobalMap(undefined, [{ name: '20260402.pmtiles' }]), false)
 })


### PR DESCRIPTION
## Summary
- keep the global map download banner visible until the configured global map file actually exists on disk
- add a small helper for checking the downloaded map inventory by filename
- add focused regression coverage for the banner visibility helper

## Testing
- npx tsx --test admin/tests/unit/global_map_banner.spec.ts