### PR TITLE
fix: self-heal Kiwix library before start

### DIFF
--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -77,6 +77,7 @@ export class DockerService {
             this.invalidateServicesStatusCache()
             return { success: true, message: 'Kiwix migrated to library mode successfully.' }
           }
+          await new KiwixLibraryService().ensureReadableLibraryFile()
         }
 
         await dockerContainer.restart()
@@ -94,6 +95,10 @@ export class DockerService {
             success: true,
             message: `Service ${serviceName} is already running`,
           }
+        }
+
+        if (serviceName === SERVICE_NAMES.KIWIX) {
+          await new KiwixLibraryService().ensureReadableLibraryFile()
         }
 
         await dockerContainer.start()

--- a/admin/app/services/kiwix_library_service.ts
+++ b/admin/app/services/kiwix_library_service.ts
@@ -1,8 +1,13 @@
-import { XMLBuilder, XMLParser } from 'fast-xml-parser'
+import { XMLBuilder, XMLParser, XMLValidator } from 'fast-xml-parser'
 import { readFile, writeFile, rename, readdir } from 'fs/promises'
 import { join } from 'path'
 import { Archive } from '@openzim/libzim'
-import { KIWIX_LIBRARY_XML_PATH, ZIM_STORAGE_PATH, ensureDirectoryExists, isValidZimFile } from '../utils/fs.js'
+import {
+  KIWIX_LIBRARY_XML_PATH,
+  ZIM_STORAGE_PATH,
+  ensureDirectoryExists,
+  isValidZimFile,
+} from '../utils/fs.js'
 import logger from '@adonisjs/core/services/logger'
 import { randomUUID } from 'node:crypto'
 
@@ -185,6 +190,38 @@ export class KiwixLibraryService {
         size: b['@_size'] !== undefined ? Number(b['@_size']) : undefined,
       }))
       .filter((b) => b.id && b.path)
+  }
+
+  async ensureReadableLibraryFile(): Promise<boolean> {
+    const filePath = this.getLibraryFilePath()
+
+    try {
+      const content = await readFile(filePath, 'utf-8')
+      if (!content.trim()) {
+        logger.warn('[KiwixLibraryService] Library XML is empty; rebuilding from disk.')
+        await this.rebuildFromDisk()
+        return true
+      }
+
+      const validationResult = XMLValidator.validate(content)
+      if (validationResult !== true) {
+        logger.warn('[KiwixLibraryService] Library XML is invalid; rebuilding from disk.')
+        await this.rebuildFromDisk()
+        return true
+      }
+
+      this._parseExistingBooks(content)
+      return false
+    } catch (err: any) {
+      if (err.code === 'ENOENT') {
+        logger.warn('[KiwixLibraryService] Library XML is missing; rebuilding from disk.')
+        await this.rebuildFromDisk()
+        return true
+      }
+      logger.warn('[KiwixLibraryService] Could not read library XML; rebuilding from disk.')
+      await this.rebuildFromDisk()
+      return true
+    }
   }
 
   async rebuildFromDisk(opts?: { excludeFilenames?: string[] }): Promise<void> {

--- a/admin/tests/unit/kiwix_library_service.spec.ts
+++ b/admin/tests/unit/kiwix_library_service.spec.ts
@@ -1,0 +1,57 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from '@japa/runner'
+
+import { KiwixLibraryService } from '../../app/services/kiwix_library_service.js'
+
+async function withTempCwd(callback: (dir: string) => Promise<void>) {
+  const originalCwd = process.cwd()
+  const dir = await mkdtemp(join(tmpdir(), 'kiwix-library-'))
+
+  try {
+    process.chdir(dir)
+    await callback(dir)
+  } finally {
+    process.chdir(originalCwd)
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+test.group('KiwixLibraryService.ensureReadableLibraryFile', () => {
+  test('rebuilds the library XML when the file is missing', async ({ assert }) => {
+    await withTempCwd(async () => {
+      const service = new KiwixLibraryService()
+
+      assert.isTrue(await service.ensureReadableLibraryFile())
+
+      const xml = await readFile(service.getLibraryFilePath(), 'utf-8')
+      assert.include(xml, '<library version="20110515">')
+    })
+  })
+
+  test('rebuilds the library XML when the file is invalid', async ({ assert }) => {
+    await withTempCwd(async (dir) => {
+      const service = new KiwixLibraryService()
+      await mkdir(join(dir, 'storage/zim'), { recursive: true })
+      await writeFile(service.getLibraryFilePath(), '<library><book></library>', 'utf-8')
+
+      assert.isTrue(await service.ensureReadableLibraryFile())
+
+      const xml = await readFile(service.getLibraryFilePath(), 'utf-8')
+      assert.include(xml, '<library version="20110515">')
+    })
+  })
+
+  test('leaves a readable library XML untouched', async ({ assert }) => {
+    await withTempCwd(async (dir) => {
+      const service = new KiwixLibraryService()
+      const xml = '<?xml version="1.0" encoding="UTF-8"?>\n<library version="20110515"></library>'
+      await mkdir(join(dir, 'storage/zim'), { recursive: true })
+      await writeFile(service.getLibraryFilePath(), xml, 'utf-8')
+
+      assert.isFalse(await service.ensureReadableLibraryFile())
+      assert.equal(await readFile(service.getLibraryFilePath(), 'utf-8'), xml)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- add a Kiwix library XML readability guard that rebuilds `kiwix-library.xml` from the current ZIM directory when the file is missing, empty, or invalid XML
- run the guard before starting or restarting the Kiwix container, after the existing legacy glob-mode migration check
- add focused unit coverage for missing, invalid, and already-readable library XML states

## Why

Kiwix library mode depends on `/data/kiwix-library.xml`. If that file is removed, truncated, or left malformed, a normal start/restart can keep `kiwix-serve` in a crash loop even when the ZIM files are still present. This makes the library-mode path self-heal before handing control to Docker.

Related historical failure mode: #710.

## Validation

- `npm run typecheck`
- `git diff --check`

I also attempted the focused unit test command locally:

- `APP_KEY=some_random_key HOST=localhost URL=http://localhost:8080 LOG_LEVEL=info DB_HOST=localhost DB_PORT=3306 DB_USER=root DB_DATABASE=nomad REDIS_HOST=localhost REDIS_PORT=6379 npm test -- --files tests/unit/kiwix_library_service.spec.ts`

That local run is blocked in this macOS environment because `@openzim/libzim` cannot rebuild: `xcrun` is loading an incompatible-architecture Command Line Tools `libxcrun.dylib`. The TypeScript compile still passes.
