### PR TITLE
fix(ai): stop local nomad_ollama when remote Ollama is configured

### DIFF
--- a/admin/app/controllers/ollama_controller.ts
+++ b/admin/app/controllers/ollama_controller.ts
@@ -212,13 +212,21 @@ export default class OllamaController {
       return response.status(404).send({ success: false, message: 'Ollama service record not found.' })
     }
 
-    // Clear path: null or empty URL removes remote config and marks service as not installed
+    // Clear path: null or empty URL removes remote config. If a local nomad_ollama container
+    // still exists (user had previously installed AI Assistant locally), restart it and keep
+    // the service marked installed. Otherwise fall back to uninstalled.
     if (!remoteUrl || remoteUrl.trim() === '') {
       await KVStore.clearValue('ai.remoteOllamaUrl')
-      ollamaService.installed = false
+      const hasLocalContainer = await this._startLocalOllamaContainerIfExists()
+      ollamaService.installed = hasLocalContainer
       ollamaService.installation_status = 'idle'
       await ollamaService.save()
-      return { success: true, message: 'Remote Ollama configuration cleared.' }
+      return {
+        success: true,
+        message: hasLocalContainer
+          ? 'Remote Ollama cleared. Local Ollama container restored.'
+          : 'Remote Ollama configuration cleared.',
+      }
     }
 
     // Validate URL format
@@ -253,6 +261,10 @@ export default class OllamaController {
     ollamaService.installation_status = 'idle'
     await ollamaService.save()
 
+    // Stop the local nomad_ollama container (if running) so it doesn't compete with the
+    // remote host for GPU / port 11434. Preserves the container and its models volume.
+    await this._stopLocalOllamaContainer()
+
     // Install Qdrant if not already installed (fire-and-forget)
     const qdrantService = await Service.query().where('service_name', SERVICE_NAMES.QDRANT).first()
     if (qdrantService && !qdrantService.installed) {
@@ -268,6 +280,50 @@ export default class OllamaController {
     })
 
     return { success: true, message: 'Remote Ollama configured.' }
+  }
+
+  private async _stopLocalOllamaContainer(): Promise<void> {
+    try {
+      const containers = await this.dockerService.docker.listContainers({ all: true })
+      const ollamaContainer = containers.find((c) =>
+        c.Names.includes(`/${SERVICE_NAMES.OLLAMA}`)
+      )
+      if (!ollamaContainer || ollamaContainer.State !== 'running') {
+        return
+      }
+      await this.dockerService.docker.getContainer(ollamaContainer.Id).stop()
+      this.dockerService.invalidateServicesStatusCache()
+      logger.info('[OllamaController] Stopped local nomad_ollama (remote Ollama configured)')
+    } catch (error: any) {
+      logger.error(
+        { err: error },
+        '[OllamaController] Failed to stop local nomad_ollama; remote Ollama is still active'
+      )
+    }
+  }
+
+  private async _startLocalOllamaContainerIfExists(): Promise<boolean> {
+    try {
+      const containers = await this.dockerService.docker.listContainers({ all: true })
+      const ollamaContainer = containers.find((c) =>
+        c.Names.includes(`/${SERVICE_NAMES.OLLAMA}`)
+      )
+      if (!ollamaContainer) {
+        return false
+      }
+      if (ollamaContainer.State !== 'running') {
+        await this.dockerService.docker.getContainer(ollamaContainer.Id).start()
+        this.dockerService.invalidateServicesStatusCache()
+        logger.info('[OllamaController] Started local nomad_ollama (remote Ollama cleared)')
+      }
+      return true
+    } catch (error: any) {
+      logger.error(
+        { err: error },
+        '[OllamaController] Failed to start local nomad_ollama on remote clear'
+      )
+      return false
+    }
   }
 
   async deleteModel({ request }: HttpContext) {


### PR DESCRIPTION
## Summary

When users configure a remote Ollama URL via AI Settings, the local `nomad_ollama` container kept running and competed with the remote host for port 11434 and GPU access. Per community reports on #662 (@kwslavens, @fjarvis, @recklessnode, @hestela), this causes random failures when integrating NOMAD with external LLM stacks (vLLM, llama.cpp, Agent Zero, openclaw, custom Ollama).

`configureRemote` now:

- **Sets URL**: after the remote URL is validated and saved, stops the local `nomad_ollama` container if it's running. Container and volume are preserved (models intact).
- **Clears URL**: if a local `nomad_ollama` container still exists, starts it back up and keeps `installed: true`. If no local container exists, falls back to the previous `installed: false` behavior.

Both helpers are non-fatal on Docker errors so a stuck container doesn't block the remote save/clear.

## Why the scope stops here

Related pain points flagged in #662:
- **Easy-setup skip when remote enabled** — already shipped in v1.31.0 (commit 69c15b8 filters OLLAMA out of `selectedServices`).
- **AI Assistant update fails when container is stopped** (per @fjarvis) — separate bug, deserves its own PR.

## Test plan

- [ ] Fresh install with local AI Assistant, set remote URL via Settings → Models, verify `nomad_ollama` transitions to `Exited` in `docker ps -a`
- [ ] Models volume intact (`docker volume inspect nomad_ollama_data`)
- [ ] Clear remote URL, verify `nomad_ollama` comes back to `Up` and service stays `installed`
- [ ] Set remote URL on an install that never had local Ollama — no error, no-op stop
- [ ] Clear remote URL on the same — falls back to `installed: false` as before
- [ ] Chat + Knowledge Base work against remote host the whole time