### PR TITLE
fix(ci): install libzim-dev so native @openzim/libzim build can resolve headers

### DIFF
--- a/.github/workflows/build-admin-on-pr.yml
+++ b/.github/workflows/build-admin-on-pr.yml
@@ -16,6 +16,12 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
+      - name: Install libzim system headers
+        # @openzim/libzim is a native Node module that compiles against the system
+        # libzim C++ library via node-gyp. The ubuntu-latest runner image stopped
+        # shipping libzim-dev preinstalled in early May 2026, breaking npm ci.
+        run: sudo apt-get update && sudo apt-get install -y libzim-dev
+
       - name: Install dependencies
         run: npm ci
         working-directory: ./admin


### PR DESCRIPTION
## Problem

The Build Admin workflow's `npm ci` step started failing on every PR opened since early May 2026 with:

```
fatal error: zim/archive.h: No such file or directory
    4 | #include <zim/archive.h>
```

`@openzim/libzim` is a native Node module that compiles against the system libzim C++ library via node-gyp. Builds were green through 2026-05-04 because the `ubuntu-latest` runner image included `libzim-dev` preinstalled. Sometime between 2026-05-04 and 2026-05-05 the runner image stopped shipping it, and every admin PR opened since has failed at the libzim compile step.

Affected PRs (failures observed today):

- #733 (cuyua9, fix-kiwix-library-xml-self-heal) — failed 2026-05-05 14:16 UTC
- #832 (chriscrosstalk, fix/810-amd-hsa-override) — failed 2026-05-05 16:01 UTC

Both hit the identical `zim/archive.h: No such file or directory` error in the same node-gyp step. Neither PR touches libzim or any native dep — purely a runner environment regression.

## Fix

Add an apt step that installs `libzim-dev` before `npm ci` runs in the Build Admin workflow. Three-line change.

```yaml
- name: Install libzim system headers
  run: sudo apt-get update && sudo apt-get install -y libzim-dev
```

## Test plan

- [ ] CI run on this PR completes successfully (validates the apt step works on whatever the current runner image is)
- [ ] Rebase-and-retry on #733 and #832 to confirm both unblock

🤖 Generated with [Claude Code](https://claude.com/claude-code)