### PR TITLE
fix(map): show marker notes in popup

### DIFF
--- a/admin/inertia/components/maps/MapComponent.tsx
+++ b/admin/inertia/components/maps/MapComponent.tsx
@@ -166,7 +166,14 @@ export default function MapComponent() {
             onClose={() => setSelectedMarkerId(null)}
             closeOnClick={false}
           >
-            <div className="text-sm font-medium">{selectedMarker.name}</div>
+            <div className="space-y-1">
+              <div className="text-sm font-medium">{selectedMarker.name}</div>
+              {selectedMarker.notes && (
+                <div className="max-w-64 whitespace-pre-wrap text-xs text-gray-700">
+                  {selectedMarker.notes}
+                </div>
+              )}
+            </div>
           </Popup>
         )}
 

--- a/admin/inertia/hooks/useMapMarkers.ts
+++ b/admin/inertia/hooks/useMapMarkers.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react'
-import api from '~/lib/api'
+import api from '../lib/api.js'
 
 export const PIN_COLORS = [
   { id: 'orange', label: 'Orange', hex: '#a84a12' },
@@ -18,7 +18,30 @@ export interface MapMarker {
   longitude: number
   latitude: number
   color: PinColorId
+  notes: string | null
   createdAt: string
+}
+
+export interface MapMarkerApiRecord {
+  id: number
+  name: string
+  longitude: number
+  latitude: number
+  color: string
+  notes?: string | null
+  created_at: string
+}
+
+export function normalizeMapMarker(record: MapMarkerApiRecord): MapMarker {
+  return {
+    id: record.id,
+    name: record.name,
+    longitude: record.longitude,
+    latitude: record.latitude,
+    color: record.color as PinColorId,
+    notes: record.notes ?? null,
+    createdAt: record.created_at,
+  }
 }
 
 export function useMapMarkers() {
@@ -27,18 +50,9 @@ export function useMapMarkers() {
 
   // Load markers from API on mount
   useEffect(() => {
-    api.listMapMarkers().then((data) => {
+    api.listMapMarkers().then((data: MapMarkerApiRecord[] | undefined) => {
       if (data) {
-        setMarkers(
-          data.map((m) => ({
-            id: m.id,
-            name: m.name,
-            longitude: m.longitude,
-            latitude: m.latitude,
-            color: m.color as PinColorId,
-            createdAt: m.created_at,
-          }))
-        )
+        setMarkers(data.map(normalizeMapMarker))
       }
       setLoaded(true)
     })
@@ -48,14 +62,7 @@ export function useMapMarkers() {
     async (name: string, longitude: number, latitude: number, color: PinColorId = 'orange') => {
       const result = await api.createMapMarker({ name, longitude, latitude, color })
       if (result) {
-        const marker: MapMarker = {
-          id: result.id,
-          name: result.name,
-          longitude: result.longitude,
-          latitude: result.latitude,
-          color: result.color as PinColorId,
-          createdAt: result.created_at,
-        }
+        const marker = normalizeMapMarker(result)
         setMarkers((prev) => [...prev, marker])
         return marker
       }

--- a/admin/inertia/lib/api.ts
+++ b/admin/inertia/lib/api.ts
@@ -574,7 +574,7 @@ class API {
   async listMapMarkers() {
     return catchInternal(async () => {
       const response = await this.client.get<
-        Array<{ id: number; name: string; longitude: number; latitude: number; color: string; created_at: string }>
+        Array<{ id: number; name: string; longitude: number; latitude: number; color: string; notes: string | null; created_at: string }>
       >('/maps/markers')
       return response.data
     })()
@@ -583,7 +583,7 @@ class API {
   async createMapMarker(data: { name: string; longitude: number; latitude: number; color?: string }) {
     return catchInternal(async () => {
       const response = await this.client.post<
-        { id: number; name: string; longitude: number; latitude: number; color: string; created_at: string }
+        { id: number; name: string; longitude: number; latitude: number; color: string; notes: string | null; created_at: string }
       >('/maps/markers', data)
       return response.data
     })()

--- a/admin/tests/unit/map_markers_normalize.spec.ts
+++ b/admin/tests/unit/map_markers_normalize.spec.ts
@@ -1,0 +1,32 @@
+import { test } from '@japa/runner'
+import { normalizeMapMarker } from '../../inertia/hooks/useMapMarkers.js'
+
+test.group('normalizeMapMarker', () => {
+  test('preserves marker notes from the API payload', ({ assert }) => {
+    const marker = normalizeMapMarker({
+      id: 7,
+      name: 'Library',
+      longitude: -1.23,
+      latitude: 4.56,
+      color: 'orange',
+      notes: 'Bring offline atlas',
+      created_at: '2026-05-08T00:00:00.000Z',
+    })
+
+    assert.equal(marker.notes, 'Bring offline atlas')
+    assert.equal(marker.name, 'Library')
+  })
+
+  test('normalizes missing notes to null', ({ assert }) => {
+    const marker = normalizeMapMarker({
+      id: 8,
+      name: 'Clinic',
+      longitude: 1.23,
+      latitude: -4.56,
+      color: 'blue',
+      created_at: '2026-05-08T00:00:00.000Z',
+    })
+
+    assert.isNull(marker.notes)
+  })
+})


### PR DESCRIPTION
## Summary
- preserve marker `notes` in the front-end map marker state
- render non-empty marker notes in the selected marker popup
- add a small unit test covering marker notes normalization from the API payload

## Testing
- `cd admin && npm run typecheck`

## Issue
- fixes #796
