### PR TITLE
fix(maps): wire delete confirmation to API

### DIFF
--- a/admin/inertia/lib/api.ts
+++ b/admin/inertia/lib/api.ts
@@ -130,6 +130,15 @@ class API {
     })()
   }
 
+  async deleteMapRegionFile(filename: string): Promise<{ message: string }> {
+    return catchInternal(async () => {
+      const response = await this.client.delete<{ message: string }>(
+        `/maps/${encodeURIComponent(filename)}`
+      )
+      return response.data
+    })()
+  }
+
   async downloadRemoteZimFile(
     url: string,
     metadata?: { title: string; summary?: string; author?: string; size_bytes?: number }

--- a/admin/inertia/pages/settings/maps.tsx
+++ b/admin/inertia/pages/settings/maps.tsx
@@ -28,6 +28,7 @@ export default function MapsManager(props: {
   const { openModal, closeAllModals } = useModals()
   const { addNotification } = useNotifications()
   const [downloading, setDownloading] = useState(false)
+  const [deletingFileKey, setDeletingFileKey] = useState<string | null>(null)
 
   const { data: curatedCollections } = useQuery({
     queryKey: [CURATED_COLLECTIONS_KEY],
@@ -118,18 +119,40 @@ export default function MapsManager(props: {
     }
   }
 
+  async function deleteFile(file: FileEntry) {
+    if (file.type !== 'file') return
+
+    try {
+      setDeletingFileKey(file.key)
+      await api.deleteMapRegionFile(file.key)
+      addNotification({
+        type: 'success',
+        message: `${file.name} has been deleted.`,
+      })
+      closeAllModals()
+      router.reload({ only: ['maps'] })
+    } catch (error) {
+      console.error('Error deleting map file:', error)
+      addNotification({
+        type: 'error',
+        message: `Failed to delete ${file.name}. Please try again.`,
+      })
+    } finally {
+      setDeletingFileKey(null)
+    }
+  }
+
   async function confirmDeleteFile(file: FileEntry) {
     openModal(
       <StyledModal
         title="Confirm Delete?"
-        onConfirm={() => {
-          closeAllModals()
-        }}
+        onConfirm={() => deleteFile(file)}
         onCancel={closeAllModals}
         open={true}
         confirmText="Delete"
         cancelText="Cancel"
         confirmVariant="danger"
+        confirmLoading={file.type === 'file' && deletingFileKey === file.key}
       >
         <p className="text-text-secondary">
           Are you sure you want to delete {file.name}? This action cannot be undone.


### PR DESCRIPTION
## Summary
- add a Maps API helper for deleting stored map region files
- call the existing DELETE /api/maps/:filename route from the Maps Manager confirmation modal
- show success/error notifications and refresh the map list after deletion

Fixes #728.

## Validation
- npm run typecheck
- npm run build