### PR TITLE
fix(docker): reject failed image pulls

### DIFF
--- a/admin/app/services/benchmark_service.ts
+++ b/admin/app/services/benchmark_service.ts
@@ -614,8 +614,7 @@ export class BenchmarkService {
       await this.dockerService.docker.getImage(SYSBENCH_IMAGE).inspect()
     } catch {
       this._updateStatus('starting', `Pulling sysbench image...`)
-      const pullStream = await this.dockerService.docker.pull(SYSBENCH_IMAGE)
-      await new Promise((resolve) => this.dockerService.docker.modem.followProgress(pullStream, resolve))
+      await this.dockerService.pullImage(SYSBENCH_IMAGE)
     }
   }
 

--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -36,6 +36,21 @@ export class DockerService {
     }
   }
 
+  async pullImage(imageName: string): Promise<void> {
+    const pullStream = await this.docker.pull(imageName)
+
+    await new Promise<void>((resolve, reject) => {
+      this.docker.modem.followProgress(pullStream, (error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        resolve()
+      })
+    })
+  }
+
   async affectContainer(
     serviceName: string,
     action: 'start' | 'stop' | 'restart'
@@ -486,13 +501,12 @@ export class DockerService {
         )
       } else {
         // Start pulling the Docker image and wait for it to complete
-        const pullStream = await this.docker.pull(service.container_image)
         this._broadcast(
           service.service_name,
           'pulling',
           `Pulling Docker image ${service.container_image}...`
         )
-        await new Promise((res) => this.docker.modem.followProgress(pullStream, res))
+        await this.pullImage(service.container_image)
       }
 
       if (service.service_name === SERVICE_NAMES.KIWIX) {
@@ -1122,7 +1136,7 @@ export class DockerService {
       const newImage = `${imageBase}:${targetVersion}`
       let runtimeImage = newImage
 
-      // GPU detection runs before the pull so AMD updates pull ollama/ollama:rocm rather
+// GPU detection runs before the pull so AMD updates pull ollama/ollama:rocm rather
       // than the standard tag. Detection result is reused below when building the new
       // container config (devices, env). Non-Ollama services skip this entirely.
       let updatedDeviceRequests: any[] | undefined = undefined
@@ -1171,8 +1185,7 @@ export class DockerService {
 
       // Step 1: Pull new image (runtimeImage diverges from newImage for AMD, see above)
       this._broadcast(serviceName, 'update-pulling', `Pulling image ${runtimeImage}...`)
-      const pullStream = await this.docker.pull(runtimeImage)
-      await new Promise((res) => this.docker.modem.followProgress(pullStream, res))
+      await this.pullImage(runtimeImage)
 
       // Step 2: Find and stop existing container
       this._broadcast(serviceName, 'update-stopping', `Stopping current container...`)


### PR DESCRIPTION
## Summary
- add a shared Docker image pull helper that rejects `followProgress` errors
- use it for service installs, service updates, and sysbench benchmark image pulls

Closes #790

## Testing
- `npm run typecheck` (from `admin/`)
- `git diff --check`
