### PR TITLE
Add Caddy authentication configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ By design, Project N.O.M.A.D. is intended to be open and available without hurdl
 For now, we recommend using network-level controls to manage access if you're planning to expose your N.O.M.A.D. instance to other devices on a local network. N.O.M.A.D. is not designed to be exposed directly to the internet, and we strongly advise against doing so unless you really know what you're doing, have taken appropriate security measures, and understand the risks involved.
 
 ### How to configure authentication with Caddy (network level authentication)
-It is possible to use a caddy configuration in order to prevent users from accessing certain pages, apps or ports. Here we will show how to configure the settings menu to require a username and password to access. It is recommended not to expose your system to the internet unless you know what you are doing. Please follow these steps at your own risk.
+It is possible to use a caddy configuration in order to prevent users from accessing certain pages, apps or ports. Here we will show how to configure the settings menu to require a username and password to access. It is recommended not to expose your system to the internet unless you know what you are doing. Please follow these steps at your own risk. These instructions are intended as a helpful example and not a prescription for good network security policy.
 
 First install caddy:
 ```bash
@@ -139,10 +139,17 @@ Example Configuration File:
 
     reverse_proxy localhost:8080
 
-    @protected path /settings/*
+    @protected {
+        path /settings/*
+        path /api/settings/*
+        path /api/system/*
+        path /api/docker/*
+        path /api/jobs/*
+        path /api/services/*
+    }
+
     basicauth @protected {
         <user> <hash>
-
     }
 }
 
@@ -156,7 +163,10 @@ user: This is the username you want to login with
 
 hash: This is the hash of your password generated in the earlier step
 
-Note that this assumes project nomad is hosted on port 8080. Also, port 8080 (or whichever port you have nomad configured to) does not need to be port forwarded. The reverse proxy will automatically forward the connection.
+Notes:
++ This assumes the nomad command center is hosted on port 8080 (default)
++ Port 8080 (or whichever port is configured for the command center) does not need to be port forwarded. The reverse proxy will automatically forward the connection.
++ If you use a real domain (e.g. nomad.example.com), Caddy will automatically provision and renew TLS certificates via Let’s Encrypt.
 
 Once everything has been configured, restart the caddy service to apply changes:
 ```

--- a/README.md
+++ b/README.md
@@ -114,6 +114,55 @@ By design, Project N.O.M.A.D. is intended to be open and available without hurdl
 
 For now, we recommend using network-level controls to manage access if you're planning to expose your N.O.M.A.D. instance to other devices on a local network. N.O.M.A.D. is not designed to be exposed directly to the internet, and we strongly advise against doing so unless you really know what you're doing, have taken appropriate security measures, and understand the risks involved.
 
+### How to configure authentication with Caddy (network level authentication)
+It is possible to use a caddy configuration in order to prevent users from accessing certain pages, apps or ports. Here we will show how to configure the settings menu to require a username and password to access. It is recommended not to expose your system to the internet unless you know what you are doing. Please follow these steps at your own risk.
+
+First install caddy:
+```bash
+sudo apt update
+sudo apt install caddy
+```
+Caddy does not store your password as raw text, you must generate a hash for your password by running the following command:
+```bash
+caddy hash-password
+```
+The program will prompt you to create a password and will output the appropriate hash to put in the caddyfile.
+
+Then create the caddy configuration
+```
+sudo nano /etc/caddy/Caddyfile
+```
+
+Example Configuration File:
+```
+<domain>:<port> {
+
+    reverse_proxy localhost:8080
+
+    @protected path /settings/*
+    basicauth @protected {
+        <user> <hash>
+
+    }
+}
+
+```
+
+domain: This is the domain name of your server if you have one (leave blank or put public ip otherwise).
+
+port: This is the port you plan to port forward for access to nomad. 
+
+user: This is the username you want to login with
+
+hash: This is the hash of your password generated in the earlier step
+
+Note that this assumes project nomad is hosted on port 8080. Also, port 8080 (or whichever port you have nomad configured to) does not need to be port forwarded. The reverse proxy will automatically forward the connection.
+
+Once everything has been configured, restart the caddy service to apply changes:
+```
+sudo systemctl restart caddy
+```
+
 ## Contributing
 Contributions are welcome and appreciated! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to the project.
 


### PR DESCRIPTION
Added instructions for configuring authentication with Caddy, including installation steps and example configuration.

## What this PR does
This PR adds a new section to the README under "About Security" that demonstrates how to configure optional network-level authentication using Caddy.

closes #764

## Why this is useful
NOMAD is intentionally designed without authentication, which works well for local, single-user setups. However, users who expose their instance to a network may want a simple way to restrict access to sensitive routes (such as `/settings/`).

This PR provides:
- A practical, copy-pasteable Caddy setup
- Instructions for generating password hashes
- A minimal reverse proxy configuration
- Guidance on safe port exposure

## Key points
- Does NOT introduce authentication into NOMAD itself
- Does NOT change any existing functionality
- Only adds documentation for optional external configuration

## Example use case
A user hosting NOMAD on a home server can:
- expose a single port via Caddy
- protect admin routes with a username/password
- keep the main interface accessible

## Additional context
This approach keeps NOMAD simple while giving users a clear path to improve security without requiring built-in auth.

## Testing
Tested locally with:
- NOMAD running on port 8080
- Caddy reverse proxy on a separate port
- `/settings/*` correctly prompting for authentication

## Future considerations
If built-in authentication is added later, this section can either:
- remain as an advanced alternative
- or be simplified/removed depending on direction

---

Let me know if you'd like any changes or additional examples included.