### PR TITLE
fix(AI): preserve semver tag in DB on AMD Ollama updates

### DIFF
--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -1103,13 +1103,17 @@ export class DockerService {
 
       this.activeInstallations.add(serviceName)
 
-      // Compute new image string. AMD-on-Ollama overrides this to the rolling :rocm tag
-      // (set during GPU detection below) since per-version ROCm tags aren't always published.
+      // newImage = the semver tag we record in the DB after the update (e.g. ollama/ollama:0.23.2).
+      // runtimeImage = the tag we actually pull and run. For AMD-on-Ollama these diverge: we run
+      // the rolling :rocm tag because per-version ROCm tags aren't always published, but the DB
+      // must keep the semver tag so the Apps page shows the actual version (not literally "rocm")
+      // and the registry update-check parses a valid tag (instead of looping on the same update).
       const currentImage = service.container_image
       const imageBase = currentImage.includes(':')
         ? currentImage.substring(0, currentImage.lastIndexOf(':'))
         : currentImage
-      let newImage = `${imageBase}:${targetVersion}`
+      const newImage = `${imageBase}:${targetVersion}`
+      let runtimeImage = newImage
 
       // GPU detection runs before the pull so AMD updates pull ollama/ollama:rocm rather
       // than the standard tag. Detection result is reused below when building the new
@@ -1137,7 +1141,7 @@ export class DockerService {
               'update-gpu-config',
               `AMD GPU detected. Using ROCm image with /dev/kfd and /dev/dri passthrough...`
             )
-            newImage = 'ollama/ollama:rocm'
+            runtimeImage = 'ollama/ollama:rocm'
             updatedAmdDevices = await this._discoverAMDDevices()
             updatedAmdGpuConfigured = true
           } else {
@@ -1158,9 +1162,9 @@ export class DockerService {
         }
       }
 
-      // Step 1: Pull new image
-      this._broadcast(serviceName, 'update-pulling', `Pulling image ${newImage}...`)
-      const pullStream = await this.docker.pull(newImage)
+      // Step 1: Pull new image (runtimeImage diverges from newImage for AMD, see above)
+      this._broadcast(serviceName, 'update-pulling', `Pulling image ${runtimeImage}...`)
+      const pullStream = await this.docker.pull(runtimeImage)
       await new Promise((res) => this.docker.modem.followProgress(pullStream, res))
 
       // Step 2: Find and stop existing container
@@ -1205,7 +1209,7 @@ export class DockerService {
       }
 
       const newContainerConfig: any = {
-        Image: newImage,
+        Image: runtimeImage,
         name: serviceName,
         Env: finalEnv.length > 0 ? finalEnv : undefined,
         Cmd: inspectData.Config?.Cmd || undefined,


### PR DESCRIPTION
## What

Closes #855. AMD users on rc.2 who click Update on AI Assistant land in a state where:
- Apps page shows their AI Assistant version as the literal string `"rocm"`.
- The update-check loop reports the same update available forever.

## Why

PR #804's AMD branch in `updateContainer()` overrode `newImage = 'ollama/ollama:rocm'` and then persisted that string to `service.container_image` (line 1273). Two downstream effects:

1. `apps.tsx:173` extracts the displayed version from `container_image` via `extractTag()`. The tag was literally `rocm`.
2. `ContainerRegistryService.getAvailableUpdates()` parsed `currentTag = "rocm"`, which isn't semver, so `parseMajorVersion()` returned NaN. The filter no longer rejected newer tags by major-version, and `isNewerVersion()` treated every future Ollama tag as newer. Result: the same update reappeared on every check, forever.

## How

Separate "what we run" from "what we persist":

- `runtimeImage` holds the tag passed to `docker.pull()` and `createContainer()` (still `:rocm` for AMD with acceleration on).
- `newImage` keeps the semver tag (`ollama/ollama:<targetVersion>`) and is the value written to the DB at line 1273.

Surgical: 1 declaration added, 3 references renamed. The install path (`_createContainer`) already had the right shape (runtime-only override at line 539, no DB write of the override), so only `updateContainer` needed the change.

## Test plan

- [x] `npm run typecheck` passes locally.
- [ ] Manual repro on NOMAD2 (AMD HX 370 / 890M, rc.2):
  - Before fix: DB shows `container_image = ollama/ollama:rocm` after triggering an Ollama update via Settings → Apps. Apps page shows version "rocm". `POST /api/system/services/check-updates` immediately re-reports the same update available.
  - After fix: DB shows `container_image = ollama/ollama:<targetVersion>`. Apps page shows the semver. Check-updates does not re-report the same update.
- [ ] `nomad_ollama` container itself still runs the `:rocm` image (verified via `docker inspect`).

## Related

- The "update never finishes" UI symptom in #855 is a separate Apps-page progress-display bug (same kind as #826 / PR #827 but on `apps.tsx` instead of `update.tsx`). The container update actually succeeds. Filed as a follow-up out of scope here.
- #856 (content updates stuck on same user's box) is likely a cascade either from this bug's reboot loop or from #848 (kiwix MIME). Worth asking the reporter to retest after rc.3.