### PR TITLE
feat(collections): add Trades & Vocational and Communications categories + refresh ZIM versions

### DIFF
--- a/admin/inertia/lib/icons.ts
+++ b/admin/inertia/lib/icons.ts
@@ -44,6 +44,7 @@ import {
   IconPlant,
   IconCode,
   IconMap,
+  IconAntenna,
 } from '@tabler/icons-react'
 
 /**
@@ -55,6 +56,7 @@ import {
  */
 export const icons = {
   IconAlertTriangle,
+  IconAntenna,
   IconArrowLeft,
   IconArrowRight,
   IconArrowUp,

--- a/collections/CATEGORIES-TODO.md
+++ b/collections/CATEGORIES-TODO.md
@@ -6,17 +6,15 @@ Potential categories to add to the tiered collections system in `kiwix-categorie
 - [x] Medicine - Medical references, first aid, emergency care
 - [x] Survival & Preparedness - Food prep, prepper videos, repair guides
 - [x] Education & Reference - Wikipedia, textbooks, TED talks
+- [x] DIY & Repair - Home improvement, woodworking, vehicle maintenance, iFixit
+- [x] Agriculture & Food - Gardening, cooking, homesteading, food preservation
+- [x] Computing & Technology - freeCodeCamp, DevDocs, electronics, Raspberry Pi
+- [x] Trades & Vocational - iFixit, mechanics, engineering, workforce textbooks, Gutenberg Technology
+- [x] Communications - Amateur radio, network engineering, S2 Underground, Army field manuals
 
 ---
 
 ## High Priority
-
-### Technology & Programming
-Stack Overflow, developer documentation, coding tutorials
-- Stack Overflow (multiple tags available)
-- DevDocs documentation
-- freeCodeCamp
-- Programming language references
 
 ### Children & Family
 Age-appropriate educational content for kids
@@ -24,22 +22,6 @@ Age-appropriate educational content for kids
 - Wikibooks Children's Bookshelf
 - Khan Academy Kids (via Kolibri - separate system)
 - Storybooks, fairy tales
-
-### Trades & Vocational
-Practical skills for building, fixing, and maintaining
-- Electrical wiring guides
-- Plumbing basics
-- Automotive repair
-- Woodworking
-- Welding fundamentals
-
-### Agriculture & Gardening
-Food production and farming (expand beyond what's in Survival)
-- Practical Plants database
-- Permaculture guides
-- Seed saving
-- Animal husbandry
-- Composting and soil management
 
 ---
 
@@ -65,13 +47,6 @@ Laws, rights, and civic procedures
 - Constitutional documents
 - Civic procedures
 - Rights and responsibilities
-
-### Communications
-Emergency and amateur radio, networking
-- Ham radio guides
-- Emergency communication protocols
-- Basic networking/IT
-- Signal procedures
 
 ---
 
@@ -105,3 +80,5 @@ Content in other languages
 - Check Kiwix catalog for available ZIM files: https://download.kiwix.org/zim/
 - Consider storage constraints - Essential tiers should be <500MB ideally
 - Mark one tier as `recommended: true` (usually Essential)
+- When bumping existing ZIM versions, also bump `spec_version` (used as the cache-invalidation key in `admin/app/services/collection_manifest_service.ts`)
+- Icons must be in the `DynamicIcon` allowlist at `admin/inertia/lib/icons.ts` — add the Tabler icon there before referencing it in a category

--- a/collections/kiwix-categories.json
+++ b/collections/kiwix-categories.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "2026-03-15",
+  "spec_version": "2026-04-21",
   "categories": [
     {
       "name": "Medicine",
@@ -72,11 +72,11 @@
           "resources": [
             {
               "id": "wikipedia_en_medicine_maxi",
-              "version": "2026-01",
+              "version": "2026-04",
               "title": "Wikipedia Medicine",
               "description": "Curated medical articles from Wikipedia with images",
-              "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_medicine_maxi_2026-01.zim",
-              "size_mb": 2000
+              "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_medicine_maxi_2026-04.zim",
+              "size_mb": 2113
             },
             {
               "id": "libretexts.org_en_med",
@@ -302,7 +302,7 @@
               "title": "LibreTexts Engineering",
               "description": "Engineering courses and technical references",
               "url": "https://download.kiwix.org/zim/libretexts/libretexts.org_en_eng_2025-01.zim",
-              "size_mb": 678
+              "size_mb": 647
             },
             {
               "id": "libretexts.org_en_biz",
@@ -335,7 +335,7 @@
               "title": "Woodworking Q&A",
               "description": "Stack Exchange Q&A for carpentry, joinery, and woodcraft",
               "url": "https://download.kiwix.org/zim/stack_exchange/woodworking.stackexchange.com_en_all_2026-02.zim",
-              "size_mb": 99
+              "size_mb": 100
             },
             {
               "id": "mechanics.stackexchange.com_en_all",
@@ -343,7 +343,7 @@
               "title": "Motor Vehicle Maintenance Q&A",
               "description": "Stack Exchange Q&A for car and motorcycle repair",
               "url": "https://download.kiwix.org/zim/stack_exchange/mechanics.stackexchange.com_en_all_2026-02.zim",
-              "size_mb": 321
+              "size_mb": 323
             }
           ]
         },
@@ -375,7 +375,7 @@
               "title": "iFixit Repair Guides",
               "description": "Step-by-step repair guides for electronics, appliances, and vehicles",
               "url": "https://download.kiwix.org/zim/ifixit/ifixit_en_all_2025-12.zim",
-              "size_mb": 3380
+              "size_mb": 3405
             }
           ]
         }
@@ -452,11 +452,11 @@
           "resources": [
             {
               "id": "lrnselfreliance_en_all",
-              "version": "2025-12",
+              "version": "2026-03",
               "title": "Learning Self-Reliance: Homesteading",
               "description": "Beekeeping, animal husbandry, and sustainable living practices",
-              "url": "https://download.kiwix.org/zim/videos/lrnselfreliance_en_all_2025-12.zim",
-              "size_mb": 3970
+              "url": "https://download.kiwix.org/zim/videos/lrnselfreliance_en_all_2026-03.zim",
+              "size_mb": 3790
             },
             {
               "id": "gutenberg_en_lcc-s",
@@ -501,26 +501,26 @@
             },
             {
               "id": "devdocs_en_javascript",
-              "version": "2026-01",
+              "version": "2026-04",
               "title": "JavaScript Documentation",
               "description": "MDN JavaScript reference and guides",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_javascript_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_javascript_2026-04.zim",
               "size_mb": 3
             },
             {
               "id": "devdocs_en_html",
-              "version": "2026-01",
+              "version": "2026-04",
               "title": "HTML Documentation",
               "description": "MDN HTML elements and attributes reference",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_html_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_html_2026-04.zim",
               "size_mb": 2
             },
             {
               "id": "devdocs_en_css",
-              "version": "2026-01",
+              "version": "2026-04",
               "title": "CSS Documentation",
               "description": "MDN CSS properties and selectors reference",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_css_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_css_2026-04.zim",
               "size_mb": 5
             }
           ]
@@ -565,11 +565,11 @@
             },
             {
               "id": "devdocs_en_git",
-              "version": "2026-01",
+              "version": "2026-04",
               "title": "Git Documentation",
               "description": "Git version control reference",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_git_2026-01.zim",
-              "size_mb": 1
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_git_2026-04.zim",
+              "size_mb": 2
             }
           ]
         },
@@ -585,7 +585,7 @@
               "title": "Electronics Q&A",
               "description": "Stack Exchange Q&A for circuit design, components, and electrical engineering",
               "url": "https://download.kiwix.org/zim/stack_exchange/electronics.stackexchange.com_en_all_2026-02.zim",
-              "size_mb": 3800
+              "size_mb": 3989
             },
             {
               "id": "robotics.stackexchange.com_en_all",
@@ -597,19 +597,189 @@
             },
             {
               "id": "devdocs_en_docker",
-              "version": "2026-01",
+              "version": "2026-04",
               "title": "Docker Documentation",
               "description": "Docker container reference and guides",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_docker_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_docker_2026-04.zim",
               "size_mb": 2
             },
             {
               "id": "devdocs_en_bash",
-              "version": "2026-01",
+              "version": "2026-04",
               "title": "Linux Documentation",
               "description": "Linux command reference and system administration",
-              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_bash_2026-01.zim",
+              "url": "https://download.kiwix.org/zim/devdocs/devdocs_en_bash_2026-04.zim",
               "size_mb": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Trades & Vocational",
+      "slug": "trades",
+      "icon": "IconTool",
+      "description": "Practical skills for building, fixing, and maintaining: repair guides, mechanics, woodworking, electronics, and technical manuals.",
+      "language": "en",
+      "tiers": [
+        {
+          "name": "Essential",
+          "slug": "trades-essential",
+          "description": "Hands-on repair and shop fundamentals. Start here.",
+          "recommended": true,
+          "resources": [
+            {
+              "id": "ifixit_en_all",
+              "version": "2025-12",
+              "title": "iFixit",
+              "description": "Community-contributed repair guides for phones, laptops, appliances, vehicles, and more.",
+              "url": "https://download.kiwix.org/zim/ifixit/ifixit_en_all_2025-12.zim",
+              "size_mb": 3405
+            },
+            {
+              "id": "mechanics.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "Motor Vehicle Mechanics Q&A",
+              "description": "Stack Exchange Q&A for car, truck, and small-engine repair and maintenance.",
+              "url": "https://download.kiwix.org/zim/stack_exchange/mechanics.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 323
+            },
+            {
+              "id": "woodworking.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "Woodworking Q&A",
+              "description": "Carpentry, cabinetry, tool selection, and finishing techniques.",
+              "url": "https://download.kiwix.org/zim/stack_exchange/woodworking.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 100
+            },
+            {
+              "id": "engineering.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "Engineering Q&A",
+              "description": "Cross-discipline engineering questions: structural, mechanical, materials, and design.",
+              "url": "https://download.kiwix.org/zim/stack_exchange/engineering.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 242
+            }
+          ]
+        },
+        {
+          "name": "Standard",
+          "slug": "trades-standard",
+          "description": "Electronics, workforce-readiness texts, and networking. Includes everything in Essential.",
+          "includesTier": "trades-essential",
+          "resources": [
+            {
+              "id": "electronics.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "Electronics Q&A",
+              "description": "Circuits, microcontrollers, soldering, and troubleshooting - the DIY electronics reference.",
+              "url": "https://download.kiwix.org/zim/stack_exchange/electronics.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 3989
+            },
+            {
+              "id": "libretexts.org_en_eng",
+              "version": "2025-01",
+              "title": "LibreTexts Engineering",
+              "description": "Open-source engineering textbooks across mechanical, electrical, civil, and chemical disciplines.",
+              "url": "https://download.kiwix.org/zim/libretexts/libretexts.org_en_eng_2025-01.zim",
+              "size_mb": 647
+            },
+            {
+              "id": "libretexts.org_en_workforce",
+              "version": "2026-01",
+              "title": "LibreTexts Workforce",
+              "description": "Vocational and applied-trades textbooks covering construction, HVAC, automotive, and welding fundamentals.",
+              "url": "https://download.kiwix.org/zim/libretexts/libretexts.org_en_workforce_2026-01.zim",
+              "size_mb": 490
+            },
+            {
+              "id": "networkengineering.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "Network Engineering Q&A",
+              "description": "Routing, switching, cabling, and small-network design.",
+              "url": "https://download.kiwix.org/zim/stack_exchange/networkengineering.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 124
+            }
+          ]
+        },
+        {
+          "name": "Comprehensive",
+          "slug": "trades-comprehensive",
+          "description": "Classic technology literature and historical technical manuals. Includes everything in Standard.",
+          "includesTier": "trades-standard",
+          "resources": [
+            {
+              "id": "gutenberg_en_lcc-t",
+              "version": "2026-03",
+              "title": "Project Gutenberg: Technology",
+              "description": "Library of Congress Class T - engineering, manufacturing, photography, mining, and handicrafts.",
+              "url": "https://download.kiwix.org/zim/gutenberg/gutenberg_en_lcc-t_2026-03.zim",
+              "size_mb": 12545
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Communications",
+      "slug": "communications",
+      "icon": "IconAntenna",
+      "description": "Amateur radio, signal operations, and networking references for emergency and off-grid communication.",
+      "language": "en",
+      "tiers": [
+        {
+          "name": "Essential",
+          "slug": "communications-essential",
+          "description": "Amateur radio Q&A for license study and day-to-day operations. Start here.",
+          "recommended": true,
+          "resources": [
+            {
+              "id": "ham.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "Amateur Radio Q&A",
+              "description": "Stack Exchange Q&A covering HF/VHF/UHF operation, antennas, propagation, and licensing.",
+              "url": "https://download.kiwix.org/zim/stack_exchange/ham.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 72
+            }
+          ]
+        },
+        {
+          "name": "Standard",
+          "slug": "communications-standard",
+          "description": "Open-source intelligence video library and networking Q&A. Includes everything in Essential.",
+          "includesTier": "communications-essential",
+          "resources": [
+            {
+              "id": "s2underground_en_all",
+              "version": "2026-04",
+              "title": "S2 Underground",
+              "description": "Open-source intelligence and communications-security video library.",
+              "url": "https://download.kiwix.org/zim/videos/s2underground_en_all_2026-04.zim",
+              "size_mb": 4640
+            },
+            {
+              "id": "networkengineering.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "Network Engineering Q&A",
+              "description": "Small-network design, routing, and cabling for on-site or off-grid networks.",
+              "url": "https://download.kiwix.org/zim/stack_exchange/networkengineering.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 124
+            }
+          ]
+        },
+        {
+          "name": "Comprehensive",
+          "slug": "communications-comprehensive",
+          "description": "U.S. Army signal operations and technical-manual archive. Includes everything in Standard.",
+          "includesTier": "communications-standard",
+          "resources": [
+            {
+              "id": "armypubs_en_all",
+              "version": "2024-12",
+              "title": "U.S. Army Publishing Directorate",
+              "description": "Field manuals including the FM 6 series (signal operations) and broader technical/doctrinal references.",
+              "url": "https://download.kiwix.org/zim/zimit/armypubs_en_all_2024-12.zim",
+              "size_mb": 7851
             }
           ]
         }


### PR DESCRIPTION
Closes #760

## Summary

- Adds two new tiered categories — **Trades & Vocational** and **Communications** — covering the remaining "High Priority" items in `collections/CATEGORIES-TODO.md`.
- Bumps 8 stale ZIM versions in the manifest to the latest releases on `download.kiwix.org` (as of 2026-04-21) and normalizes `size_mb` for 5 resources shared across categories.
- Registers `IconAntenna` in the `DynamicIcon` allowlist so the Communications category icon renders.
- Refreshes `CATEGORIES-TODO.md` to reflect the categories that have already shipped since the last edit (DIY, Agriculture, Computing) alongside the two added here.
- Bumps `spec_version` to `2026-04-21` so existing installs refetch the manifest (see cache-invalidation compare at `admin/app/services/collection_manifest_service.ts:55`).

## Details

### New categories

| Category | Slug | Icon | Tiers |
|---|---|---|---|
| Trades & Vocational | `trades` | `IconTool` | Essential / Standard / Comprehensive |
| Communications | `communications` | `IconAntenna` | Essential / Standard / Comprehensive |

Full tier contents are in the diff. A few resources (`ifixit_en_all`, `mechanics.stackexchange.com_en_all`, `woodworking.stackexchange.com_en_all`, `electronics.stackexchange.com_en_all`, `libretexts.org_en_eng`, `networkengineering.stackexchange.com_en_all`) are referenced from multiple categories; the loader keys on `id` so dedupe is handled downstream.

### ZIM version bumps

Verified each via `curl -I` against `download.kiwix.org`:

- `wikipedia_en_medicine_maxi` 2026-01 → 2026-04 (2000 → 2113 MB)
- `lrnselfreliance_en_all` 2025-12 → 2026-03 (3970 → 3790 MB)
- `devdocs_en_javascript` 2026-01 → 2026-04
- `devdocs_en_html` 2026-01 → 2026-04
- `devdocs_en_css` 2026-01 → 2026-04
- `devdocs_en_git` 2026-01 → 2026-04 (1 → 2 MB)
- `devdocs_en_docker` 2026-01 → 2026-04
- `devdocs_en_bash` 2026-01 → 2026-04

### `size_mb` normalization for shared resources

Corrected to match current `Content-Length` from Kiwix:

- `ifixit_en_all` 3380 → 3405
- `mechanics.stackexchange.com_en_all` 321 → 323
- `woodworking.stackexchange.com_en_all` 99 → 100
- `electronics.stackexchange.com_en_all` 3800 → 3989
- `libretexts.org_en_eng` 678 → 647

## Test plan

- [ ] `POST /api/manifests/refresh` with `zim_categories` returns `changed: true` (spec_version differs)
- [ ] Command Center renders both new category cards with correct icons (Trades uses existing `IconTool`, Communications uses newly-registered `IconAntenna`)
- [ ] Tier modal shows correct resources and rolls `includesTier` through Essential → Standard → Comprehensive
- [ ] Installing the Essential tier of either new category downloads the listed ZIMs and they show up in Content Explorer
- [ ] Existing installs of the bumped resources (e.g. `wikipedia_en_medicine_maxi_2026-01`) show an update prompt rather than duplicate entries
- [ ] JSON validates against `zimCategoriesSpecSchema` in `admin/app/validators/curated_collections.ts`

## Notes

- Did not touch existing resource URLs or tier structure beyond the bumps listed above.
- Spec-version convention followed from commit `4443799` ("fix(Collections): update ZIM files to latest versions").
- Happy to split this into separate `feat` and `chore` PRs if preferred — see linked issue for discussion.