### PR TITLE
fix(ci): prevent script injection in release workflow via env var indirection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,13 @@ jobs:
         id: finalize-notes
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
+          NEW_RELEASE_VERSION: ${{ steps.semver.outputs.new_release_version }}
         run: |
           git pull origin main
           chmod +x .github/scripts/finalize-release-notes.sh
           EXIT_CODE=0
           .github/scripts/finalize-release-notes.sh \
-            "${{ steps.semver.outputs.new_release_version }}" \
+            "$NEW_RELEASE_VERSION" \
             admin/docs/release-notes.md || EXIT_CODE=$?
           if [[ "$EXIT_CODE" -eq 0 ]]; then
             echo "has_notes=true" >> $GITHUB_OUTPUT
@@ -64,12 +65,14 @@ jobs:
           steps.semver.outputs.new_release_published == 'true' &&
           steps.finalize-notes.outputs.has_notes == 'true' &&
           !contains(steps.semver.outputs.new_release_version, '-')
+        env:
+          NEW_RELEASE_VERSION: ${{ steps.semver.outputs.new_release_version }}
         run: |
           git config user.name "cosmistack-bot"
           git config user.email "dev@cosmistack.com"
           git remote set-url origin https://x-access-token:${{ secrets.COSMISTACKBOT_ACCESS_TOKEN }}@github.com/${{ github.repository }}.git
           git add admin/docs/release-notes.md
-          git commit -m "docs(release): finalize v${{ steps.semver.outputs.new_release_version }} release notes [skip ci]"
+          git commit -m "docs(release): finalize v${NEW_RELEASE_VERSION} release notes [skip ci]"
           git push origin main
 
       - name: Update GitHub release body
@@ -79,8 +82,9 @@ jobs:
           !contains(steps.semver.outputs.new_release_version, '-')
         env:
           GH_TOKEN: ${{ secrets.COSMISTACKBOT_ACCESS_TOKEN }}
+          NEW_RELEASE_VERSION: ${{ steps.semver.outputs.new_release_version }}
         run: |
-          gh release edit "v${{ steps.semver.outputs.new_release_version }}" \
+          gh release edit "v${NEW_RELEASE_VERSION}" \
             --notes-file admin/docs/release-notes.md.section
 
       # Future: Send release notes email


### PR DESCRIPTION
## Summary

Hardens `.github/workflows/release.yml` against GitHub Actions script injection (CWE-77 / CWE-78) by passing `steps.semver.outputs.new_release_version` through step-level `env:` blocks rather than interpolating it directly into `run:` shell scripts.

## Vulnerability

- **File:** `.github/workflows/release.yml`
- **Pattern:** `${{ steps.semver.outputs.new_release_version }}` interpolated directly inside `run:` shell scripts at three sites (the `finalize-notes` step, the release-notes commit step, and the `gh release edit` step).
- **Class:** Command injection via GitHub Actions expression interpolation. GitHub's own Actions hardening guidance flags this exact pattern: any value substituted via `${{ ... }}` into a `run:` block becomes part of the script the runner executes, so a value containing shell metacharacters (e.g. `$(...)`, `` ` ` ``, `;`, newlines) would be evaluated by `bash`.

## Fix

Move the value into a step-scoped `env:` block and reference it as a normal shell variable (`"$NEW_RELEASE_VERSION"` / `"${NEW_RELEASE_VERSION}"`). Once it's a real environment variable, `bash` treats it as data, not code — no expansion or command substitution is performed on its contents. This is the canonical mitigation recommended by GitHub's "Security hardening for GitHub Actions" docs.

The diff is minimal: 8 lines added, 4 lines changed in a single workflow file. No behavior change for legitimate semver inputs.

## Testing

- Verified all three call sites are converted; `grep`'d for any remaining `${{ steps.semver.outputs.new_release_version }}` inside `run:` blocks and confirmed the only remaining occurrence is inside the commented-out `curl` block (left as-is to keep the diff focused; happy to update that too if preferred).
- Confirmed shell quoting around `"$NEW_RELEASE_VERSION"` is preserved everywhere it's used.
- The workflow's existing `if:` guards (e.g. `!contains(steps.semver.outputs.new_release_version, '-')`) and step IDs are unchanged.

## Security analysis

The practical exploit window is narrow: the workflow runs on `workflow_dispatch` only, is gated by `check_authorization` against `DEPLOYMENT_AUTHORIZED_USERS`, and `new_release_version` is produced by semantic-release, which emits strictly semver-formatted strings. So this isn't a "drive-by" injection that any external contributor can trigger.

That said, the fix is still worth landing as defense-in-depth. If the value ever became attacker-influenceable (e.g. a future plugin change, a custom `analyzeCommits`/`generateNotes` config that derives version from commit data, or a bug in semantic-release's sanitization), the consequence is runner code execution with access to `secrets.COSMISTACKBOT_ACCESS_TOKEN` — a token with write access to the repo. That's a meaningful escalation beyond what an authorized release operator would normally have via the UI (they can trigger a release, but they don't get to read the raw token material). The cost of the fix is essentially zero.

### Adversarial review

Before submitting we tried to talk ourselves out of this finding. The strongest counter-arguments are (a) the trigger is gated to an allowlist, and (b) semver constrains the input shape. Neither fully neutralizes it: authorization to trigger the workflow is not the same as authorization to exfiltrate the bot token, and the semver guarantee depends on a third-party action's continued correctness rather than a property enforced at this layer. Given the fix is a two-line-per-site mechanical change with no runtime impact, the risk/reward favors landing it.

## References

- GitHub docs: [Security hardening for GitHub Actions — Using an intermediate environment variable](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable)
- CWE-77: Improper Neutralization of Special Elements used in a Command
- CWE-78: Improper Neutralization of Special Elements used in an OS Command

cc @lewiswigmore
