### PR TITLE
fix(kiwix): lazy-load native libzim bindings

### DIFF
--- a/admin/app/services/kiwix_library_service.ts
+++ b/admin/app/services/kiwix_library_service.ts
@@ -1,13 +1,18 @@
 import { XMLBuilder, XMLParser } from 'fast-xml-parser'
 import { readFile, writeFile, rename, readdir } from 'fs/promises'
 import { join } from 'path'
-import { Archive } from '@openzim/libzim'
+import type { Archive as ZimArchive } from '@openzim/libzim'
 import { KIWIX_LIBRARY_XML_PATH, ZIM_STORAGE_PATH, ensureDirectoryExists, isValidZimFile } from '../utils/fs.js'
 import logger from '@adonisjs/core/services/logger'
 import { randomUUID } from 'node:crypto'
 
 const CONTAINER_DATA_PATH = '/data'
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8"?>\n'
+
+async function loadArchiveClass(): Promise<typeof import('@openzim/libzim').Archive> {
+  const { Archive } = await import('@openzim/libzim')
+  return Archive
+}
 
 interface KiwixBook {
   id: string
@@ -60,7 +65,8 @@ export class KiwixLibraryService {
         logger.warn(`[KiwixLibraryService] Skipping invalid/corrupted ZIM file: ${zimFilePath}`)
         return null
       }
-      const archive = new Archive(zimFilePath)
+      const Archive = await loadArchiveClass()
+      const archive: ZimArchive = new Archive(zimFilePath)
 
       const getMeta = (key: string): string | undefined => {
         try {

--- a/admin/app/services/zim_extraction_service.ts
+++ b/admin/app/services/zim_extraction_service.ts
@@ -1,4 +1,4 @@
-import { Archive, Entry } from '@openzim/libzim'
+import type { Archive as ZimArchive, Entry } from '@openzim/libzim'
 import * as cheerio from 'cheerio'
 import { HTML_SELECTORS_TO_REMOVE, NON_CONTENT_HEADING_PATTERNS } from '../../constants/zim_extraction.js'
 import logger from '@adonisjs/core/services/logger'
@@ -7,9 +7,14 @@ import { randomUUID } from 'node:crypto'
 import { access } from 'node:fs/promises'
 import { isValidZimFile } from '../utils/fs.js'
 
+async function loadArchiveClass(): Promise<typeof import('@openzim/libzim').Archive> {
+    const { Archive } = await import('@openzim/libzim')
+    return Archive
+}
+
 export class ZIMExtractionService {
 
-    private extractArchiveMetadata(archive: Archive): ZIMArchiveMetadata {
+    private extractArchiveMetadata(archive: ZimArchive): ZIMArchiveMetadata {
         try {
             return {
                 title: archive.getMetadata('Title') || archive.getMetadata('Name') || 'Unknown',
@@ -59,7 +64,8 @@ export class ZIMExtractionService {
                 throw new Error(`ZIM file is invalid or corrupted: ${filePath}`)
             }
 
-            const archive = new Archive(filePath)
+            const Archive = await loadArchiveClass()
+            const archive: ZimArchive = new Archive(filePath)
 
             // Extract archive-level metadata once
             const archiveMetadata = this.extractArchiveMetadata(archive)


### PR DESCRIPTION
## Summary
- keep `@openzim/libzim` as a type-only import during module loading
- dynamically import `Archive` only inside the ZIM-specific code paths that open an archive
- apply the same lazy-loading behavior to library rebuild metadata reads and ZIM extraction

## Why
`@openzim/libzim` is a native binding. If the binding has not been built for the local platform yet, importing the package fails immediately. The Kiwix services only need that native binding when they actually open a ZIM file, so app boot/build/test paths that merely import the services should not fail before any ZIM operation runs.

This keeps the existing behavior for valid ZIM processing while avoiding an eager native-addon requirement for unrelated app paths.

## Tests
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm run typecheck`
- `npm run build`
