### PR TITLE
fix(AI): rewrite RAG query on first chat follow-up (#regression)

### DIFF
--- a/admin/app/controllers/ollama_controller.ts
+++ b/admin/app/controllers/ollama_controller.ts
@@ -383,10 +383,15 @@ export default class OllamaController {
       // Get recent conversation history (last 6 messages for 3 turns)
       const recentMessages = messages.slice(-6)
 
-      // Skip rewriting for short conversations. Rewriting adds latency with
-      // little RAG benefit until there is enough context to matter.
+      // Skip rewriting on the very first turn — with only one user message
+      // there is no prior context to fold in, so the rewrite would just echo
+      // the message back at the cost of an extra LLM round-trip. From the
+      // first follow-up onward we need the rewrite so the RAG query carries
+      // entities and topics from earlier turns ("the bars" → "Hershey's bars
+      // chocolate poisoning dog"); without it, embeddings match nothing and
+      // the assistant loses the thread.
       const userMessages = recentMessages.filter(msg => msg.role === 'user')
-      if (userMessages.length <= 2) {
+      if (userMessages.length < 2) {
         return lastUserMessage?.content || null
       }
 


### PR DESCRIPTION
## What

`rewriteQueryWithContext` in `admin/app/controllers/ollama_controller.ts` short-circuits the conversation-aware query rewriter when `userMessages.length <= 2`. That bound skips not just the first turn (where there's nothing to rewrite) but also the **first follow-up** (where the rewriter is most needed). Result: any chat that has had exactly one prior exchange sends RAG the raw latest message as the query, embeddings match nothing relevant (the prior turn's entities are gone), no RAG system message is injected, and the assistant answers the follow-up as if it were a brand-new, context-less question.

This PR changes the threshold to `< 2` so the rewriter runs from the first follow-up onward, matching the original behavior prior to commit `96e5027` (2026-03-11).

## Why

User scenario reproduced on NOMAD3 running v1.32.0-rc.3 with `mistral-nemo:12b`:

| Turn | Message |
|---|---|
| 1 (user) | "my 30lb terrier just ate 3 Hershey's bars about 30 minutes ago - we are snowed in and can't get to the vet…" |
| 1 (assistant) | Correctly retrieves chocolate-poisoning context, answers with theobromine math, induce-vomiting guidance, etc. |
| 2 (user) | "great - they threw up 2 of the bars it looks like" |
| 2 (assistant, pre-patch) | "Relevant Context: None. Since there is no relevant context provided regarding throwing up bars for s'more peanut butter bars or related recipes…" → drifts into recipe troubleshooting |

The pronoun "the bars" without rewriting embeds to recipe content far more strongly than to canine chocolate toxicity. Once the rewriter is skipped, RAG returns nothing above the 0.3 similarity threshold and the model loses the thread.

## How

```diff
-      // Skip rewriting for short conversations. Rewriting adds latency with
-      // little RAG benefit until there is enough context to matter.
+      // Skip rewriting on the very first turn — with only one user message
+      // there is no prior context to fold in, so the rewrite would just echo
+      // the message back at the cost of an extra LLM round-trip. From the
+      // first follow-up onward we need the rewrite so the RAG query carries
+      // entities and topics from earlier turns ("the bars" → "Hershey's bars
+      // chocolate poisoning dog"); without it, embeddings match nothing and
+      // the assistant loses the thread.
       const userMessages = recentMessages.filter(msg => msg.role === 'user')
-      if (userMessages.length <= 2) {
+      if (userMessages.length < 2) {
         return lastUserMessage?.content || null
       }
```

The original perf-motivation comment isn't wrong — it's just that rewriting on turn 2 IS worthwhile, and the latency cost (one extra small-model round-trip) is the price of correct context carry. Turn 1 with only one user message still short-circuits, so there's no added latency on first message.

## Verification

Hot-patched the compiled controller into the NOMAD3 admin container and replayed the dog-chocolate scenario via `POST /api/ollama/chat` with the same three-message conversation. Pre-patch behavior matches the reporter's screenshot (pivots to recipes). Post-patch:

> "Based on the provided knowledge base contexts, none directly relate to chocolate poisoning in dogs. However… **Because my dog threw up 2 out of the 3 consumed chocolate bars**, it's likely that we caught symptoms early and minimized much worse effects. However, **I would strongly recommend contacting my vet right away**…"

The "3 chocolate bars" detail is the smoking gun — that fact appears only in turn 1, which the unpatched build was effectively dropping. Post-patch the model carries it forward correctly.

## Notes

- One-line code change with expanded comment explaining intent for future readers.
- Targeted at `rc` since v1.32.0-rc.3 just dropped and this regression has been live since v1.31.x (commit landed 2026-03-11). Worth getting into rc.4 if we're cutting one before GA.
- A secondary, pre-existing issue surfaced during testing on this fix: RAG can over-match on semantic-similar-but-clinically-wrong content (a radiation-sickness chunk scored 74.3% relevance on a warfarin-headache follow-up), and small models like `mistral-nemo:12b` anchor on the bad chunk instead of dismissing it per `rag_context` rule 4. That's a separate retrieval-tuning conversation (raise 0.3 threshold? strengthen "ignore irrelevant" instruction?) and out of scope here.