### PR TITLE
fix(install): warn loudly on non-x86_64 architectures before pulling images

### DIFF
--- a/install/install_nomad.sh
+++ b/install/install_nomad.sh
@@ -86,6 +86,21 @@ check_is_debian_based() {
     echo -e "${GREEN}#${RESET} This script is running on a Debian-based system.\\n"
 }
 
+check_is_x86_64() {
+  local arch
+  arch="$(uname -m)"
+  if [[ "${arch}" != "x86_64" && "${arch}" != "amd64" ]]; then
+    echo -e "${YELLOW}#${RESET} WARNING: Detected architecture '${arch}'. NOMAD officially supports x86_64 only.\\n"
+    echo -e "${YELLOW}#${RESET} ARM64/aarch64 support is tracked in PR #419 and is not yet ready.\\n"
+    echo -e "${YELLOW}#${RESET} Continuing on an unsupported architecture will likely fail and may leave\\n"
+    echo -e "${YELLOW}#${RESET} partial Docker images and files behind that you'll need to clean up manually.\\n"
+    echo -e "${YELLOW}#${RESET} Continuing in 10 seconds... press Ctrl+C now to abort.\\n"
+    sleep 10
+    return
+  fi
+  echo -e "${GREEN}#${RESET} Architecture check passed (${arch}).\\n"
+}
+
 ensure_dependencies_installed() {
   local missing_deps=()
 
@@ -539,6 +554,7 @@ success_message() {
 
 # Pre-flight checks
 check_is_debian_based
+check_is_x86_64
 check_is_bash
 check_has_sudo
 ensure_dependencies_installed


### PR DESCRIPTION
Reported in #782 by @Dinsmoor on a DGX Spark (ARM64). The install script currently has no architecture precheck, so on ARM64/aarch64 hosts it pulls ~2.7GB of amd64 Docker images that won't run, then fails partway through with a vague "Cannot connect to the Docker daemon" error. The user is left to manually clean up partial images and `/opt/project-nomad/`.

## Approach

Adds `check_is_x86_64()` to the preflight sequence (modeled on the existing `check_is_debian_based()` pattern at line 79). On any architecture other than x86_64/amd64:

- Prints a clear 5-line warning explaining NOMAD officially supports x86_64 only
- Points at PR #419 for the ARM64 tracking work
- Calls out that continuing will likely leave partial files behind
- Sleeps 10 seconds before continuing — Ctrl+C aborts cleanly before any Docker work happens

## Why warn-and-continue instead of hard exit

A hard exit would block the community/hacker path: ARM64 users with QEMU binfmt_misc emulation set up can run amd64 images (slowly), and #487 explicitly framed ARM64 as community-supported for now. The warn-and-countdown approach addresses the real user-facing complaint (silent waste of bandwidth + leftover debris) without locking out adventurous users.

## Test plan

- [x] `bash -n install/install_nomad.sh` (syntax check passes)
- [ ] Manual on x86_64: `Architecture check passed (x86_64)` is printed, install proceeds
- [ ] Manual on aarch64: warning is printed, 10s pause, continues if not aborted

## Notes

This does not address the broader cleanup-on-failure ask from #782 (trapping partial-install state and rolling it back). That's a larger scope and worth its own PR.