### PR TITLE
fix(zim): accumulate across Kiwix pages to prevent empty Content Explorer

### DIFF
--- a/admin/app/services/zim_service.ts
+++ b/admin/app/services/zim_service.ts
@@ -57,84 +57,105 @@ export class ZimService {
     query?: string
   }): Promise<ListRemoteZimFilesResponse> {
     const LIBRARY_BASE_URL = 'https://browse.library.kiwix.org/catalog/v2/entries'
+    // Kiwix returns pages of content unaware of what the user has installed locally. When
+    // the installed set is large, a single 12-item Kiwix page can come back with everything
+    // already installed → 0 post-filter items → frontend deadlock (#731). Accumulate across
+    // upstream pages so we return a useful batch. Bounded by MAX_KIWIX_FETCHES so a heavily
+    // saturated install doesn't hang a single request; the frontend scroll loop + auto-fetch
+    // effect handle continuation.
+    const KIWIX_PAGE_SIZE = 60
+    const MAX_KIWIX_FETCHES = 5
 
-    const res = await axios.get(LIBRARY_BASE_URL, {
-      params: {
-        start: start,
-        count: count,
-        lang: 'eng',
-        ...(query ? { q: query } : {}),
-      },
-      responseType: 'text',
-    })
-
-    const data = res.data
     const parser = new XMLParser({
       ignoreAttributes: false,
       attributeNamePrefix: '',
       textNodeName: '#text',
     })
-    const result = parser.parse(data)
 
-    if (!isRawListRemoteZimFilesResponse(result)) {
-      throw new Error('Invalid response format from remote library')
-    }
-
-    const entries = result.feed.entry
-      ? Array.isArray(result.feed.entry)
-        ? result.feed.entry
-        : [result.feed.entry]
-      : []
-
-    const filtered = entries.filter((entry: any) => {
-      return isRawRemoteZimFileEntry(entry)
-    })
-
-    const mapped: (RemoteZimFileEntry | null)[] = filtered.map((entry: RawRemoteZimFileEntry) => {
-      const downloadLink = entry.link.find((link: any) => {
-        return (
-          typeof link === 'object' &&
-          'rel' in link &&
-          'length' in link &&
-          'href' in link &&
-          'type' in link &&
-          link.type === 'application/x-zim'
-        )
-      })
-
-      if (!downloadLink) {
-        return null
-      }
-
-      // downloadLink['href'] will end with .meta4, we need to remove that to get the actual download URL
-      const download_url = downloadLink['href'].substring(0, downloadLink['href'].length - 6)
-      const file_name = download_url.split('/').pop() || `${entry.title}.zim`
-      const sizeBytes = parseInt(downloadLink['length'], 10)
-
-      return {
-        id: entry.id,
-        title: entry.title,
-        updated: entry.updated,
-        summary: entry.summary,
-        size_bytes: sizeBytes || 0,
-        download_url: download_url,
-        author: entry.author.name,
-        file_name: file_name,
-      }
-    })
-
-    // Filter out any null entries (those without a valid download link)
-    // or files that already exist in the local storage
+    // Snapshot locally-installed files once — the filesystem won't change mid-request.
     const existing = await this.list()
     const existingKeys = new Set(existing.files.map((file) => file.name))
-    const withoutExisting = mapped.filter(
-      (entry): entry is RemoteZimFileEntry => entry !== null && !existingKeys.has(entry.file_name)
-    )
+
+    const accumulated: RemoteZimFileEntry[] = []
+    const seenIds = new Set<string>()
+    let currentStart = start
+    let totalResults = 0
+
+    for (let i = 0; i < MAX_KIWIX_FETCHES; i++) {
+      const res = await axios.get(LIBRARY_BASE_URL, {
+        params: {
+          start: currentStart,
+          count: KIWIX_PAGE_SIZE,
+          lang: 'eng',
+          ...(query ? { q: query } : {}),
+        },
+        responseType: 'text',
+      })
+
+      const parsed = parser.parse(res.data)
+      if (!isRawListRemoteZimFilesResponse(parsed)) {
+        throw new Error('Invalid response format from remote library')
+      }
+      totalResults = parsed.feed.totalResults
+
+      const rawEntries = parsed.feed.entry
+        ? Array.isArray(parsed.feed.entry)
+          ? parsed.feed.entry
+          : [parsed.feed.entry]
+        : []
+
+      // Empty upstream response — bail even if totalResults suggests more (transient Kiwix
+      // hiccup or totalResults drift between pages). Prevents a pointless spin.
+      if (rawEntries.length === 0) break
+
+      // Advance by actual returned count, not requested count. Short pages at the tail
+      // would otherwise cause us to skip entries on the next fetch.
+      currentStart += rawEntries.length
+
+      for (const raw of rawEntries) {
+        if (!isRawRemoteZimFileEntry(raw)) continue
+        const entry = raw as RawRemoteZimFileEntry
+
+        const downloadLink = entry.link.find(
+          (link: any) =>
+            typeof link === 'object' &&
+            'rel' in link &&
+            'length' in link &&
+            'href' in link &&
+            'type' in link &&
+            link.type === 'application/x-zim'
+        )
+        if (!downloadLink) continue
+
+        // downloadLink['href'] ends with .meta4; strip that to get the actual .zim URL.
+        const download_url = downloadLink['href'].substring(0, downloadLink['href'].length - 6)
+        const file_name = download_url.split('/').pop() || `${entry.title}.zim`
+        if (existingKeys.has(file_name)) continue
+        if (seenIds.has(entry.id)) continue
+        seenIds.add(entry.id)
+
+        const sizeBytes = parseInt(downloadLink['length'], 10)
+        accumulated.push({
+          id: entry.id,
+          title: entry.title,
+          updated: entry.updated,
+          summary: entry.summary,
+          size_bytes: sizeBytes || 0,
+          download_url,
+          author: entry.author.name,
+          file_name,
+        })
+      }
+
+      if (accumulated.length >= count) break
+      if (currentStart >= totalResults) break
+    }
 
     return {
-      items: withoutExisting,
-      has_more: result.feed.totalResults > start,
-      total_count: result.feed.totalResults,
+      items: accumulated,
+      has_more: currentStart < totalResults,
+      total_count: totalResults,
+      next_start: currentStart,
     }
   }
 

