### PR TITLE
fix(System): correct NVIDIA VRAM in Graphics card (#835)

### DIFF
--- a/admin/app/services/system_service.ts
+++ b/admin/app/services/system_service.ts
@@ -399,9 +399,38 @@ export class SystemService {
           os.kernel = dockerInfo.KernelVersion
         }
 
-        // If si.graphics() returned no controllers (common inside Docker),
-        // fall back to runtime + Ollama log probe to figure out what's accessible.
-        if (!graphics.controllers || graphics.controllers.length === 0) {
+        // si.graphics() in the admin container uses lspci (pciutils ships in
+        // the image for AMD detection). lspci has no real VRAM info for NVIDIA
+        // cards, so systeminformation parses the first PCI memory Region (BAR0,
+        // 16-32 MiB on most NVIDIA cards) as `vram`. nvidia-smi enrichment also
+        // can't run since the binary isn't in the admin image. No real dGPU
+        // has under 256 MiB, so any NVIDIA controller below that needs the
+        // probes below to give us real data.
+        const NVIDIA_BOGUS_VRAM_THRESHOLD_MIB = 256
+        const isBogusNvidiaVram = (c: { vendor?: string; vram?: number | null }) =>
+          /nvidia/i.test(c.vendor || '') &&
+          typeof c.vram === 'number' &&
+          c.vram < NVIDIA_BOGUS_VRAM_THRESHOLD_MIB
+
+        // Clear the bogus value up front. If a probe replaces the entry below
+        // we get the real VRAM; if no probe succeeds (Ollama not installed,
+        // passthrough_failed) the UI falls back to "N/A" instead of showing
+        // "32 MB". The lspci model/vendor strings stay since they're still
+        // useful for identifying the card.
+        const hasLspciBogusNvidiaVram = (graphics.controllers || []).some(isBogusNvidiaVram)
+        if (hasLspciBogusNvidiaVram) {
+          for (const c of graphics.controllers) {
+            if (isBogusNvidiaVram(c)) c.vram = null
+          }
+        }
+
+        // Run the probes when controllers are empty (common inside Docker) or
+        // when lspci gave us bogus NVIDIA BAR0 values that need replacing.
+        if (
+          !graphics.controllers ||
+          graphics.controllers.length === 0 ||
+          hasLspciBogusNvidiaVram
+        ) {
           const runtimes = dockerInfo.Runtimes || {}
           gpuHealth.hasNvidiaRuntime = 'nvidia' in runtimes
 


### PR DESCRIPTION
## What

Fixes #835. NVIDIA VRAM in Settings > System > Graphics regressed to 32 MB across the board in 1.32.0-rc.2 (GTX 1050 Ti, others). Restores correct values.

## Why

#804 added `pciutils` to the admin image so AMD detection could fall back to `lspci`. As a side effect, `si.graphics()` from `systeminformation` now finds NVIDIA cards via lspci inside the container, but reads the first PCI memory Region (BAR0, typically 16-32 MiB on NVIDIA) as VRAM. The `nvidia-smi` enrichment that would normally correct this can't run because the binary isn't shipped in the admin image. End result: every NVIDIA card reports ~32 MB of VRAM, and the lspci-style model name `GP107 [GeForce GTX 1050 Ti]` shows up instead of the friendlier `NVIDIA GeForce GTX 1050 Ti` from `nvidia-smi`.

The Ollama-log and `nvidia-smi`-via-Ollama probes that #804 already added would give the right number, but they only ran when `graphics.controllers` came back empty.

## How

`admin/app/services/system_service.ts`:
1. Detect lspci-bogus NVIDIA entries: vendor matches `/nvidia/i` and `vram < 256` MiB.
2. Null the bogus VRAM up front so the UI shows "N/A" if no probe ends up replacing it.
3. Extend the existing fallback trigger so the probes also run on bogus entries, not just empty `controllers`.

When a probe succeeds, the controller entry is replaced wholesale with real data (model, vendor, vram). When no probe can reach a value (Ollama not installed, passthrough broken), VRAM stays null so the UI renders "N/A" instead of the misleading "32 MB". `gpuHealth` also ends up correctly populated (`hasNvidiaRuntime`, `gpuVendor`, etc.) instead of being skipped via the host-install else-branch.

## Verification

| Scenario | Before | After |
|---|---|---|
| Container with lspci, no nvidia-smi, Ollama running | vram 32, model `AD104 [GeForce RTX 4070 Ti]`, status falsely `ok` | vram 12288, model `NVIDIA GeForce RTX 4070 Ti`, status legitimately `ok`, `hasNvidiaRuntime=true` |
| AMD via DRM sysfs | unchanged | unchanged |
| Host install with nvidia-smi locally | unchanged (probes don't trigger) | unchanged |

Tested three ways:
1. Unit-style script exercising the heuristic against synthetic `controllers` payloads (16/16 cases pass, including boundary at 255/256, mixed AMD+NVIDIA, lowercase vendor strings, empty/undefined controllers, vram=0).
2. Dev server on host with `nvidia-smi` shimmed out of PATH to mimic the container condition. `/api/system/info` returned the bug payload before the patch and the fixed payload after.
3. Built the admin Docker image with the patch and ran it against the local Ollama container. Same fixed payload.

## Notes

- Threshold of 256 MiB chosen because no real dGPU has less than that, and BAR0 sizes top out around 64 MiB on consumer NVIDIA cards. Plenty of headroom on both sides.
- Scoped the detection to NVIDIA only. AMD's correct VRAM comes from `systeminformation`'s `/sys/class/drm/.../mem_info_vram_total` path, so AMD entries don't have the same problem.
- No Dockerfile change. `pciutils` stays in the image since #804's host-install AMD fallback still wants it.