### PR TITLE
fix(disk-display): gate NAS Storage label on network filesystem type

### DIFF
--- a/admin/inertia/hooks/useDiskDisplayData.ts
+++ b/admin/inertia/hooks/useDiskDisplayData.ts
@@ -19,9 +19,15 @@ export function getAllDiskDisplayItems(
 ): DiskDisplayItem[] {
   const validDisks = disks?.filter((d) => d.totalSize > 0) || []
 
-  // If /app/storage is on a dedicated filesystem (e.g. NFS), it won't appear
-  // in the block-device list. Prepend it so NAS and OS disk are both shown.
-  const storageMount = fsSize?.find((fs) => fs.mount === '/app/storage' && fs.size > 0)
+  // If /app/storage is backed by a network filesystem (NFS/CIFS), it won't
+  // appear in the block-device list. Prepend it so NAS and OS disk are both
+  // shown. Local-disk-backed /app/storage is already reported in disk[] and
+  // fsSize[], so skip it here to avoid a phantom "NAS Storage" entry.
+  const NETWORK_FS_TYPES = new Set(['nfs', 'nfs4', 'cifs', 'smbfs', 'smb2', 'smb3'])
+  const storageMount = fsSize?.find(
+    (fs) =>
+      fs.mount === '/app/storage' && fs.size > 0 && NETWORK_FS_TYPES.has(fs.type?.toLowerCase())
+  )
   const storageMountItem: DiskDisplayItem[] = storageMount
     ? [
         {


### PR DESCRIPTION
Closes #743

The `/app/storage` entry in `fsSize[]` was always labeled "NAS Storage" regardless of whether it was actually on a network filesystem. On non-NFS installs this caused the local disk to be double-reported (once as "NAS Storage", once as the block device).

Gates the label on the fsSize entry's `type` being one of `nfs`/`nfs4`/`cifs`/`smbfs`/`smb2`/`smb3`. Local-backed `/app/storage` falls through and is only shown as its disk[] entry.

### Tested on
Built `project-nomad:nas-label-fix` from this branch and deployed to a local non-NFS install. "NAS Storage" row no longer appears; only the physical disks are shown.