### PR TITLE
fix(settings/update): four UI/UX fixes for the System Update page

### DIFF
--- a/admin/inertia/pages/settings/update.tsx
+++ b/admin/inertia/pages/settings/update.tsx
@@ -5,7 +5,7 @@ import StyledTable from '~/components/StyledTable'
 import StyledSectionHeader from '~/components/StyledSectionHeader'
 import ActiveDownloads from '~/components/ActiveDownloads'
 import Alert from '~/components/Alert'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { IconAlertCircle, IconArrowBigUpLines, IconCheck, IconCircleCheck, IconReload } from '@tabler/icons-react'
 import { SystemUpdateStatus } from '../../../types/system'
 import type { ContentUpdateCheckResult, ResourceUpdateInfo } from '../../../types/collections'
@@ -23,6 +23,23 @@ type Props = {
   currentVersion: string
   earlyAccess: boolean
 }
+
+const STAGE_LABELS: Record<SystemUpdateStatus['stage'], string> = {
+  idle: 'Preparing Update',
+  starting: 'Starting Update',
+  pulling: 'Pulling Images',
+  pulled: 'Images Pulled',
+  recreating: 'Recreating Containers',
+  complete: 'Update Complete',
+  error: 'Update Failed',
+}
+
+const ADVANCED_STAGES: ReadonlySet<SystemUpdateStatus['stage']> = new Set([
+  'pulling',
+  'pulled',
+  'recreating',
+  'complete',
+])
 
 function ContentUpdatesSection() {
   const { addNotification } = useNotifications()
@@ -251,6 +268,12 @@ export default function SystemUpdatePage(props: { system: Props }) {
   const [email, setEmail] = useState('')
   const [versionInfo, setVersionInfo] = useState<Omit<Props, 'earlyAccess'>>(props.system)
   const [showConnectionLostNotice, setShowConnectionLostNotice] = useState(false)
+  // Tracks whether this update session has progressed past 'idle'/'starting'.
+  // The sidecar sits on 'complete' for ~5s before resetting to 'idle' (see
+  // install/sidecar-updater/update-watcher.sh), and the SPA can miss that
+  // window across the admin container restart. If we resurface to 'idle'
+  // after seeing an advanced stage, treat it as the missed completion.
+  const seenAdvancedStageRef = useRef(false)
 
   const earlyAccessSetting = useSystemSetting({
     key: 'system.earlyAccess', initialData: {
@@ -270,11 +293,22 @@ export default function SystemUpdatePage(props: { system: Props }) {
         }
         setUpdateStatus(response)
 
+        if (ADVANCED_STAGES.has(response.stage)) {
+          seenAdvancedStageRef.current = true
+        }
+
         // If we can connect again, hide the connection lost notice
         setShowConnectionLostNotice(false)
 
-        // Check if update is complete or errored
-        if (response.stage === 'complete') {
+        // Check if update is complete or errored. We also treat a return to
+        // 'idle' as completion if we previously saw an advanced stage — this
+        // catches the race where the sidecar's brief 'complete' window passes
+        // while we're disconnected during the admin container restart.
+        const isComplete =
+          response.stage === 'complete' ||
+          (response.stage === 'idle' && seenAdvancedStageRef.current)
+
+        if (isComplete) {
           // Re-check version so the KV store clears the stale "update available" flag
           // before we reload, otherwise the banner shows "current → current"
           try {
@@ -304,6 +338,7 @@ export default function SystemUpdatePage(props: { system: Props }) {
   const handleStartUpdate = async () => {
     try {
       setError(null)
+      seenAdvancedStageRef.current = false
       setIsUpdating(true)
       const response = await api.startSystemUpdate()
       if (!response || !response.success) {
@@ -368,7 +403,7 @@ export default function SystemUpdatePage(props: { system: Props }) {
     if (updateStatus?.stage === 'error')
       return <IconAlertCircle className="h-12 w-12 text-desert-red" />
     if (isUpdating) return <IconReload className="h-12 w-12 text-desert-green animate-spin" />
-    if (props.system.updateAvailable)
+    if (versionInfo.updateAvailable)
       return <IconArrowBigUpLines className="h-16 w-16 text-desert-green" />
     return <IconCircleCheck className="h-16 w-16 text-desert-olive" />
   }
@@ -380,6 +415,9 @@ export default function SystemUpdatePage(props: { system: Props }) {
     onSuccess: () => {
       addNotification({ message: 'Setting updated successfully.', type: 'success' })
       earlyAccessSetting.refetch()
+      // Toggling Early Access changes which versions are eligible, so re-evaluate
+      // immediately rather than making the user click Check Again.
+      checkVersionMutation.mutate()
     },
     onError: (error) => {
       console.error('Error updating setting:', error)
@@ -461,11 +499,11 @@ export default function SystemUpdatePage(props: { system: Props }) {
               {!isUpdating && (
                 <>
                   <h2 className="text-2xl font-bold text-desert-green mb-2">
-                    {props.system.updateAvailable ? 'Update Available' : 'System Up to Date'}
+                    {versionInfo.updateAvailable ? 'Update Available' : 'System Up to Date'}
                   </h2>
                   <p className="text-desert-stone-dark mb-6">
-                    {props.system.updateAvailable
-                      ? `A new version (${props.system.latestVersion}) is available for your Project N.O.M.A.D. instance.`
+                    {versionInfo.updateAvailable
+                      ? `A new version (${versionInfo.latestVersion}) is available for your Project N.O.M.A.D. instance.`
                       : 'Your system is running the latest version!'}
                   </p>
                 </>
@@ -473,8 +511,8 @@ export default function SystemUpdatePage(props: { system: Props }) {
 
               {isUpdating && updateStatus && (
                 <>
-                  <h2 className="text-2xl font-bold text-desert-green mb-2 capitalize">
-                    {updateStatus.stage === 'idle' ? 'Preparing Update' : updateStatus.stage}
+                  <h2 className="text-2xl font-bold text-desert-green mb-2">
+                    {STAGE_LABELS[updateStatus.stage] ?? updateStatus.stage}
                   </h2>
                   <p className="text-desert-stone-dark mb-6">{updateStatus.message}</p>
                 </>


### PR DESCRIPTION
Closes #826.

Fixes four bugs on `/settings/update` surfaced while QA'ing v1.32.0-rc.1 upgrades on NOMAD1, NOMAD2, NOMAD3 (1.31.1 → 1.32.0-rc.1, all three completed on the backend).

## Summary

| # | Bug | Fix |
|---|---|---|
| 1 | Heading "System Up to Date" + subtext "Your system is running the latest version!" persisted after Check Again surfaced a newer version (alongside the new `Latest Version` row + `Start Update` button) | Heading, subtext, and status icon now read from `versionInfo` state (which `checkVersionMutation` already populates) instead of stale `props.system` |
| 2 | Pulling-state heading rendered the raw lowercase enum (`pulling`, `pulled`, ...) — visually masked by Tailwind `capitalize`, but screen readers and the a11y tree got the untransformed lowercase string | Replaced with a `STAGE_LABELS` map; dropped the `capitalize` class so visual + accessible names match |
| 3 | Update progress UI never recovered when the SPA missed the sidecar's brief `complete` window across the admin container restart. NOMAD3 sat at "0% / spinning" while the upgrade actually finished in ~49s | Added `seenAdvancedStageRef` — once the session observes an advanced stage, a later poll seeing `idle` is treated as the missed completion (reloads as advertised in step 3 of the on-screen process). Reset on each Start Update |
| 4 | Toggling Enable Early Access did not trigger a recheck — user had to know to click Check Again manually | Recheck via `checkVersionMutation` is now chained in the setting's `onSuccess` |

## Why bug 3 happens

The sidecar (`install/sidecar-updater/update-watcher.sh`, line 105 + 144–145) writes `complete` (100%), sleeps 5 seconds, then writes `idle` back. The SPA polls every 2s, but the admin container restart in the middle of the run causes a window of `ERR_CONNECTION_REFUSED` against `/api/system/update/status`. If the SPA's first successful post-restart poll lands after that 5-second window, it sees `idle` and the existing `if (response.stage === 'complete')` branch never fires — the page is stuck on its last observed progress percentage indefinitely.

The fix adds a one-line ref that records whether the current session ever observed an advanced stage (`pulling | pulled | recreating | complete`). On a later `idle` poll while `isUpdating === true`, that's treated as the missed completion. Reset to `false` at the top of each Start Update so failed-then-retried updates don't auto-reload incorrectly.

This change is browser-side only — no sidecar or server changes needed.

## Files

Single file touched: `admin/inertia/pages/settings/update.tsx` (+47/-9).

## Test plan

- [x] `npm run typecheck` (`tsc --noEmit`) clean.
- [ ] In a dev environment, confirm the heading reads "Update Available" after Check Again surfaces a new version.
- [ ] Confirm the pulling/recreating heading reads "Pulling Images" / "Recreating Containers" (no lowercase enum visible to a screen reader).
- [ ] Toggle Enable Early Access ON without Early Access content available → should immediately re-evaluate (no manual Check Again).
- [ ] Run a real upgrade end-to-end and confirm the page reloads after completion (validates bug 3 didn't regress the happy path).
- [ ] Bug 3 is timing-dependent and hard to reproduce on demand; the deterministic reproduction is to rerun NOMAD3-style — sidecar `complete → idle` transition occurring while the SPA is between polls — confirmed in QA notes attached to #826.

## Reviewer notes

Bug 3 is the load-bearing one. Bugs 1, 2, 4 are small copy/UX cleanups bundled into the same PR because they live a few lines apart on the same page; happy to split if you'd prefer.

The ref-based race fix is intentionally narrow: it doesn't change polling cadence, doesn't rework SSE, and doesn't touch the sidecar's `complete → idle` sleep window. If a future PR wants to harden the reconnect path further (e.g., a visible "Reconnecting…" banner during the SSE gap), that's additive and out of scope here.