### PR TITLE
fix(kiwix): self-heal missing library XML

### DIFF
--- a/admin/app/services/kiwix_library_service.ts
+++ b/admin/app/services/kiwix_library_service.ts
@@ -187,6 +187,35 @@ export class KiwixLibraryService {
       .filter((b) => b.id && b.path)
   }
 
+  private _validateLibraryXml(xmlContent: string): void {
+    const parser = new XMLParser({
+      ignoreAttributes: false,
+      attributeNamePrefix: '@_',
+      isArray: (name) => name === 'book',
+    })
+
+    const parsed = parser.parse(xmlContent)
+    if (!parsed?.library || typeof parsed.library !== 'object') {
+      throw new Error('Kiwix library XML is missing the library root element.')
+    }
+  }
+
+  async ensureValidLibraryXml(): Promise<boolean> {
+    try {
+      const content = await readFile(this.getLibraryFilePath(), 'utf-8')
+      this._validateLibraryXml(content)
+      return false
+    } catch (err: any) {
+      if (err.code && err.code !== 'ENOENT') {
+        throw err
+      }
+
+      logger.warn('[KiwixLibraryService] Library XML is missing or invalid; rebuilding from disk.')
+      await this.rebuildFromDisk()
+      return true
+    }
+  }
+
   async rebuildFromDisk(opts?: { excludeFilenames?: string[] }): Promise<void> {
     const dirPath = join(process.cwd(), ZIM_STORAGE_PATH)
     await ensureDirectoryExists(dirPath)

--- a/admin/providers/kiwix_migration_provider.ts
+++ b/admin/providers/kiwix_migration_provider.ts
@@ -22,6 +22,7 @@ export default class KiwixMigrationProvider {
         const Service = (await import('#models/service')).default
         const { SERVICE_NAMES } = await import('../constants/service_names.js')
         const { DockerService } = await import('#services/docker_service')
+        const { KiwixLibraryService } = await import('#services/kiwix_library_service')
 
         const kiwixService = await Service.query()
           .where('service_name', SERVICE_NAMES.KIWIX)
@@ -34,9 +35,15 @@ export default class KiwixMigrationProvider {
 
         const dockerService = new DockerService()
         const isLegacy = await dockerService.isKiwixOnLegacyConfig()
+        const kiwixLibraryService = new KiwixLibraryService()
 
         if (!isLegacy) {
-          logger.info('[KiwixMigrationProvider] Kiwix is already in library mode — no migration needed.')
+          const rebuilt = await kiwixLibraryService.ensureValidLibraryXml()
+          if (rebuilt) {
+            logger.info('[KiwixMigrationProvider] Rebuilt missing or invalid Kiwix library XML.')
+          } else {
+            logger.info('[KiwixMigrationProvider] Kiwix is already in library mode — no migration needed.')
+          }
           return
         }
 


### PR DESCRIPTION
## Summary
- validate the Kiwix library XML when Kiwix is already in library mode
- rebuild `/storage/zim/kiwix-library.xml` from disk when the file is missing or invalid
- keep the existing legacy migration path unchanged

## Validation
- cd admin && npm run typecheck
- cd admin && npx eslint providers/kiwix_migration_provider.ts app/services/kiwix_library_service.ts
- cd admin && npm run build