### PR TITLE
fix(Downloads): treat missing Content-Type as octet-stream (#848)

### DIFF
--- a/admin/app/utils/downloads.ts
+++ b/admin/app/utils/downloads.ts
@@ -47,7 +47,14 @@ export async function doResumableDownload({
     timeout,
   })
 
-  const contentType = headResponse.headers['content-type'] || ''
+  // Some upstream hosts (notably download.kiwix.org for .zim files) don't set a
+  // Content-Type header at all. Per RFC 7231 §3.1.1.5, "if no Content-Type is
+  // provided" the recipient may treat it as application/octet-stream — which is
+  // already in every binary-content allowlist we use (ZIM, PMTILES, base assets).
+  // Without this default, the validator below throws `MIME type  is not allowed`
+  // and breaks all downloads from kiwix's primary host (#848).
+  const contentType =
+    headResponse.headers['content-type'] || 'application/octet-stream'
   const totalBytes = parseInt(headResponse.headers['content-length'] || '0')
   const supportsRangeRequests = headResponse.headers['accept-ranges'] === 'bytes'
 


### PR DESCRIPTION
## What

Fixes #848. ZIM (and any other binary) downloads from upstream hosts that don't set a `Content-Type` header now succeed instead of failing with `MIME type  is not allowed`.

## Why

The validator in `admin/app/utils/downloads.ts` reads `headers['content-type'] || ''`, then runs each entry of `allowedMimeTypes` through `contentType.includes(mt)`. When the header is missing, `''.includes('application/octet-stream')` is `false`, so every allowed type fails to match and the download throws.

`download.kiwix.org` and several of its mirrors don't always set Content-Type on `.zim` responses. With NOMAD pointing at the Kiwix catalog by default, this can break ZIM downloads outright. Choosifur reported the issue with `nomad_admin` logs showing the empty MIME error verbatim.

RFC 7231 §3.1.1.5 says missing Content-Type may be treated as `application/octet-stream`. That MIME is already in every binary-content allowlist we use:

- `ZIM_MIME_TYPES` (collection_update_service.ts:17, zim_service.ts:34, docker_service.ts:746-750)
- `PMTILES_MIME_TYPES` (collection_update_service.ts:18, map_service.ts:67)
- `BASE_ASSETS_MIME_TYPES` (map_service.ts:59)

So defaulting empty to octet-stream keeps existing behavior for every caller while letting Kiwix downloads through.

## How

One-line change to `admin/app/utils/downloads.ts:50` plus a comment. `headers['content-type'] || ''` becomes `headers['content-type'] || 'application/octet-stream'`.

## Verification

Logic-checked against 9 cases including:
- Mirror sets `application/octet-stream` (passes, unchanged)
- Mirror omits Content-Type entirely (now passes, was the bug)
- Empty Content-Type string (now passes)
- Wrong content type like `text/html` for PMTILES (still rejected)
- Strict allowlist without octet-stream + missing Content-Type (still rejects, no over-relaxation)
- Content-Type with charset suffix (passes, existing behavior)

Also confirmed against live Kiwix mirrors via `curl -sIL` — most set `application/octet-stream` correctly, but the redirect-by-geo logic on `download.kiwix.org` can land users on mirrors with inconsistent header behavior.

## Notes

- No new permissive matching beyond what the existing `contentType.includes(mimeType)` substring check already does.
- Doesn't change the error format or any other validator behavior — same `MIME type X is not allowed` shape, just less likely to fire spuriously.
- Independent of the upcoming custom-mirror feature (#593) — that gives users a workaround by picking a mirror that sets headers, this fixes the underlying validator so any well-formed response works.