--- a/admin/inertia/pages/settings/zim/remote-explorer.tsx
+++ b/admin/inertia/pages/settings/zim/remote-explorer.tsx
@@ -83,8 +83,10 @@ export default function ZimRemoteExplorer() {
     useInfiniteQuery<ListRemoteZimFilesResponse>({
       queryKey: ['remote-zim-files', query],
       queryFn: async ({ pageParam = 0 }) => {
-        const pageParsed = parseInt((pageParam as number).toString(), 10)
-        const start = isNaN(pageParsed) ? 0 : pageParsed * 12
+        // pageParam is an opaque Kiwix offset returned by the backend as `next_start`.
+        // The backend accumulates across multiple upstream pages when needed (#731), so the
+        // frontend can't derive the next offset from a 12-item page assumption.
+        const start = typeof pageParam === 'number' ? pageParam : 0
         const res = await api.listRemoteZimFiles({ start, count: 12, query: query || undefined })
         if (!res) {
           throw new Error('Failed to fetch remote ZIM files.')
@@ -92,12 +94,7 @@ export default function ZimRemoteExplorer() {
         return res.data
       },
       initialPageParam: 0,
-      getNextPageParam: (_lastPage, pages) => {
-        if (!_lastPage.has_more) {
-          return undefined // No more pages to fetch
-        }
-        return pages.length
-      },
+      getNextPageParam: (lastPage) => (lastPage.has_more ? lastPage.next_start : undefined),
       refetchOnWindowFocus: false,
       placeholderData: keepPreviousData,
     })
@@ -119,18 +116,16 @@ export default function ZimRemoteExplorer() {
     (parentRef?: HTMLDivElement | null) => {
       if (parentRef) {
         const { scrollHeight, scrollTop, clientHeight } = parentRef
-        //once the user has scrolled within 200px of the bottom of the table, fetch more data if we can
-        if (
-          scrollHeight - scrollTop - clientHeight < 200 &&
-          !isFetching &&
-          hasMore &&
-          flatData.length > 0
-        ) {
+        // Fetch more when near the bottom. The `flatData.length > 0` guard that used to be
+        // here caused the #731 deadlock when a heavily-saturated install returned an empty
+        // page with has_more=true — removing it lets the existing on-mount/on-data effect
+        // below drive bounded auto-fetch until hasMore flips false.
+        if (scrollHeight - scrollTop - clientHeight < 200 && !isFetching && hasMore) {
           fetchNextPage()
         }
       }
     },
-    [fetchNextPage, isFetching, hasMore, flatData.length]
+    [fetchNextPage, isFetching, hasMore]
   )
 
   const virtualizer = useVirtualizer({

--- a/admin/types/zim.ts
+++ b/admin/types/zim.ts
@@ -16,6 +16,7 @@ export type ListRemoteZimFilesResponse = {
   items: RemoteZimFileEntry[]
   has_more: boolean
   total_count: number
+  next_start: number
 }
 
 export type RawRemoteZimFileEntry = {


### PR DESCRIPTION
## Summary

Closes #731 (reported + diagnosed by @johno10661).

When a user has many ZIMs already installed (~400 of ~1093), the \"Browse the Kiwix Library\" view showed \"No records found.\" The Kiwix catalog returned 12 items per page; \`zim_service.listRemote\` filtered out already-installed entries; when every item on a page was already installed the response was \`items: []\` with \`has_more: true\`; and the frontend's infinite-scroll guard (\`flatData.length > 0\`) blocked the next fetch, so the user was stuck.

Search worked because targeted queries rarely produce a full-page-of-installed collision.

## What changed

### Backend — \`admin/app/services/zim_service.ts\`

\`listRemote\` now accumulates across upstream pages before returning. Up to 5 Kiwix fetches per request, 60 items each. Terminates early when:
- accumulated post-filter results reach the requested \`count\`
- Kiwix returns an empty page (transient hiccup / totalResults drift)
- \`currentStart\` crosses \`totalResults\`

\`currentStart\` advances by the actual returned entry count, not the requested count — so short tail-end pages don't skip entries. Dedupe set keyed on entry \`id\` guards against upstream paging races. The installed-file snapshot (\`this.list()\`) is taken once before the loop rather than per iteration. Pre-existing \`has_more\` off-by-one (comparing totalResults to the INPUT start) is fixed implicitly — new code compares against post-advancement \`currentStart\`.

Response shape adds \`next_start: number\` — the Kiwix offset at which to resume on the next request.

### Types — \`admin/types/zim.ts\`

\`ListRemoteZimFilesResponse\` gains \`next_start: number\`. No other consumers of this type needed updates.

### Frontend — \`admin/inertia/pages/settings/zim/remote-explorer.tsx\`

- \`useInfiniteQuery\` now uses the backend's \`next_start\` cursor as \`pageParam\` instead of computing \`pageParam * 12\` locally. That Kiwix-offset math was always a leaky abstraction; it's outright broken once the backend does multi-page accumulation.
- \`getNextPageParam: (lastPage) => lastPage.has_more ? lastPage.next_start : undefined\`.
- \`fetchOnBottomReached\` drops the \`flatData.length > 0\` guard. The existing on-mount effect (\`useEffect(() => fetchOnBottomReached(...), [fetchOnBottomReached])\`) drives bounded auto-fetch when a short page lands, correctly terminating when \`hasMore\` flips false.

## Test plan (NOMAD3, 192.168.200.183)

- [ ] Before patch: Content Explorer → Browse the Kiwix Library shows \"No records found\" (or reproduce by adding dummy \`.zim\` files to \`/opt/project-nomad/storage/zim\` to saturate the filter).
- [ ] After patch deployed: Browse view loads a scrollable list of non-installed ZIMs on first request.
- [ ] Network tab: initial \`GET /api/zim/list-remote?start=0&count=12\` returns ≥12 items plus \`next_start\`, \`has_more: true\`.
- [ ] Scrolling down sends next request with \`start={next_start from previous response}\` — not \`start=12\` — and continues paginating.
- [ ] Search (\"wikipedia\") still works — targeted path unchanged.
- [ ] Clear search — browse view still loads.
- [ ] With very high installed count, a short page returns \`has_more: true\` and the frontend auto-continues via the on-mount effect until the viewport fills or \`has_more\` flips.
- [ ] Download a ZIM from the list; confirm it's filtered out on the next \`listRemote\` refresh.

## Risks

- **Latency:** up to 5 × ~300ms Kiwix fetches per request in the worst case (~1.5s). Cap is deliberate — subsequent scrolls amortize cost.
- **Pagination contract:** only caller of \`listRemoteZimFiles\` is the Content Explorer page; no other consumers.
- **TanStack v5 cursor:** \`initialPageParam: 0\` + numeric cursor is the documented infinite-query pattern. Query key includes \`query\` so search resets correctly.