### PR TITLE
Docs/add map marker api

### DIFF
--- a/admin/docs/api-reference.md
+++ b/admin/docs/api-reference.md
@@ -153,8 +153,8 @@ ZIM files provide offline Wikipedia, books, and other content via Kiwix.
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/api/maps/markers` | List map markers |
-| PATCH | `/api/maps/markers/{id}` | Update a  map marker (body: {"name": "Test Marker", "longitude": 0.0, "latitude": 0.0, "color": "yellow", "marker_type": "pin"} ) fields that don't change can be omitted|
 | POST | `/api/maps/markers` | Add map marker (body: {"name": "Test Marker", "longitude": 0.0, "latitude": 0.0, "color": "yellow", "marker_type": "pin"} ) |
+| PATCH | `/api/maps/markers/{id}` | Update a  map marker (body: {"name": "Test Marker", "longitude": 0.0, "latitude": 0.0, "color": "yellow", "marker_type": "pin"} ) fields that don't change can be omitted|
 | DELETE | `/api/maps/markers/{id}` | Delete a map marker | 
 
 ---

--- a/admin/docs/api-reference.md
+++ b/admin/docs/api-reference.md
@@ -148,7 +148,7 @@ ZIM files provide offline Wikipedia, books, and other content via Kiwix.
 | POST | `/api/maps/download-collection` | Download an entire collection by slug (async) |
 | DELETE | `/api/maps/:filename` | Delete a local map file |
 
-### Markers
+### Map Markers
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/admin/docs/api-reference.md
+++ b/admin/docs/api-reference.md
@@ -148,6 +148,15 @@ ZIM files provide offline Wikipedia, books, and other content via Kiwix.
 | POST | `/api/maps/download-collection` | Download an entire collection by slug (async) |
 | DELETE | `/api/maps/:filename` | Delete a local map file |
 
+### Markers
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/maps/markers` | List map markers |
+| PATCH | `/api/maps/markers/{id}` | Update a  map marker (body: {"name": "Test Marker", "longitude": 0.0, "latitude": 0.0, "color": "yellow", "marker_type": "pin"} ) fields that don't change can be omitted|
+| POST | `/api/maps/markers` | Add map marker (body: {"name": "Test Marker", "longitude": 0.0, "latitude": 0.0, "color": "yellow", "marker_type": "pin"} ) |
+| DELETE | `/api/maps/markers/{id}` | Delete a map marker | 
+
 ---
 
 ## Downloads


### PR DESCRIPTION
Updated the admin/docs/api-reference.md file to include the four actions that can be currently done with map markers. 