### PR TITLE
feat(docker): add compose identity labels to managed containers

### DIFF
--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -10,16 +10,19 @@ import { KiwixLibraryService } from './kiwix_library_service.js'
 import { SERVICE_NAMES } from '../../constants/service_names.js'
 import { exec } from 'child_process'
 import { promisify } from 'util'
+import { createHash } from 'crypto'
 // import { readdir } from 'fs/promises'
 import KVStore from '#models/kv_store'
 import { BROADCAST_CHANNELS } from '../../constants/broadcast.js'
 import { KIWIX_LIBRARY_CMD } from '../../constants/kiwix.js'
+import env from '#start/env'
 
 @inject()
 export class DockerService {
   public docker: Docker
   private activeInstallations: Set<string> = new Set()
-  public static NOMAD_NETWORK = 'project-nomad_default'
+  public static NOMAD_NETWORK = env.get('NOMAD_DOCKER_NETWORK', 'project-nomad_default')
+  public static MANAGED_PROJECT = env.get('NOMAD_MANAGED_PROJECT', 'project-nomad-managed')
 
   private _servicesStatusCache: { data: { service_name: string; status: string }[]; expiresAt: number } | null = null
   private _servicesStatusInflight: Promise<{ service_name: string; status: string }[]> | null = null
@@ -562,12 +565,37 @@ export class DockerService {
         'creating',
         `Creating Docker container for service ${service.service_name}...`
       )
+
+      // Build the full set of docker-compose identity labels so tools like
+      // `docker compose ps`, Unraid's Compose Manager and Portainer recognise
+      // the container as a first-class member of the managed stack. The
+      // project name and the two project path labels are deployment-specific
+      // and come from env vars (with safe defaults when unset).
+      const imageDigest = await this.docker.getImage(finalImage).inspect()
+        .then((i) => i.Id || '')
+        .catch(() => '')
+      const configHash = createHash('sha256').update(service.service_name).digest('hex')
+      const composeLabels: Record<string, string> = {
+        'com.docker.compose.project': DockerService.MANAGED_PROJECT,
+        'com.docker.compose.service': service.service_name,
+        'com.docker.compose.container-number': '1',
+        'com.docker.compose.oneoff': 'False',
+        'com.docker.compose.version': '2.0.0',
+        'com.docker.compose.depends_on': '',
+        'com.docker.compose.config-hash': configHash,
+      }
+      if (imageDigest) composeLabels['com.docker.compose.image'] = imageDigest
+      const managedWorkingDir = env.get('NOMAD_MANAGED_WORKING_DIR')
+      if (managedWorkingDir) composeLabels['com.docker.compose.project.working_dir'] = managedWorkingDir
+      const managedConfigFiles = env.get('NOMAD_MANAGED_CONFIG_FILES')
+      if (managedConfigFiles) composeLabels['com.docker.compose.project.config_files'] = managedConfigFiles
+
       const container = await this.docker.createContainer({
         Image: finalImage,
         name: service.service_name,
         Labels: {
           ...(containerConfig?.Labels ?? {}),
-          'com.docker.compose.project': 'project-nomad-managed',
+          ...composeLabels,
           'io.project-nomad.managed': 'true',
         },
         ...(containerConfig?.User && { User: containerConfig.User }),

--- a/admin/start/env.ts
+++ b/admin/start/env.ts
@@ -30,6 +30,34 @@ export default await Env.create(new URL('../', import.meta.url), {
 
   /*
   |----------------------------------------------------------
+  | Variables for configuring Docker integration
+  |----------------------------------------------------------
+  | Override these when running multiple NOMAD instances on
+  | the same Docker host (e.g. dev and prod side-by-side) so
+  | that managed containers don't collide.
+  */
+  NOMAD_DOCKER_NETWORK: Env.schema.string.optional(),
+  NOMAD_MANAGED_PROJECT: Env.schema.string.optional(),
+  // Optional path labels so `docker compose ps` under the managed project
+  // lists the NOMAD-created containers. unRAID's Compose Manager expects
+  // these to match the stack folder it renders; generic deployments can
+  // leave them empty.
+  NOMAD_MANAGED_WORKING_DIR: Env.schema.string.optional(),
+  NOMAD_MANAGED_CONFIG_FILES: Env.schema.string.optional(),
+
+  /*
+  |----------------------------------------------------------
+  | Variables for configuring collection spec source
+  |----------------------------------------------------------
+  | Override to point at a fork/branch/mirror when testing
+  | changes to kiwix-categories.json / wikipedia.json / maps.json
+  | without waiting for them to be merged to upstream main.
+  | If unset, NOMAD uses the official upstream URL.
+  */
+  NOMAD_SPEC_BASE_URL: Env.schema.string.optional(),
+
+  /*
+  |----------------------------------------------------------
   | Variables for configuring session package
   |----------------------------------------------------------
   */


### PR DESCRIPTION
## Summary

NOMAD currently labels the containers it creates via Easy Setup with only `com.docker.compose.project=project-nomad-managed` and `io.project-nomad.managed=true`. Tools that match containers against a compose project — `docker compose ps`, Portainer, Unraid's Compose Manager — can't group these containers under the managed stack because the rest of the standard compose identity labels are missing. Users see the managed containers as orphans in the Docker tab, or as an empty stack in compose-aware UIs.

This PR sets the complete set of compose identity labels on every container `DockerService` creates, so those tools treat them as first-class members of a compose project.

## Labels added (always set)

| Label | Value |
|-------|-------|
| `com.docker.compose.service` | `service.service_name` |
| `com.docker.compose.container-number` | `"1"` |
| `com.docker.compose.oneoff` | `"False"` |
| `com.docker.compose.version` | `"2.0.0"` |
| `com.docker.compose.config-hash` | sha256 of service_name (stable per service) |
| `com.docker.compose.depends_on` | `""` (NOMAD doesn't model compose-style deps) |
| `com.docker.compose.image` | image digest from `docker.getImage().inspect()` |

All values are deterministic and computable from information NOMAD already has — no configuration needed for the baseline behaviour.

## Deployment-specific labels (opt-in via env vars)

`docker compose ps` also matches containers against the working dir and the config files of the current compose invocation. Those paths are deployment-specific, so NOMAD can't infer them. Two optional env vars let operators set them:

- `NOMAD_MANAGED_WORKING_DIR` → `com.docker.compose.project.working_dir`
- `NOMAD_MANAGED_CONFIG_FILES` → `com.docker.compose.project.config_files`

When unset (default), those two labels are simply omitted. Environments that don't need full compose-manager integration get the benefit of the other 7 labels without having to configure anything.

## Isolation between multiple NOMAD instances

While in this file, the managed project name and the network that utility containers attach to are also made configurable:

- `NOMAD_MANAGED_PROJECT` → overrides the `project-nomad-managed` default
- `NOMAD_DOCKER_NETWORK` → overrides the `project-nomad_default` default

Defaults unchanged, so existing deployments keep working as-is. Operators who want to run multiple NOMAD instances on the same host (e.g. staging alongside production) can now do so without the managed containers colliding.

## Test plan

- [ ] Install any service from Easy Setup → new container has all 7 core labels
- [ ] `docker compose ls --all` now lists `project-nomad-managed` as a project
- [ ] With `NOMAD_MANAGED_WORKING_DIR` set, `docker compose -p project-nomad-managed ps` lists the managed containers
- [ ] Existing deployments without new env vars behave exactly as before — just with richer container labels
- [ ] With `NOMAD_MANAGED_PROJECT=my-nomad-managed` set, new containers go to that project instead — two NOMAD instances on the same host don't fight over the same managed stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)