### PR TITLE
fix(qdrant) disable qdrant telemetry on new installs and migration for existing

### DIFF
--- a/admin/database/migrations/1771300000001_disable_qdrant_telemetry.ts
+++ b/admin/database/migrations/1771300000001_disable_qdrant_telemetry.ts
@@ -1,0 +1,41 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'services'
+
+  async up() {
+    this.defer(async (db) => {
+      const row = await db.from(this.tableName).where('service_name', 'nomad_qdrant').first()
+      if (!row) return
+
+      const config = JSON.parse(row.container_config)
+      const env: string[] = config.Env ?? []
+
+      if (!env.includes('QDRANT__TELEMETRY_DISABLED=true')) {
+        config.Env = [...env, 'QDRANT__TELEMETRY_DISABLED=true']
+        await db
+          .from(this.tableName)
+          .where('service_name', 'nomad_qdrant')
+          .update({ container_config: JSON.stringify(config) })
+      }
+    })
+  }
+
+  async down() {
+    this.defer(async (db) => {
+      const row = await db.from(this.tableName).where('service_name', 'nomad_qdrant').first()
+      if (!row) return
+
+      const config = JSON.parse(row.container_config)
+      config.Env = (config.Env ?? []).filter(
+        (e: string) => e !== 'QDRANT__TELEMETRY_DISABLED=true'
+      )
+      if (config.Env.length === 0) delete config.Env
+
+      await db
+        .from(this.tableName)
+        .where('service_name', 'nomad_qdrant')
+        .update({ container_config: JSON.stringify(config) })
+    })
+  }
+}

--- a/admin/database/migrations/1771300000001_disable_qdrant_telemetry.ts
+++ b/admin/database/migrations/1771300000001_disable_qdrant_telemetry.ts
@@ -8,7 +8,8 @@ export default class extends BaseSchema {
       const row = await db.from(this.tableName).where('service_name', 'nomad_qdrant').first()
       if (!row) return
 
-      const config = JSON.parse(row.container_config)
+      const raw = row.container_config
+      const config = typeof raw === 'string' ? JSON.parse(raw) : raw
       const env: string[] = config.Env ?? []
 
       if (!env.includes('QDRANT__TELEMETRY_DISABLED=true')) {
@@ -26,7 +27,8 @@ export default class extends BaseSchema {
       const row = await db.from(this.tableName).where('service_name', 'nomad_qdrant').first()
       if (!row) return
 
-      const config = JSON.parse(row.container_config)
+      const raw = row.container_config
+      const config = typeof raw === 'string' ? JSON.parse(raw) : raw
       config.Env = (config.Env ?? []).filter(
         (e: string) => e !== 'QDRANT__TELEMETRY_DISABLED=true'
       )

--- a/admin/database/seeders/service_seeder.ts
+++ b/admin/database/seeders/service_seeder.ts
@@ -57,6 +57,7 @@ export default class ServiceSeeder extends BaseSeeder {
           PortBindings: { '6333/tcp': [{ HostPort: '6333' }], '6334/tcp': [{ HostPort: '6334' }] },
         },
         ExposedPorts: { '6333/tcp': {}, '6334/tcp': {} },
+        Env: ['QDRANT__TELEMETRY_DISABLED=true'],
       }),
       ui_location: '6333',
       installed: false,

--- a/admin/docs/release-notes.md
+++ b/admin/docs/release-notes.md
@@ -13,6 +13,7 @@
 - **Downloads**: Added improved handling for corrupt ZIM file downloads and removed duplicate Ollama download logs. Thanks @aegisman for the contribution!
 - **Security**: Closed a potential SSRF vulnerability in the map file download functionality by implementing stricter URL validation and blocking private IP ranges. Thanks @LuisMIguelFurlanettoSousa for the fix!
 - **Security**: Sanitized error messages from the backend to prevent potential information disclosure. Thanks @LuisMIguelFurlanettoSousa for the fix!
+- **Privacy**: Qdrant telemetry is now disabled by default, preventing DNS queries to `telemetry.qdrant.io`. Closes #742.
 
 ### Improvements
 - **AI Assistant**: Now uses the currently loaded model for query rewriting and chat title generation for improved performance and consistency. Thanks @hestela for the contribution!


### PR DESCRIPTION
Closes #742

Qdrant sends telemetry data to telemetry.qdrant.io by default, which conflicts with NOMAD's offline-first, privacy-focused mission. This fix sets QDRANT__TELEMETRY_DISABLED=true in the Qdrant container config, preventing any outbound telemetry DNS queries.

Changes:

Updated admin/database/seeders/service_seeder.ts to include the env var for fresh installs
Added migration 1771300000001_disable_qdrant_telemetry to patch existing installs — necessary because the container config is stored in the services DB table at seed time, so existing deployments would not pick up the seeder change alone
Added release note under Unreleased
Testing

Tested on a live NOMAD dev instance (Ubuntu VM, Docker-based deployment):

Built image from branch and deployed via docker compose up -d
Confirmed migration ran successfully on startup via container logs
Verified env var present in Qdrant container: docker inspect nomad_qdrant | grep TELEMETRY returned QDRANT__TELEMETRY_DISABLED=true
Confirmed Qdrant continued to function normally (RAG/knowledge base jobs completed successfully in logs)
Confirmed the normal update path (entrypoint runs migration:run --force on every startup) means existing users will receive this fix automatically on next update — no manual action required
Confirmed in Pihole no more Qdrant logs appeared