### PR TITLE
fix(docker): write /app/version.json from VERSION build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,10 @@ ENV NODE_ENV=production
 WORKDIR /app
 COPY --from=production-deps /app/node_modules /app/node_modules
 COPY --from=build /app/build /app
-# Copy root package.json for version info
-COPY package.json /app/version.json
+# Generate version.json from the VERSION build-arg so the image tag is the
+# single source of truth (previously copied root package.json, which drifted
+# from the tag when semantic-release did not commit the bump back).
+RUN echo "{\"version\":\"${VERSION}\"}" > /app/version.json
 
 # Copy docs and README for access within the container
 COPY admin/docs /app/docs


### PR DESCRIPTION
## Problem

NOMAD3 was upgraded from v1.31.1-rc.1 to v1.31.1-rc.2 today. The container image tag is correct (`ghcr.io/crosstalk-solutions/project-nomad:v1.31.1-rc.2`), but the UI reports version `1.31.0` and keeps showing "update to v1.31.1-rc.2 available."

## Root Cause

`SystemService.getAppVersion()` reads `/app/version.json`, which the Dockerfile populates by copying the **root** `package.json`:

```dockerfile
# Copy root package.json for version info
COPY package.json /app/version.json
```

`semantic-release` (`.releaserc.json`) is configured to bump root `package.json` via `@semantic-release/npm` and commit it back via `@semantic-release/git`. That worked on `main` for v1.31.0 (see commit `37abad3 chore(release): 1.31.0`) but there is no equivalent commit for `v1.31.1-rc.1` or `v1.31.1-rc.2` on `rc`. Result:

```
$ git show v1.31.1-rc.2:package.json | head -3
{
  "name": "project-nomad",
  "version": "1.31.0",   # <-- stale
```

Both RCs were built with a `version.json` still reading `1.31.0`, so every installed instance misreports its version.

## Fix

The build workflow already passes `VERSION` as a build-arg (used today only for the OCI image label). Generate `version.json` from that arg instead:

```dockerfile
RUN echo "{\"version\":\"${VERSION}\"}" > /app/version.json
```

This makes the Docker image tag the single source of truth and eliminates the dependency on the post-release commit-back. Whatever version is typed into the build workflow is what the running instance reports.

## Behavior

- Production builds (`VERSION=1.31.1-rc.2`) -> `/app/version.json` = `{"version":"1.31.1-rc.2"}`
- Local dev builds (no VERSION override) -> `{"version":"dev"}`, which matches the existing `NODE_ENV=development` short-circuit in `getAppVersion()`.
- Root `package.json` still exists and is still bumped by `@semantic-release/npm` -- just no longer consulted by the image. No workflow changes needed.

## Not Addressed Here

The existing `v1.31.1-rc.2` image on ghcr.io is not retroactively fixed -- it would need a rebuild+retag for the current RC to report itself correctly. The next build (rc.3 or stable) will have the right version once this lands.

The underlying semantic-release-on-`rc`-branch issue (why the commit-back isn't happening) is a separate question. This PR makes it a non-issue.

## Files

- `Dockerfile` -- 2-line change