### PR TITLE
[codex] Handle Docker pull errors from followProgress

### DIFF
--- a/admin/app/services/benchmark_service.ts
+++ b/admin/app/services/benchmark_service.ts
@@ -598,7 +598,12 @@ export class BenchmarkService {
     } catch {
       this._updateStatus('starting', `Pulling sysbench image...`)
       const pullStream = await this.dockerService.docker.pull(SYSBENCH_IMAGE)
-      await new Promise((resolve) => this.dockerService.docker.modem.followProgress(pullStream, resolve))
+      await new Promise<void>((resolve, reject) => {
+        this.dockerService.docker.modem.followProgress(pullStream, (error) => {
+          if (error) reject(error)
+          else resolve()
+        })
+      })
     }
   }
 

--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -485,7 +485,12 @@ export class DockerService {
           'pulling',
           `Pulling Docker image ${service.container_image}...`
         )
-        await new Promise((res) => this.docker.modem.followProgress(pullStream, res))
+        await new Promise<void>((resolve, reject) => {
+          this.docker.modem.followProgress(pullStream, (error) => {
+            if (error) reject(error)
+            else resolve()
+          })
+        })
       }
 
       if (service.service_name === SERVICE_NAMES.KIWIX) {
@@ -1024,7 +1029,12 @@ export class DockerService {
       // Step 1: Pull new image
       this._broadcast(serviceName, 'update-pulling', `Pulling image ${newImage}...`)
       const pullStream = await this.docker.pull(newImage)
-      await new Promise((res) => this.docker.modem.followProgress(pullStream, res))
+      await new Promise<void>((resolve, reject) => {
+        this.docker.modem.followProgress(pullStream, (error) => {
+          if (error) reject(error)
+          else resolve()
+        })
+      })
 
       // Step 2: Find and stop existing container
       this._broadcast(serviceName, 'update-stopping', `Stopping current container...`)


### PR DESCRIPTION
## Summary
- reject Docker image pull promises when dockerode followProgress reports an error
- apply the same handling to service installs, service updates, and sysbench image setup

## Root cause
The existing code passed the Promise resolve function directly to followProgress. dockerode calls that callback as (err, output), so pull failures could resolve the Promise with the error object instead of rejecting.

## Validation
- npm ci
- npm run typecheck
- git diff --check

## Notes
- npm run lint currently fails on pre-existing repo-wide formatting/import issues, including untouched files. A scoped lint run on the touched files also reports existing style issues unrelated to this change.

Fixes #790