### PR TITLE
docs: add Community Add-Ons page with field manuals + W3Schools packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Contributions are welcome and appreciated! Please see [CONTRIBUTING.md](CONTRIBU
 - **Benchmark Leaderboard:** [benchmark.projectnomad.us](https://benchmark.projectnomad.us) - See how your hardware stacks up against other NOMAD builds
 - **Troubleshooting Guide:** [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - Find solutions to common issues
 - **FAQ:** [FAQ.md](FAQ.md) - Find answers to frequently asked questions
+- **Community Add-Ons:** [admin/docs/community-add-ons.md](admin/docs/community-add-ons.md) - Third-party content packs built by the community
 
 ## License
 

--- a/admin/app/services/docs_service.ts
+++ b/admin/app/services/docs_service.ts
@@ -12,9 +12,10 @@ export class DocsService {
     'home': 1,
     'getting-started': 2,
     'use-cases': 3,
-    'faq': 4,
-    'about': 5,
-    'release-notes': 6,
+    'community-add-ons': 4,
+    'faq': 5,
+    'about': 6,
+    'release-notes': 7,
   }
 
   async getDocs() {
@@ -91,6 +92,7 @@ export class DocsService {
 
   private static readonly TITLE_OVERRIDES: Record<string, string> = {
     'faq': 'FAQ',
+    'community-add-ons': 'Community Add-Ons',
   }
 
   private prettify(filename: string) {

--- a/admin/docs/community-add-ons.md
+++ b/admin/docs/community-add-ons.md
@@ -1,0 +1,48 @@
+# Community Add-Ons
+
+Project N.O.M.A.D. ships with a curated set of built-in tools and content, but the community has started building add-ons that extend the platform with specialized offline content packs. These are third-party projects, not maintained by the N.O.M.A.D. team. Install them at your own discretion, and please direct any bugs or feature requests to the add-on's own repository.
+
+Have you built a NOMAD add-on? Open an issue on the [Project N.O.M.A.D. GitHub repository](https://github.com/Crosstalk-Solutions/project-nomad/issues/new) or send us a note through the [contact form on projectnomad.us](https://www.projectnomad.us/contact), and we'll review it for inclusion on this page.
+
+---
+
+## ZIM Content Packs
+
+ZIM content packs drop additional offline reference material into your existing Kiwix library. They typically ship with an `install.sh` script that downloads source material, builds a ZIM file with `zimwriterfs`, and registers it with your running Kiwix container.
+
+### U.S. Military Field Manuals
+
+**Repository:** [github.com/jrsphoto/ZIM-military-field-manuals](https://github.com/jrsphoto/ZIM-military-field-manuals)
+
+Roughly 180 public-domain U.S. military field manuals covering field medicine, survival, combat first aid, map reading, and more. Built into a searchable ZIM that drops into your Kiwix library.
+
+Final ZIM size is around 2 GB. The builder downloads about 2 GB of source PDFs from archive.org during the build.
+
+### W3Schools Programming Archive
+
+**Repository:** [github.com/kennethbrewer3/ZIM-w3schools-offline](https://github.com/kennethbrewer3/ZIM-w3schools-offline)
+
+A full offline copy of the W3Schools programming tutorials, covering HTML, CSS, JavaScript, Python, SQL, and more. Good for learning to code, looking up syntax, or teaching programming in an environment without internet.
+
+Final ZIM size is around 700 MB. The builder downloads about 6 GB of source files from a GitHub mirror during the build.
+
+---
+
+## Installing a Community Add-On
+
+Each add-on has its own install instructions, but most ZIM packs follow the same shape:
+
+1. Clone the add-on's repository onto your NOMAD host over SSH.
+2. Check the README for required build dependencies. Most need `git`, `python3`, `unzip`, and `zim-tools`.
+3. Run the included `install.sh` with a `--deploy` flag, pointing it at your Kiwix library path (`/opt/project-nomad/storage/zim`) and your Kiwix container name (`nomad_kiwix_server`).
+4. The script builds the ZIM, copies it into your Kiwix library, registers it with Kiwix, and restarts the Kiwix container.
+
+Once the script finishes, the new content will appear in your Information Library the next time you load it.
+
+Expect the initial build to take anywhere from a few minutes to an hour or more depending on the add-on's size and your host's CPU.
+
+---
+
+## A Note on Support
+
+These add-ons are community-built and community-maintained. If something goes wrong with an install script or the content inside a ZIM, please open an issue on the add-on's own repository rather than Project N.O.M.A.D.'s. We're happy to help if the issue is with NOMAD itself, for example if Kiwix isn't picking up a new ZIM after an install, but we can't maintain or support third-party content.


### PR DESCRIPTION
## Summary
- Adds a dedicated **Community Add-Ons** page to the in-app docs listing third-party ZIM content packs built by the community
- Launches with two current add-ons: [jrsphoto's U.S. military field manuals](https://github.com/jrsphoto/ZIM-military-field-manuals) and [kennethbrewer3's W3Schools archive](https://github.com/kennethbrewer3/ZIM-w3schools-offline)
- Includes a general how-to-install section and a note steering support issues back to each add-on's own repo

## Changes
- **New:** `admin/docs/community-add-ons.md` — the doc itself
- `admin/app/services/docs_service.ts` — adds `community-add-ons` at slot 4 in `DOC_ORDER` (between Use Cases and FAQ) and a `TITLE_OVERRIDES` entry so the hyphen in "Add-Ons" renders correctly
- `README.md` — one new bullet under Community & Resources

## How to submit a new add-on
The page directs submitters to open a GitHub issue or use the projectnomad.us contact form.

## Test plan
- [ ] Start the admin app, confirm the new page appears in the sidebar between **Use Cases** and **FAQ** with the title **Community Add-Ons**
- [ ] Click through to `/docs/community-add-ons` and verify all external links render and point to the right repos
- [ ] Confirm no other doc pages regressed in ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)