### PR TITLE
fix(rag): pass num_ctx and truncate to Ollama embed call

### DIFF
--- a/admin/app/services/ollama_service.ts
+++ b/admin/app/services/ollama_service.ts
@@ -480,10 +480,21 @@ export class OllamaService {
     }
 
     try {
-      // Prefer Ollama native endpoint (supports batch input natively)
+      // Prefer Ollama native endpoint (supports batch input natively).
+      // Pass num_ctx explicitly so we don't depend on the embedding model's
+      // modelfile defaults. Some installs ship nomic-embed-text:v1.5 with
+      // num_ctx=2048, which our chunker (sized for ~1500 tokens) can exceed
+      // on dense content, causing "input length exceeds context length" errors.
+      // truncate:true is a runtime safety net for any chunk that still overshoots.
+      // 8192 matches nomic-embed-text:v1.5's RoPE-extrapolated max.
       const response = await axios.post(
         `${this.baseUrl}/api/embed`,
-        { model, input },
+        {
+          model,
+          input,
+          truncate: true,
+          options: { num_ctx: 8192 },
+        },
         { timeout: 60000 }
       )
       // Some backends (e.g. LM Studio) return HTTP 200 for unknown endpoints with an incompatible


### PR DESCRIPTION
## Summary

Closes #762. Addresses Bug 1 of #756.

`OllamaService.embed()` was calling `/api/embed` with just `{ model, input }` and no `num_ctx` override. On host Ollama installs where nomic-embed-text:v1.5 ships with `num_ctx=2048` (its training context per the model card), our chunker can produce inputs that exceed that limit on dense content. The native call errors, the catch silently falls back to the OpenAI-compatible endpoint which also errors, and the user sees `BadRequestError: 400 the input length exceeds the context length`.

This patch passes:
- `options.num_ctx: 8192` (nomic-embed-text v1.5's RoPE-extrapolated max) so the embed call doesn't depend on the local modelfile's default
- `truncate: true` so Ollama silently truncates any input that still overshoots, instead of erroring

Same root cause as #369 and #670 (both closed without an actual fix). Reported on #756 by @NC4WD with a clean stack trace and storage layout details that pinpointed the codepath.

## Test plan (NOMAD3, v1.31.1, nomad_ollama container)

Pre-patch baseline: uploaded 3 PDFs and 1 .txt of varying density/size; all succeeded because NOMAD3's modelfile already has `num_ctx=8192` so the bug doesn't trigger here. Confirms the fix won't regress installs that were already working.

Post-patch verification: re-uploaded the same 4 files via `POST /api/rag/upload`; all 4 jobs completed (`active-jobs`, `failed-jobs` both `[]`); nomad_ollama logs show all `/api/embed` calls returning 200; chunks visible in `/api/rag/files`.

| File | Size | Pre-patch result | Post-patch result |
|---|---|---|---|
| Box-Oven-Cooking.pdf | 13 KB | succeeded | succeeded |
| A-Better-Way-to-Gardening.pdf | 630 KB | succeeded | succeeded |
| Survival-and-Austere-Medicine.pdf | 4 MB (192 chunks, 24 batches) | succeeded | succeeded |
| Federalist Papers (Project Gutenberg, dense plain text) | 1.1 MB (~340 chunks) | succeeded | succeeded |

Reproducing the actual failure mode requires an Ollama install where `num_ctx=2048` is enforced. The fix is defensive against that environment without changing behavior on installs that were already working.

## Notes

- No chunker constants changed in this PR. `CHAR_TO_TOKEN_RATIO=2` is still inaccurate (real BPE is ~1.3 chars/token for English) but the runtime `num_ctx=8192` plus `truncate:true` makes that estimation error harmless. A follow-up PR could tighten the chunker for better retrieval quality but is not needed to fix the user-facing bug.
- The OpenAI-compatible fallback path (`/v1/embeddings`) is untouched. It's used for non-Ollama backends (LM Studio etc.) which have their own context handling.