### PR TITLE
fix(Maps): render notes in marker popup when populated

### DIFF
--- a/admin/inertia/components/maps/MapComponent.tsx
+++ b/admin/inertia/components/maps/MapComponent.tsx
@@ -243,6 +243,11 @@ export default function MapComponent({
               closeOnClick={false}
             >
               <div className="text-sm font-medium">{selectedMarker.name}</div>
+              {selectedMarker.notes && selectedMarker.notes.trim() && (
+                <div className="mt-1 text-xs text-desert-stone-dark whitespace-pre-wrap break-words max-w-[240px]">
+                  {selectedMarker.notes}
+                </div>
+              )}
             </Popup>
           )}
 

--- a/admin/inertia/hooks/useMapMarkers.ts
+++ b/admin/inertia/hooks/useMapMarkers.ts
@@ -18,6 +18,7 @@ export interface MapMarker {
   longitude: number
   latitude: number
   color: PinColorId
+  notes: string | null
   createdAt: string
 }
 
@@ -36,6 +37,7 @@ export function useMapMarkers() {
             longitude: m.longitude,
             latitude: m.latitude,
             color: m.color as PinColorId,
+            notes: m.notes ?? null,
             createdAt: m.created_at,
           }))
         )
@@ -54,6 +56,7 @@ export function useMapMarkers() {
           longitude: result.longitude,
           latitude: result.latitude,
           color: result.color as PinColorId,
+          notes: result.notes ?? null,
           createdAt: result.created_at,
         }
         setMarkers((prev) => [...prev, marker])

--- a/admin/inertia/lib/api.ts
+++ b/admin/inertia/lib/api.ts
@@ -631,7 +631,7 @@ class API {
   async listMapMarkers() {
     return catchInternal(async () => {
       const response = await this.client.get<
-        Array<{ id: number; name: string; longitude: number; latitude: number; color: string; created_at: string }>
+        Array<{ id: number; name: string; longitude: number; latitude: number; color: string; notes: string | null; created_at: string }>
       >('/maps/markers')
       return response.data
     })()
@@ -640,7 +640,7 @@ class API {
   async createMapMarker(data: { name: string; longitude: number; latitude: number; color?: string }) {
     return catchInternal(async () => {
       const response = await this.client.post<
-        { id: number; name: string; longitude: number; latitude: number; color: string; created_at: string }
+        { id: number; name: string; longitude: number; latitude: number; color: string; notes: string | null; created_at: string }
       >('/maps/markers', data)
       return response.data
     })()


### PR DESCRIPTION
Closes #796.

## Summary

The maps API has accepted and persisted `notes` on map markers since PR #770, but the marker popup ignored the field. Now it shows a notes block beneath the name when populated, with whitespace preserved (`whitespace-pre-wrap`) and long text wrapped (`break-words`, `max-w-[240px]`).

Threaded the field through the read path:
- `api.listMapMarkers` / `api.createMapMarker` response types in `lib/api.ts`
- `MapMarker` interface in `hooks/useMapMarkers.ts` and the `data.map` projection (plus the `addMarker` echo)
- `selectedMarker` popup in `components/maps/MapComponent.tsx`

## Scope

Matches #796 verbatim ("Add a `notes` block (when non-empty) below the existing fields"). The create/update UI is **unchanged** — users still set notes via API or DB directly. Adding a notes textarea to the create popup or the saved-locations sidebar is a separate UX bite that I'd rather not bundle here.

A marker with `null` / empty / whitespace-only notes renders identically to before (the conditional `selectedMarker.notes && selectedMarker.notes.trim()` short-circuits before the block is rendered).

## Files

- `admin/inertia/lib/api.ts` (+2/-2)
- `admin/inertia/hooks/useMapMarkers.ts` (+3/-0)
- `admin/inertia/components/maps/MapComponent.tsx` (+5/-0)

10 lines added, 2 changed across 3 files.

## Test plan

- [x] `npm run typecheck` (`tsc --noEmit`) clean.
- [x] Tailwind classes used (`text-desert-stone-dark`, `whitespace-pre-wrap`, `break-words`, `max-w-[240px]`) verified to already exist elsewhere in the codebase.
- [x] API path that persists notes already verified in QA — POST/GET round-trip on `/api/maps/markers` with `notes` field is present and working on v1.32.0-rc.1.
- [ ] **Visual confirmation pending** — I didn't spin up a dev server to render the popup. The diff is small and conditional, and the upstream data path is proven, but a reviewer's quick local render is the easiest way to sanity-check spacing and text legibility before merge. Suggested manual repro: `curl -X POST http://<host>:8080/api/maps/markers -H 'Content-Type: application/json' -d '{"name":"Demo","longitude":-122.4,"latitude":37.7,"notes":"Multi-line note\nsecond line."}'` then click the marker on `/maps`.