### PR TITLE
docs: link to new WSL2 install guide from README and FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -20,7 +20,9 @@ Long answer: Custom storage paths, mount points, and external drives (like iSCSI
 
 ## Can I run NOMAD on MAC, WSL2, or a non-Debian-based Distro?
 
-See [Why does NOMAD require a Debian-based OS?](#why-does-nomad-require-a-debian-based-os)
+**WSL2 on Windows** is community-supported via the [WSL2 install guide](https://www.projectnomad.us/install/wsl2) — covers two install paths (native Docker and Docker Desktop) with all known gotchas documented and empirical performance numbers comparing WSL2 to bare-metal.
+
+**macOS and other non-Debian Linux distros** aren't officially supported. See [Why does NOMAD require a Debian-based OS?](#why-does-nomad-require-a-debian-based-os) for details.
 
 ## Why does NOMAD require a Debian-based OS?
 
@@ -28,7 +30,7 @@ Project N.O.M.A.D. is currently designed to run on Debian-based Linux distributi
 
 Support for other operating systems will come in the future, but because our development resources are limited as a free and open-source project, we needed to prioritize our efforts and focus on a narrower set of supported platforms for the initial release. We chose Debian-based Linux as our starting point because it's widely used, easy to spin up, and provides a stable environment for running Docker containers.
 
-Community members have provided guides for running N.O.M.A.D. on other platforms (e.g. WSL2, Mac, etc.) in our Discord community and [Github Discussions](https://github.com/Crosstalk-Solutions/project-nomad/discussions), so if you're interested in running N.O.M.A.D. on a non-Debian-based system, we recommend checking there for any available resources or guides. However, keep in mind that if you choose to run N.O.M.A.D. on a non-Debian-based system, you may encounter issues that we won't be able to provide support for, and you may need to have a higher level of technical expertise to troubleshoot and resolve any problems that arise.
+For Windows users, the [WSL2 install guide](https://www.projectnomad.us/install/wsl2) provides a community-supported path. Community members have also published guides for other platforms (e.g. macOS) in our Discord community and [Github Discussions](https://github.com/Crosstalk-Solutions/project-nomad/discussions), so if you're interested in running N.O.M.A.D. on a non-Debian-based system, we recommend checking there for any available resources or guides. However, keep in mind that if you choose to run N.O.M.A.D. on a non-Debian-based system, you may encounter issues that we won't be able to provide support for, and you may need to have a higher level of technical expertise to troubleshoot and resolve any problems that arise.
 
 ## Can I run NOMAD on a Raspberry Pi or other ARM-based device?
 Project N.O.M.A.D. is currently designed to run on x86-64 architecture, and we have not yet tested or optimized it for ARM-based devices like the Raspberry Pi (and have not published any official images for ARM architecture).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ sudo bash install_nomad.sh
 
 Project N.O.M.A.D. is now installed on your device! Open a browser and navigate to `http://localhost:8080` (or `http://DEVICE_IP:8080`) to start exploring!
 
-For a complete step-by-step walkthrough (including Ubuntu installation), see the [Installation Guide](https://www.projectnomad.us/install).
+For a complete step-by-step walkthrough (including Ubuntu installation), see the [Installation Guide](https://www.projectnomad.us/install). For Windows users, see the [WSL2 install guide](https://www.projectnomad.us/install/wsl2) — community-supported path covering native Docker and Docker Desktop install routes.
 
 ### Advanced Installation
 For more control over the installation process, copy and paste the [Docker Compose template](https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/main/install/management_compose.yaml) into a `docker-compose.yml` file and customize it to your liking (be sure to replace any placeholders with your actual values). Then, run `docker compose up -d` to start the Command Center and its dependencies. Note: this method is recommended for advanced users only, as it requires familiarity with Docker and manual configuration before starting.


### PR DESCRIPTION
## Summary

The `/install/wsl2` community-supported install guide is now live on projectnomad.us. This PR updates the README install section and FAQ to point Windows users at it.

- **README.md**: appends a sentence to the Installation Guide line directing Windows users to `/install/wsl2`.
- **FAQ.md**: replaces the deadend deflection ("WSL2 → see the Debian-only answer") with a real answer for WSL2, while keeping macOS / non-Debian distros pointed at the existing detail. Also updates the "community guides" mention in the Why-Debian section to call out the WSL2 guide directly.

This doesn't change the official-support stance — bare-metal Debian-based Linux remains the supported configuration. The repo docs were just out of sync with the website now that there's a real WSL2 walkthrough.

## Context

The new WSL2 guide on the website covers two install paths (native Docker, Docker Desktop), five WSL2-specific gotchas, vendor GPU matrix, and an empirical perf comparison table. Credit to @nielseni6 (#260) and @charlesmerritt (#572) for the prior community work it builds on.

## Test plan

- [x] README link works: https://www.projectnomad.us/install/wsl2 returns 200
- [x] FAQ links resolve to existing in-page anchor and the new website page
- [x] No copy regressions for users on Debian/Ubuntu — the existing flow text is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)