### PR TITLE
fix(Maps): send filename instead of full path to delete endpoint

### DIFF
--- a/admin/inertia/pages/settings/maps.tsx
+++ b/admin/inertia/pages/settings/maps.tsx
@@ -138,7 +138,7 @@ export default function MapsManager(props: {
 
     try {
       setDeletingFileKey(file.key)
-      await api.deleteMapRegionFile(file.key)
+      await api.deleteMapRegionFile(file.name)
       addNotification({
         type: 'success',
         message: `${file.name} has been deleted.`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-nomad",
-  "version": "1.31.0",
+  "version": "1.32.0-rc.1",
   "description": "\"",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #828.

Delete handler was passing `file.key` (absolute path) instead of `file.name` (basename), so the server couldn't resolve the file and returned 404. One-line swap.