### PR TITLE
ci: run admin typecheck before build

### DIFF
--- a/.github/workflows/build-admin-on-pr.yml
+++ b/.github/workflows/build-admin-on-pr.yml
@@ -20,6 +20,10 @@ jobs:
         run: npm ci
         working-directory: ./admin
 
+      - name: Run typecheck
+        run: npm run typecheck
+        working-directory: ./admin
+
       - name: Run build
         run: npm run build
         working-directory: ./admin


### PR DESCRIPTION
## Summary
- run the existing admin `typecheck` script in the pull request build workflow
- keep the typecheck after `npm ci` and before `npm run build`, so TypeScript errors fail before the build step

## Tests
- `git diff --check`
- parsed `.github/workflows/build-admin-on-pr.yml` with Python YAML
- attempted `npm ci` in `admin`; blocked locally by macOS Command Line Tools architecture mismatch while building `@openzim/libzim` native bindings (`libxcrun.dylib` x86_64 vs arm64e), before project scripts ran