### PR TITLE
test(security): cover SSRF validator edge cases

### DIFF
--- a/.github/workflows/build-admin-on-pr.yml
+++ b/.github/workflows/build-admin-on-pr.yml
@@ -20,6 +20,10 @@ jobs:
         run: npm ci
         working-directory: ./admin
 
+      - name: Run tests
+        run: npm test
+        working-directory: ./admin
+
       - name: Run build
         run: npm run build
         working-directory: ./admin

--- a/admin/tests/unit/validators/common.spec.ts
+++ b/admin/tests/unit/validators/common.spec.ts
@@ -1,0 +1,30 @@
+import { test } from '@japa/runner'
+
+import { assertNotPrivateUrl } from '#validators/common'
+
+test.group('assertNotPrivateUrl', () => {
+  test('rejects loopback and link-local endpoints', ({ assert }) => {
+    const blocked = [
+      'http://localhost:3000/file.zim',
+      'http://127.0.0.1:8080/file.zim',
+      'http://169.254.169.254/latest/meta-data',
+      'http://[fe80::1]/file.zim',
+    ]
+
+    for (const url of blocked) {
+      assert.throws(() => assertNotPrivateUrl(url), 'Download URL must not point to a loopback or link-local address')
+    }
+  })
+
+  test('allows LAN and public hosts', ({ assert }) => {
+    const allowed = [
+      'http://192.168.1.8:8080/file.zim',
+      'http://my-nas:8080/file.zim',
+      'https://downloads.example.com/archive.zim',
+    ]
+
+    for (const url of allowed) {
+      assert.doesNotThrow(() => assertNotPrivateUrl(url))
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add regression coverage for `assertNotPrivateUrl()` loopback and link-local endpoints
- keep LAN/public hosts allowed to preserve the intended download contract
- run `npm test` in the admin pull-request workflow before `npm run build`

## Testing
- `npm run build` ✅
- `npm test -- --files=tests/unit/validators/common.spec.ts` ⚠️ blocked locally because `@openzim/libzim` native binding is unavailable in this machine environment
