### PR TITLE
fix(logging): also write production logs to stdout for docker visibility

### DIFF
--- a/admin/config/logger.ts
+++ b/admin/config/logger.ts
@@ -18,7 +18,14 @@ const loggerConfig = defineConfig({
         targets:
           targets()
             .pushIf(!app.inProduction, targets.pretty())
+            // Production: write JSON to both the persisted log file (for Debug
+            // Info bundle export) AND stdout (so `docker logs nomad_admin` and
+            // any external log aggregator can see runtime telemetry — RAG
+            // retrieval scores, query rewrites, etc.). Writing to fd 1 via
+            // pino/file is the standard way to do this; without it, prod
+            // installs are effectively running blind from a debugger's POV.
             .pushIf(app.inProduction, targets.file({ destination: "/app/storage/logs/admin.log", mkdir: true }))
+            .pushIf(app.inProduction, targets.file({ destination: 1 }))
             .toArray(),
       },
     },


### PR DESCRIPTION
## What

`admin/config/logger.ts` configures the production logger with a single file target writing to `/app/storage/logs/admin.log` and no stdout target. As a result, `docker logs nomad_admin` shows only the banner lines from non-pino stdout writes (worker-startup messages, etc.) but none of the `logger.info` / `logger.debug` / `logger.error` output from the AdonisJS app — controllers, services, providers, jobs, all of it.

This adds a second production target so logs land in both places: the persisted file (preserved for Debug Info bundle export) AND stdout (for `docker logs` and any external log aggregator).

## Why

Until this change, debugging a running NOMAD from outside the admin container required either:
1. Exec-ing into nomad_admin and tailing `/app/storage/logs/admin.log` manually, or
2. Triggering a Debug Info bundle export and downloading the log file

Neither flow surfaces logs to docker's native logging APIs, container log aggregators (Loki, Promtail, syslog forwarders), or simple ops tooling like `docker logs --tail` for tailing during a repro.

I hit this debugging RAG retrieval quality earlier today — `logger.info("[RAG] Query rewritten: ...")` calls weren't appearing in `docker logs` despite `LOG_LEVEL=debug`. Found the file destination via `cat /app/storage/logs/admin.log` and the bug became obvious. But that's the wrong default — visibility should be the default, not require exec-ing into the container.

The upcoming AI Quality eval framework needs stable, scrapable log output from outside the container so an evaluation harness can correlate (request, rewritten query, retrieved chunks, response). Without this fix the harness has to either run inside the admin container or hit a separate debug endpoint, neither of which is what we want for a clean eval signal.

## How

`admin/config/logger.ts`:

```diff
       transport: {
         targets:
           targets()
             .pushIf(!app.inProduction, targets.pretty())
+            // Production: write JSON to both the persisted log file (for Debug
+            // Info bundle export) AND stdout (so \`docker logs nomad_admin\` and
+            // any external log aggregator can see runtime telemetry — RAG
+            // retrieval scores, query rewrites, etc.). Writing to fd 1 via
+            // pino/file is the standard way to do this; without it, prod
+            // installs are effectively running blind from a debugger's POV.
             .pushIf(app.inProduction, targets.file({ destination: "/app/storage/logs/admin.log", mkdir: true }))
+            .pushIf(app.inProduction, targets.file({ destination: 1 }))
             .toArray(),
       },
```

One added line of behavior (the second `.pushIf`), six lines of comment. No new dependencies. `pino/file` accepts numeric `destination` as a file descriptor (1 = stdout, 2 = stderr), so this uses the same transport mechanism as the file target — just routed to fd 1.

## Verification

Hot-patched the compiled `config/logger.js` into NOMAD8's admin container (v1.32.0-rc.3) and restarted:

**Before:** `docker logs --tail 15 nomad_admin` showed only non-pino worker-startup lines.

**After:** structured JSON lines now appear in stdout —
```json
{"level":30,"time":1778624429112,"pid":136,"msg":"[CheckUpdateJob] Update check scheduled with cron: 0 2,14 * * *"}
{"level":30,"time":1778624429144,"pid":1,"msg":"[VersionCheckProvider] Checking for stale updateAvailable (current=1.32.0-rc.3)"}
{"level":30,"time":1778624429169,"pid":1,"msg":"[KiwixMigrationProvider] Kiwix not installed — skipping migration check."}
{"level":30,"time":1778624429207,"pid":1,"msg":"[QdrantRestartPolicyProvider] Qdrant already has unless-stopped restart policy — no update needed."}
```

File destination still receives writes — `/app/storage/logs/admin.log` grew from 36102 → 36234 bytes after an `/api/system/info` request, confirming Debug Info bundle export is unaffected.

## Notes

- Targets `dev` since this is foundational diagnostic plumbing, not RC-critical. Happy to retarget to `rc` if you want it in rc.4 / v1.32.0 stable — it'd reduce the support burden on any v1.32 user we ask to share logs.
- No log-volume / throughput concern at NOMAD's scale — admin container handles light request volume and dual-writing pino targets is negligible overhead.
- This is Phase 1 of the AI Quality eval work we discussed; unblocks the eval harness's ability to correlate retrieval telemetry without exec-ing into containers.