### PR TITLE
fix(stream): skip compression for Server-Sent Events

### DIFF
--- a/admin/app/middleware/compression_middleware.ts
+++ b/admin/app/middleware/compression_middleware.ts
@@ -2,8 +2,23 @@ import env from '#start/env'
 import type { HttpContext } from '@adonisjs/core/http'
 import type { NextFn } from '@adonisjs/core/types/http'
 import compression from 'compression'
+import type { IncomingMessage, ServerResponse } from 'node:http'
 
-const compress = env.get('DISABLE_COMPRESSION') ? null : compression()
+// Skip compression for Server-Sent Events. The compression library buffers
+// response writes to determine encoding, which collapses per-token streaming
+// into a single block delivered after generation completes (regression in
+// v1.31.0-rc.2, reported in #781 by @toasterking).
+const compress = env.get('DISABLE_COMPRESSION')
+  ? null
+  : compression({
+      filter: (req: IncomingMessage, res: ServerResponse) => {
+        const contentType = res.getHeader('Content-Type')
+        if (typeof contentType === 'string' && contentType.includes('text/event-stream')) {
+          return false
+        }
+        return compression.filter(req, res)
+      },
+    })
 
 export default class CompressionMiddleware {
   async handle({ request, response }: HttpContext, next: NextFn) {

--- a/admin/app/middleware/compression_middleware.ts
+++ b/admin/app/middleware/compression_middleware.ts
@@ -2,7 +2,6 @@ import env from '#start/env'
 import type { HttpContext } from '@adonisjs/core/http'
 import type { NextFn } from '@adonisjs/core/types/http'
 import compression from 'compression'
-import type { IncomingMessage, ServerResponse } from 'node:http'
 
 // Skip compression for Server-Sent Events. The compression library buffers
 // response writes to determine encoding, which collapses per-token streaming
@@ -11,7 +10,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 const compress = env.get('DISABLE_COMPRESSION')
   ? null
   : compression({
-      filter: (req: IncomingMessage, res: ServerResponse) => {
+      filter: (req: any, res: any) => {
         const contentType = res.getHeader('Content-Type')
         if (typeof contentType === 'string' && contentType.includes('text/event-stream')) {
           return false


### PR DESCRIPTION
Closes #781. Reported and bisected by @toasterking — works in v1.31.0-rc.1, broken from v1.31.0-rc.2 onward.

## Root cause

The global compression middleware (added in v1.31.0-rc.2) wraps `response.write` to determine whether to gzip/brotli the response. The `compression` library's default filter returns `true` for any `text/*` content type, including `text/event-stream`. Once enabled, the middleware buffers writes to fill its compression buffer, which collapses per-token SSE streaming into a single block delivered after generation completes.

Symptom (from #781): AI chat responses no longer appear progressively in the UI; the entire reply lands at once after a long delay. CPU-bound users feel this most.

## Fix

Adds a `filter` to `compression()` that returns `false` when the response `Content-Type` is `text/event-stream`. Other responses fall through to `compression.filter(req, res)` — the library's default — so compressible content types still get compressed.

```ts
filter: (req, res) => {
  const contentType = res.getHeader('Content-Type')
  if (typeof contentType === 'string' && contentType.includes('text/event-stream')) {
    return false
  }
  return compression.filter(req, res)
}
```

The chat controller already sets `Content-Type: text/event-stream` and calls `flushHeaders()` before any write (`ollama_controller.ts:42-45`), so the filter sees the right Content-Type at the time it's consulted (first write).

Currently the only SSE endpoint in the codebase is `/api/ollama/chat`. Future SSE endpoints will benefit automatically as long as they set the right Content-Type before writing.

## Test plan

Verified end-to-end on NOMAD3 v1.31.1 with the patched middleware:

**Before fix:** all 15 SSE chunks for `count from 1 to 30` on `llama3.2:1b` arrive within 10ms of each other after the model completes generation.

**After fix:** tokens stream at ~150ms intervals on `mistral-nemo:12b`, e.g.:
```
1777328424.31 data: {"message":{"content":"In", ...}}
1777328424.53 data: {"message":{"content":" the", ...}}     (+220ms)
1777328424.67 data: {"message":{"content":" heart", ...}}   (+150ms)
1777328424.83 data: {"message":{"content":" of", ...}}      (+160ms)
1777328424.98 data: {"message":{"content":" Paris", ...}}   (+150ms)
```

**Compression still works for non-SSE:** `GET /home --compressed` still returns `Content-Encoding: br` (Brotli), `Vary: Accept-Encoding` set as expected.

- [x] `npx tsc --noEmit` (only pre-existing platform-module missing errors remain — `compression` was already listed before this change)
- [x] Manual repro on NOMAD3 RTX 5060 with `mistral-nemo:12b` and `llama3.2:1b`
- [x] Verified `/home` still returns `Content-Encoding: br`