### PR TITLE
fix(rag): repair ZIM embedding pipeline (sync filter, batch gate, DOM walk)

### DIFF
--- a/admin/app/services/rag_service.ts
+++ b/admin/app/services/rag_service.ts
@@ -532,9 +532,12 @@ export class RagService {
       }
     }
 
-    // Count unique articles processed in this batch
+    // Count unique articles processed in this batch. hasMoreBatches gates on the article
+    // count — zimChunks.length counts section-level chunks (multiple per article under the
+    // 'structured' strategy), so comparing it to ZIM_BATCH_SIZE (an article limit) caps
+    // processing at the first batch for any real archive.
     const articlesInBatch = new Set(zimChunks.map((c) => c.documentId)).size
-    const hasMoreBatches = zimChunks.length === ZIM_BATCH_SIZE
+    const hasMoreBatches = articlesInBatch >= ZIM_BATCH_SIZE
 
     logger.info(
       `[RAG] Successfully embedded ${totalChunks} total chunks from ${articlesInBatch} articles (hasMore: ${hasMoreBatches})`
@@ -1252,8 +1255,12 @@ export class RagService {
 
       logger.info(`[RAG] Found ${sourcesInQdrant.size} unique sources in Qdrant`)
 
-      // Find files that are in storage but not in Qdrant
-      const filesToEmbed = filesInStorage.filter((filePath) => !sourcesInQdrant.has(filePath))
+      // Find files that are in storage, not already in Qdrant, and have an embeddable type.
+      // Non-embeddable files (e.g. kiwix-library.xml in /storage/zim) would otherwise be
+      // dispatched to EmbedFileJob, fail with "Unsupported file type", and retry on every sync.
+      const filesToEmbed = filesInStorage.filter(
+        (filePath) => !sourcesInQdrant.has(filePath) && determineFileType(filePath) !== 'unknown'
+      )
 
       logger.info(`[RAG] Found ${filesToEmbed.length} files that need embedding`)
 

--- a/admin/app/services/zim_extraction_service.ts
+++ b/admin/app/services/zim_extraction_service.ts
@@ -216,7 +216,10 @@ export class ZIMExtractionService {
         const sections: Array<{ heading: string; text: string; level: number }> = [];
         let currentSection = { heading: 'Introduction', content: [] as string[], level: 2 };
 
-        $('body').children().each((_, element) => {
+        // Walk the full DOM rather than only direct children of <body>. Modern ZIMs (Devdocs,
+        // Wikipedia, FreeCodeCamp, etc.) wrap article content in a container div, which under
+        // .children() would be a single non-heading/non-paragraph element and yield zero sections.
+        $('body').find('h2, h3, h4, p, ul, ol, dl, table').each((_, element) => {
             const $el = $(element);
             const tagName = element.tagName?.toLowerCase();
 
@@ -251,6 +254,20 @@ export class ZIMExtractionService {
                 text: currentSection.content.join(' ').replace(/\s+/g, ' ').trim(),
                 level: currentSection.level,
             });
+        }
+
+        // Fallback: if the selector walk produced no sections but the body has meaningful
+        // text (unusual structure, minimal markup), emit one section with the full body text
+        // so the article still contributes to the knowledge base.
+        if (sections.length === 0) {
+            const bodyText = $('body').text().replace(/\s+/g, ' ').trim();
+            if (bodyText.length > 0) {
+                sections.push({
+                    heading: title || 'Content',
+                    text: bodyText,
+                    level: 2,
+                });
+            }
         }
 
         return {


### PR DESCRIPTION
## Summary

Three bugs in the RAG embedding pipeline, diagnosed and patched by @sbruschke against v1.31.0. Collectively these are the root cause of #388 (the known-broken RAG embedding pipeline reported by @dcbenji, @OSIASLEE, @jrsphoto, and others) — any one of them is enough to kill embedding for real-world ZIMs.

### 1. \`scanAndSyncStorage\` queued non-embeddable files (#718)

\`rag_service.ts:1256\` filtered only by "not already in Qdrant." Kiwix's generated \`kiwix-library.xml\` got queued on every sync, failed \`determineFileType()\` in EmbedFileJob with \"Unsupported file type,\" and retried 30× per dispatch — flooding \`nomad_admin\` logs forever. Now gated on \`determineFileType(filePath) !== 'unknown'\`.

### 2. \`hasMoreBatches\` compared the wrong count (#719)

\`rag_service.ts:537\` used \`zimChunks.length === ZIM_BATCH_SIZE\`. \`zimChunks.length\` counts section-level chunks (multiple per article under the 'structured' strategy), but \`ZIM_BATCH_SIZE\` is an article limit — the two are never equal for real archives, so processing silently stopped after the first 50 articles. Now gated on \`articlesInBatch >= ZIM_BATCH_SIZE\`.

### 3. \`extractStructuredContent\` only walked direct children of \`<body>\` (#720)

\`zim_extraction_service.ts:219\` used \`$('body').children()\`, which only visits direct children. Modern ZIMs wrap article content in a container div (Devdocs, Wikipedia, FreeCodeCamp, React docs, etc.), so the iteration visited one non-heading/non-paragraph element and emitted zero sections — the article \"embedded successfully\" with 0 chunks. Now walks the full DOM via \`$('body').find('h2, h3, h4, p, ul, ol, dl, table')\`, with a whole-body text fallback when the selector walk yields nothing.

## Credit

All three diagnoses and proposed fixes come from @sbruschke's bug reports. Their version of the fixes was confirmed working on v1.31.0 with the following before/after chunk counts:

| ZIM | Chunks before | Chunks after |
|---|---|---|
| devdocs_en_git | 0 | 916 |
| devdocs_en_react | 0 | 481 |
| devdocs_en_node | 0 | 423 |
| libretexts_en_eng | 1 | 35 (and climbing) |

Wikipedia resumed progressing normally through its 6M articles after the combined fix.

## Test plan

- [ ] Fresh sync with Kiwix library XML present — verify \`kiwix-library.xml\` is NOT in the failed-jobs queue and logs are clean
- [ ] Sync a ZIM with >50 articles, verify second batch dispatches at offset=50 and processing continues until exhausted
- [ ] Install \`devdocs_en_git\` (or any wrapped-HTML ZIM), sync, verify Qdrant has hundreds of points from that source
- [ ] Install a ZIM that previously worked (Wikipedia Simple, Gutenberg classics) — regression-check that structured extraction still produces sensible sections
- [ ] AI Assistant RAG retrieval surfaces content from newly-working ZIMs

Closes #718
Closes #719
Closes #720
Closes #388