### PR TITLE
feat(content-updates): show size, surface downloads in Active Downloads

### DIFF
--- a/admin/app/services/collection_update_service.ts
+++ b/admin/app/services/collection_update_service.ts
@@ -53,8 +53,10 @@ export class CollectionUpdateService {
         `[CollectionUpdateService] Update check complete: ${response.data.length} update(s) available`
       )
 
+      const updates = await this.enrichWithSizes(response.data)
+
       return {
-        updates: response.data,
+        updates,
         checked_at: new Date().toISOString(),
       }
     } catch (error) {
@@ -105,6 +107,8 @@ export class CollectionUpdateService {
         update.resource_type === 'zim' ? ZIM_MIME_TYPES : PMTILES_MIME_TYPES,
       forceNew: true,
       filetype: update.resource_type,
+      title: update.resource_id,
+      totalBytes: update.size_bytes,
       resourceMetadata: {
         resource_id: update.resource_id,
         version: update.latest_version,
@@ -126,19 +130,40 @@ export class CollectionUpdateService {
   async applyAllUpdates(
     updates: ResourceUpdateInfo[]
   ): Promise<{ results: Array<{ resource_id: string; success: boolean; jobId?: string; error?: string }> }> {
-    const results: Array<{
-      resource_id: string
-      success: boolean
-      jobId?: string
-      error?: string
-    }> = []
-
-    for (const update of updates) {
-      const result = await this.applyUpdate(update)
-      results.push({ resource_id: update.resource_id, ...result })
-    }
+    const results = await Promise.all(
+      updates.map(async (update) => {
+        const result = await this.applyUpdate(update)
+        return { resource_id: update.resource_id, ...result }
+      })
+    )
 
     return { results }
+  }
+
+  /**
+   * Fetch Content-Length for each update URL in parallel. HEAD failures are non-fatal —
+   * the update row just renders without a size. Bounded to HEAD_TIMEOUT_MS so a slow
+   * mirror doesn't block the whole check.
+   */
+  private async enrichWithSizes(updates: ResourceUpdateInfo[]): Promise<ResourceUpdateInfo[]> {
+    const HEAD_TIMEOUT_MS = 5000
+
+    return await Promise.all(
+      updates.map(async (update) => {
+        if (update.size_bytes) return update // Trust upstream if it already gave us one
+        try {
+          const head = await axios.head(update.download_url, {
+            timeout: HEAD_TIMEOUT_MS,
+            maxRedirects: 5,
+            validateStatus: (s) => s >= 200 && s < 400,
+          })
+          const len = Number(head.headers['content-length'])
+          return Number.isFinite(len) && len > 0 ? { ...update, size_bytes: len } : update
+        } catch {
+          return update
+        }
+      })
+    )
   }
 
   private buildFilename(update: ResourceUpdateInfo): string {

--- a/admin/app/validators/common.ts
+++ b/admin/app/validators/common.ts
@@ -100,6 +100,7 @@ const resourceUpdateInfoBase = vine.object({
   installed_version: vine.string().trim(),
   latest_version: vine.string().trim().minLength(1),
   download_url: vine.string().url({ require_tld: false }).trim(),
+  size_bytes: vine.number().positive().optional(),
 })
 
 export const applyContentUpdateValidator = vine.compile(resourceUpdateInfoBase)

--- a/admin/inertia/hooks/useDownloads.ts
+++ b/admin/inertia/hooks/useDownloads.ts
@@ -19,8 +19,9 @@ const useDownloads = (props: useDownloadsProps) => {
     queryFn: () => api.listDownloadJobs(props.filetype),
     refetchInterval: (query) => {
       const data = query.state.data
-      // Only poll when there are active downloads; otherwise use a slower interval
-      return data && data.length > 0 ? 2000 : 30000
+      // Idle poll is kept tight so newly-dispatched jobs surface quickly — small ZIM
+      // updates can complete in ~2s, so a 30s idle interval almost always missed them.
+      return data && data.length > 0 ? 2000 : 3000
     },
     enabled: props.enabled ?? true,
   })

--- a/admin/inertia/pages/settings/update.tsx
+++ b/admin/inertia/pages/settings/update.tsx
@@ -12,9 +12,10 @@ import type { ContentUpdateCheckResult, ResourceUpdateInfo } from '../../../type
 import api from '~/lib/api'
 import Input from '~/components/inputs/Input'
 import Switch from '~/components/inputs/Switch'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNotifications } from '~/context/NotificationContext'
 import { useSystemSetting } from '~/hooks/useSystemSetting'
+import { formatBytes } from '~/lib/util'
 
 type Props = {
   updateAvailable: boolean
@@ -25,6 +26,7 @@ type Props = {
 
 function ContentUpdatesSection() {
   const { addNotification } = useNotifications()
+  const queryClient = useQueryClient()
   const [checkResult, setCheckResult] = useState<ContentUpdateCheckResult | null>(null)
   const [isChecking, setIsChecking] = useState(false)
   const [applyingIds, setApplyingIds] = useState<Set<string>>(new Set())
@@ -60,6 +62,9 @@ function ContentUpdatesSection() {
             ? { ...prev, updates: prev.updates.filter((u) => u.resource_id !== update.resource_id) }
             : prev
         )
+        // Force Active Downloads to refetch now — small updates finish before the next
+        // idle poll fires, so without this the user wouldn't see them.
+        queryClient.invalidateQueries({ queryKey: ['download-jobs'] })
       } else {
         addNotification({ type: 'error', message: result?.error || 'Failed to start update' })
       }
@@ -95,6 +100,9 @@ function ContentUpdatesSection() {
             ? { ...prev, updates: prev.updates.filter((u) => !successIds.has(u.resource_id)) }
             : prev
         )
+        if (successIds.size > 0) {
+          queryClient.invalidateQueries({ queryKey: ['download-jobs'] })
+        }
       }
     } catch {
       addNotification({ type: 'error', message: 'Failed to apply updates' })
@@ -179,6 +187,15 @@ function ContentUpdatesSection() {
                         }`}
                     >
                       {record.resource_type === 'zim' ? 'ZIM' : 'Map'}
+                    </span>
+                  ),
+                },
+                {
+                  accessor: 'size_bytes',
+                  title: 'Size',
+                  render: (record) => (
+                    <span className="text-desert-stone-dark">
+                      {record.size_bytes ? formatBytes(record.size_bytes, 1) : '—'}
                     </span>
                   ),
                 },

--- a/admin/types/collections.ts
+++ b/admin/types/collections.ts
@@ -86,6 +86,7 @@ export type ResourceUpdateInfo = {
   installed_version: string
   latest_version: string
   download_url: string
+  size_bytes?: number
 }
 
 export type ContentUpdateCheckResult = {


### PR DESCRIPTION
## Summary

Three compounding UX problems on **Settings → Check for Updates → Content Updates** — all fixed.

### 1. No size column
Users had no idea how large an update was before clicking. Upstream `/api/v1/resources/check-updates` doesn't return size, so `CollectionUpdateService.checkForUpdates()` now enriches each update with a parallel HEAD request for `Content-Length` (5s timeout, non-fatal on failure). A **Size** column renders `formatBytes(size_bytes, 1)` or an em-dash fallback.

### 2. Small updates never appeared in Active Downloads
Verified this live on NOMAD5 by race-polling `/api/downloads/jobs` every 300ms during an 8 MB update: the job was visible for **~2 seconds**, then gone. Meanwhile, `useDownloads` idled at **30 s between polls**, and neither `handleApply` nor `handleApplyAll` invalidated the `download-jobs` query after dispatching. The window of invisibility was basically always.

Fixes:
- `useDownloads.ts`: idle poll dropped from 30 s → 3 s (active poll unchanged at 2 s).
- `update.tsx`: both apply handlers now call `queryClient.invalidateQueries({ queryKey: ['download-jobs'] })` on success, forcing an immediate refetch.

### 3. Update downloads had no title / no byte-count progress
`applyUpdate` wasn't passing `title` or `totalBytes` to `RunDownloadJob.dispatch`, so if an update *did* briefly surface it rendered as just a filename + percentage — no friendly label, no `X KB / Y MB` counter. Now matches `zim_service`'s dispatch pattern.

### Bonus
`applyAllUpdates` now parallelizes via `Promise.all` instead of awaiting each dispatch sequentially — five updates dispatch in parallel instead of five sequential BullMQ round-trips.

## Files changed
- `admin/types/collections.ts` — `ResourceUpdateInfo.size_bytes?: number`
- `admin/app/validators/common.ts` — accept `size_bytes` on apply requests
- `admin/app/services/collection_update_service.ts` — `enrichWithSizes()`, forward title/totalBytes, parallel applyAll
- `admin/inertia/hooks/useDownloads.ts` — 30 s → 3 s idle poll
- `admin/inertia/pages/settings/update.tsx` — invalidate on click, add Size column

## Verification (done on NOMAD5 v1.31.1)

Backend hot-patched in place and verified:

```
POST /api/content-updates/check →
{
  "updates": [
    { "resource_id": "devdocs_en_css",       ..., "size_bytes": 4885308 },
    { "resource_id": "devdocs_en_html",      ..., "size_bytes": 1677062 },
    { "resource_id": "devdocs_en_javascript", ..., "size_bytes": 2695200 }
  ]
}
```

Apply flow carries size through to the download job:

```
POST /api/content-updates/apply-all → 200 OK
GET  /api/downloads/jobs            → [{ ..., title: "devdocs_en_html", totalBytes: 1677062, status: "active" }]
```

TypeScript typecheck passes with zero errors.

## Test plan
- [ ] Fresh `npm run dev` on `dev` + this branch
- [ ] Settings → Check for Updates → Check for Content Updates — Size column renders
- [ ] Click Update All — updates appear in Active Downloads immediately (< 1s)
- [ ] Individual Update button — same thing
- [ ] Simulate slow mirror (block HEAD to `download.kiwix.org`) — updates still list, Size shows em-dash, no user-facing error
- [ ] Old ZIM removed after update completes (existing behavior, regression-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)