### PR TITLE
fix(map): Show marker notes in popups

### DIFF
--- a/admin/inertia/components/maps/MapComponent.tsx
+++ b/admin/inertia/components/maps/MapComponent.tsx
@@ -166,7 +166,14 @@ export default function MapComponent() {
             onClose={() => setSelectedMarkerId(null)}
             closeOnClick={false}
           >
-            <div className="text-sm font-medium">{selectedMarker.name}</div>
+            <div className="space-y-1">
+              <div className="text-sm font-medium">{selectedMarker.name}</div>
+              {selectedMarker.notes && (
+                <div className="max-w-64 whitespace-pre-wrap text-xs text-gray-700">
+                  {selectedMarker.notes}
+                </div>
+              )}
+            </div>
           </Popup>
         )}
 

--- a/admin/inertia/hooks/useMapMarkers.ts
+++ b/admin/inertia/hooks/useMapMarkers.ts
@@ -1,25 +1,10 @@
 import { useState, useCallback, useEffect } from 'react'
-import api from '~/lib/api'
+import api from '../lib/api.js'
+import { normalizeMapMarker, PIN_COLORS } from '../lib/map_markers.js'
+import type { MapMarker, MapMarkerApiRecord, PinColorId } from '../lib/map_markers.js'
 
-export const PIN_COLORS = [
-  { id: 'orange', label: 'Orange', hex: '#a84a12' },
-  { id: 'red', label: 'Red', hex: '#994444' },
-  { id: 'green', label: 'Green', hex: '#424420' },
-  { id: 'blue', label: 'Blue', hex: '#2563eb' },
-  { id: 'purple', label: 'Purple', hex: '#7c3aed' },
-  { id: 'yellow', label: 'Yellow', hex: '#ca8a04' },
-] as const
-
-export type PinColorId = typeof PIN_COLORS[number]['id']
-
-export interface MapMarker {
-  id: number
-  name: string
-  longitude: number
-  latitude: number
-  color: PinColorId
-  createdAt: string
-}
+export { PIN_COLORS }
+export type { MapMarker, MapMarkerApiRecord, PinColorId }
 
 export function useMapMarkers() {
   const [markers, setMarkers] = useState<MapMarker[]>([])
@@ -27,18 +12,9 @@ export function useMapMarkers() {
 
   // Load markers from API on mount
   useEffect(() => {
-    api.listMapMarkers().then((data) => {
+    api.listMapMarkers().then((data: MapMarkerApiRecord[] | undefined) => {
       if (data) {
-        setMarkers(
-          data.map((m) => ({
-            id: m.id,
-            name: m.name,
-            longitude: m.longitude,
-            latitude: m.latitude,
-            color: m.color as PinColorId,
-            createdAt: m.created_at,
-          }))
-        )
+        setMarkers(data.map(normalizeMapMarker))
       }
       setLoaded(true)
     })
@@ -48,14 +24,7 @@ export function useMapMarkers() {
     async (name: string, longitude: number, latitude: number, color: PinColorId = 'orange') => {
       const result = await api.createMapMarker({ name, longitude, latitude, color })
       if (result) {
-        const marker: MapMarker = {
-          id: result.id,
-          name: result.name,
-          longitude: result.longitude,
-          latitude: result.latitude,
-          color: result.color as PinColorId,
-          createdAt: result.created_at,
-        }
+        const marker = normalizeMapMarker(result)
         setMarkers((prev) => [...prev, marker])
         return marker
       }

--- a/admin/inertia/lib/api.ts
+++ b/admin/inertia/lib/api.ts
@@ -574,7 +574,7 @@ class API {
   async listMapMarkers() {
     return catchInternal(async () => {
       const response = await this.client.get<
-        Array<{ id: number; name: string; longitude: number; latitude: number; color: string; created_at: string }>
+        Array<{ id: number; name: string; longitude: number; latitude: number; color: string; notes: string | null; created_at: string }>
       >('/maps/markers')
       return response.data
     })()
@@ -583,7 +583,7 @@ class API {
   async createMapMarker(data: { name: string; longitude: number; latitude: number; color?: string }) {
     return catchInternal(async () => {
       const response = await this.client.post<
-        { id: number; name: string; longitude: number; latitude: number; color: string; created_at: string }
+        { id: number; name: string; longitude: number; latitude: number; color: string; notes: string | null; created_at: string }
       >('/maps/markers', data)
       return response.data
     })()

--- a/admin/inertia/lib/map_markers.ts
+++ b/admin/inertia/lib/map_markers.ts
@@ -1,0 +1,42 @@
+export const PIN_COLORS = [
+  { id: 'orange', label: 'Orange', hex: '#a84a12' },
+  { id: 'red', label: 'Red', hex: '#994444' },
+  { id: 'green', label: 'Green', hex: '#424420' },
+  { id: 'blue', label: 'Blue', hex: '#2563eb' },
+  { id: 'purple', label: 'Purple', hex: '#7c3aed' },
+  { id: 'yellow', label: 'Yellow', hex: '#ca8a04' },
+] as const
+
+export type PinColorId = typeof PIN_COLORS[number]['id']
+
+export interface MapMarker {
+  id: number
+  name: string
+  longitude: number
+  latitude: number
+  color: PinColorId
+  notes: string | null
+  createdAt: string
+}
+
+export interface MapMarkerApiRecord {
+  id: number
+  name: string
+  longitude: number
+  latitude: number
+  color: string
+  notes?: string | null
+  created_at: string
+}
+
+export function normalizeMapMarker(record: MapMarkerApiRecord): MapMarker {
+  return {
+    id: record.id,
+    name: record.name,
+    longitude: record.longitude,
+    latitude: record.latitude,
+    color: record.color as PinColorId,
+    notes: record.notes ?? null,
+    createdAt: record.created_at,
+  }
+}

--- a/admin/tests/unit/map_markers_normalize.spec.ts
+++ b/admin/tests/unit/map_markers_normalize.spec.ts
@@ -1,0 +1,32 @@
+import { test } from '@japa/runner'
+import { normalizeMapMarker } from '../../inertia/lib/map_markers.js'
+
+test.group('normalizeMapMarker', () => {
+  test('preserves marker notes from the API payload', ({ assert }) => {
+    const marker = normalizeMapMarker({
+      id: 7,
+      name: 'Library',
+      longitude: -1.23,
+      latitude: 4.56,
+      color: 'orange',
+      notes: 'Bring offline atlas',
+      created_at: '2026-05-08T00:00:00.000Z',
+    })
+
+    assert.equal(marker.notes, 'Bring offline atlas')
+    assert.equal(marker.name, 'Library')
+  })
+
+  test('normalizes missing notes to null', ({ assert }) => {
+    const marker = normalizeMapMarker({
+      id: 8,
+      name: 'Clinic',
+      longitude: 1.23,
+      latitude: -4.56,
+      color: 'blue',
+      created_at: '2026-05-08T00:00:00.000Z',
+    })
+
+    assert.isNull(marker.notes)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #796.

This updates map marker normalization so the API `notes` field is preserved on client-side marker objects, then renders those notes in the selected marker popup below the marker name. The normalization logic now lives in a small pure helper module so the notes behavior has focused regression coverage without importing the React hook or API client.

## Verification

- `npm run typecheck`
- `APP_KEY=12345678901234567890123456789012 HOST=localhost URL=http://localhost LOG_LEVEL=info DB_HOST=127.0.0.1 DB_PORT=3306 DB_USER=root DB_DATABASE=project_nomad_test REDIS_HOST=127.0.0.1 REDIS_PORT=6379 node ace test unit --files tests/unit/map_markers_normalize.spec.ts`
  - The two `normalizeMapMarker` assertions passed.
  - The command then failed during application shutdown because local Redis was unavailable (`ECONNREFUSED 127.0.0.1:6379`). I attempted to start Redis via Docker, but the Redis image pull timed out against Docker Hub in this environment.