### PR TITLE
fix(qdrant): disable anonymous telemetry by default

### DIFF
--- a/admin/database/seeders/service_seeder.ts
+++ b/admin/database/seeders/service_seeder.ts
@@ -57,6 +57,10 @@ export default class ServiceSeeder extends BaseSeeder {
           PortBindings: { '6333/tcp': [{ HostPort: '6333' }], '6334/tcp': [{ HostPort: '6334' }] },
         },
         ExposedPorts: { '6333/tcp': {}, '6334/tcp': {} },
+        // Disable Qdrant's anonymous telemetry to telemetry.qdrant.io. NOMAD is offline-first
+        // and ships with zero telemetry by default — Qdrant's upstream default of enabled
+        // telemetry doesn't match that posture.
+        Env: ['QDRANT__TELEMETRY_DISABLED=true'],
       }),
       ui_location: '6333',
       installed: false,


### PR DESCRIPTION
## Summary

Closes #742 (reported by @BerkDaMerc, who caught Qdrant phoning home to \`telemetry.qdrant.io\` via their pi-hole).

Qdrant ships with anonymous telemetry enabled upstream. NOMAD's marketing and product posture is explicitly \"zero telemetry\" — this fix aligns reality with the posture by setting \`QDRANT__TELEMETRY_DISABLED=true\` on the Qdrant container at seed time.

One-line change to \`admin/database/seeders/service_seeder.ts\`, adding:

\`\`\`ts
Env: ['QDRANT__TELEMETRY_DISABLED=true'],
\`\`\`

to the Qdrant \`container_config\`.

## Caveat for existing installs

Docker bakes \`Env\` into containers at create time, not at image pull time. Existing installs will keep their current telemetry-enabled \`nomad_qdrant\` container until it's recreated. Two ways that happens:

1. User clicks **Force Reinstall** on the Qdrant service via the Knowledge Base panel (preserves the Qdrant data volume, so embeddings stay intact).
2. Natural attrition — next time the container is recreated for any reason.

Worth a note in release notes so privacy-conscious users know to force-reinstall if they want immediate coverage.

## Test plan (NOMAD3)

- [ ] Fresh install: \`docker inspect nomad_qdrant --format '{{.Config.Env}}'\` includes \`QDRANT__TELEMETRY_DISABLED=true\`
- [ ] Monitor pi-hole / DNS queries for \`telemetry.qdrant.io\` during knowledge base embedding run — expect zero outbound DNS to that host
- [ ] Existing install upgraded via sidecar: Qdrant env still lacks the flag until force-reinstall (expected), then has it after
- [ ] Force-reinstall Qdrant via UI: env picked up, Qdrant data volume retained, existing embeddings still queryable