### PR TITLE
fix(queue): singleton QueueService to stop ioredis connection leak

### DIFF
--- a/admin/app/jobs/check_service_updates_job.ts
+++ b/admin/app/jobs/check_service_updates_job.ts
@@ -95,7 +95,7 @@ export class CheckServiceUpdatesJob {
   }
 
   static async scheduleNightly() {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
 
     await queue.upsertJobScheduler(
@@ -114,7 +114,7 @@ export class CheckServiceUpdatesJob {
   }
 
   static async dispatch() {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
 
     const job = await queue.add(

--- a/admin/app/jobs/check_update_job.ts
+++ b/admin/app/jobs/check_update_job.ts
@@ -42,7 +42,7 @@ export class CheckUpdateJob {
   }
 
   static async scheduleNightly() {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
 
     await queue.upsertJobScheduler(
@@ -61,7 +61,7 @@ export class CheckUpdateJob {
   }
 
   static async dispatch() {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
 
     const job = await queue.add(this.key, {}, {

--- a/admin/app/jobs/download_model_job.ts
+++ b/admin/app/jobs/download_model_job.ts
@@ -34,7 +34,7 @@ export class DownloadModelJob {
 
   /** Signal cancellation via Redis so the worker process can pick it up on its next poll tick */
   static async signalCancel(jobId: string): Promise<void> {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     const client = await queue.client
     await client.set(this.cancelKey(jobId), '1', 'EX', 300) // 5 min TTL
@@ -66,7 +66,7 @@ export class DownloadModelJob {
     DownloadModelJob.abortControllers.set(job.id!, abortController)
 
     // Get Redis client for checking cancel signals from the API process
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const cancelRedis = await queueService.getQueue(DownloadModelJob.queue).client
 
     // Track whether cancellation was explicitly requested by the user. Only user-initiated
@@ -154,14 +154,14 @@ export class DownloadModelJob {
   }
 
   static async getByModelName(modelName: string): Promise<Job | undefined> {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     const jobId = this.getJobId(modelName)
     return await queue.getJob(jobId)
   }
 
   static async dispatch(params: DownloadModelJobParams) {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     const jobId = this.getJobId(params.modelName)
 

--- a/admin/app/jobs/embed_file_job.ts
+++ b/admin/app/jobs/embed_file_job.ts
@@ -184,7 +184,7 @@ export class EmbedFileJob {
   }
 
   static async listActiveJobs(): Promise<EmbedJobWithProgress[]> {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     const jobs = await queue.getJobs(['waiting', 'active', 'delayed'])
 
@@ -198,14 +198,14 @@ export class EmbedFileJob {
   }
 
   static async getByFilePath(filePath: string): Promise<Job | undefined> {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     const jobId = this.getJobId(filePath)
     return await queue.getJob(jobId)
   }
 
   static async dispatch(params: EmbedFileJobParams) {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
 
     // Continuation batches (batchOffset > 0) must NOT reuse the deterministic
@@ -267,7 +267,7 @@ export class EmbedFileJob {
   }
 
   static async listFailedJobs(): Promise<EmbedJobWithProgress[]> {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     // Jobs that have failed at least once are in 'delayed' (retrying) or terminal 'failed' state.
     // We identify them by job.data.status === 'failed' set in the catch block of handle().
@@ -286,7 +286,7 @@ export class EmbedFileJob {
   }
 
   static async cleanupFailedJobs(): Promise<{ cleaned: number; filesDeleted: number }> {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     const allJobs = await queue.getJobs(['waiting', 'delayed', 'failed'])
     const failedJobs = allJobs.filter((job) => (job.data as any).status === 'failed')

--- a/admin/app/jobs/run_benchmark_job.ts
+++ b/admin/app/jobs/run_benchmark_job.ts
@@ -53,7 +53,7 @@ export class RunBenchmarkJob {
   }
 
   static async dispatch(params: RunBenchmarkJobParams) {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
 
     try {
@@ -89,7 +89,7 @@ export class RunBenchmarkJob {
   }
 
   static async getJob(benchmarkId: string): Promise<Job | undefined> {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     return await queue.getJob(benchmarkId)
   }

--- a/admin/app/jobs/run_download_job.ts
+++ b/admin/app/jobs/run_download_job.ts
@@ -31,7 +31,7 @@ export class RunDownloadJob {
 
   /** Signal cancellation via Redis so the worker process can pick it up */
   static async signalCancel(jobId: string): Promise<void> {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     const client = await queue.client
     await client.set(this.cancelKey(jobId), '1', 'EX', 300) // 5 min TTL
@@ -46,7 +46,7 @@ export class RunDownloadJob {
     RunDownloadJob.abortControllers.set(job.id!, abortController)
 
     // Get Redis client for checking cancel signals from the API process
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const cancelRedis = await queueService.getQueue(RunDownloadJob.queue).client
 
     let lastKnownProgress: Pick<DownloadProgressData, 'downloadedBytes' | 'totalBytes'> = {
@@ -199,7 +199,7 @@ export class RunDownloadJob {
   }
 
   static async getByUrl(url: string): Promise<Job | undefined> {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     const jobId = this.getJobId(url)
     return await queue.getJob(jobId)
@@ -229,7 +229,7 @@ export class RunDownloadJob {
   }
 
   static async dispatch(params: RunDownloadJobParams) {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     const jobId = this.getJobId(params.url)
 

--- a/admin/app/jobs/run_extract_pmtiles_job.ts
+++ b/admin/app/jobs/run_extract_pmtiles_job.ts
@@ -49,7 +49,7 @@ export class RunExtractPmtilesJob {
   }
 
   static async signalCancel(jobId: string): Promise<void> {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     const client = await queue.client
     await client.set(this.cancelKey(jobId), '1', 'EX', 300)
@@ -77,7 +77,7 @@ export class RunExtractPmtilesJob {
         `maxzoom=${maxzoom ?? 'source-max'} out=${outputFilepath}`
     )
 
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const cancelRedis = await queueService.getQueue(RunExtractPmtilesJob.queue).client
 
     let userCancelled = false
@@ -249,13 +249,13 @@ export class RunExtractPmtilesJob {
   }
 
   static async getById(jobId: string): Promise<Job | undefined> {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     return await queue.getJob(jobId)
   }
 
   static async dispatch(params: RunExtractPmtilesJobParams) {
-    const queueService = new QueueService()
+    const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     const jobId = this.getJobId(params.sourceUrl, params.regionFilepath, params.maxzoom)
 

--- a/admin/app/services/queue_service.ts
+++ b/admin/app/services/queue_service.ts
@@ -1,8 +1,24 @@
 import { Queue } from 'bullmq'
 import queueConfig from '#config/queue'
 
+// Process-wide singleton. Each `Queue` opens two ioredis connections (one for
+// commands, one blocking). Instantiating a fresh QueueService per dispatch /
+// status lookup leaks both, and under sustained job churn (e.g. multi-batch ZIM
+// ingestion enqueueing a continuation every few seconds) it saturates Redis's
+// maxclients within hours.
 export class QueueService {
   private queues: Map<string, Queue> = new Map()
+
+  private static _instance: QueueService | null = null
+
+  private constructor() {}
+
+  static getInstance(): QueueService {
+    if (!QueueService._instance) {
+      QueueService._instance = new QueueService()
+    }
+    return QueueService._instance
+  }
 
   getQueue(name: string): Queue {
     if (!this.queues.has(name)) {
@@ -18,5 +34,6 @@ export class QueueService {
     for (const queue of this.queues.values()) {
       await queue.close()
     }
+    this.queues.clear()
   }
 }

--- a/admin/app/services/zim_service.ts
+++ b/admin/app/services/zim_service.ts
@@ -314,7 +314,7 @@ export class ZimService {
     if (restart) {
       // Check if there are any remaining ZIM download jobs before restarting
       const { QueueService } = await import('./queue_service.js')
-      const queueService = new QueueService()
+      const queueService = QueueService.getInstance()
       const queue = queueService.getQueue('downloads')
 
       // Get all active and waiting jobs


### PR DESCRIPTION
## Summary

Every static call site in jobs and services instantiates a fresh `QueueService` (24 call sites across 8 files). `QueueService.getQueue()` opens a BullMQ `Queue` when not cached, and each `Queue` opens two ioredis connections (one command, one blocking). Because every static call constructed a *new* `QueueService`, its internal cache was never shared — every call opened a fresh pair and none were ever closed.

In normal operation this leaked a few connections per API hit. **After PR #872 unblocked multi-batch ZIM ingestion**, every batch's `EmbedFileJob.dispatch()` call (every ~50 articles, fired every few seconds during a wikipedia-class ingestion) leaked two more. On NOMAD3 at ~1 batch/4s sustained, that's ~1,800 leaked connections/hour. Redis hit its 10,000-maxclient ceiling in ~5 hours and `nomad_admin` fell into an EPIPE flood loop. Restarting `nomad_redis` alone didn't help — admin opened 10,000+ new connections within seconds of Redis coming back. Only stopping admin actually drained the leak (10,000 → 1 connection).

## Fix

Collapse `QueueService` to a true process-wide singleton:

- Private constructor + static `getInstance()` accessor
- The existing per-queue `Map` is now shared across every dispatch / status / cleanup call, so each queue's underlying connections are opened exactly once per process
- `close()` now also clears the map so the singleton can be torn down cleanly if a graceful-shutdown hook is ever wired up

All 24 `new QueueService()` callers updated to `QueueService.getInstance()`. The private constructor enforces this at compile time — any new caller that tries `new QueueService()` fails the build.

## Test plan

Validated on NOMAD3 (RTX 5060, v1.32.0-rc.4 + this patch hot-applied):

- [x] Restarted admin with patched JS, sustained multi-batch `wikipedia_en_simple_all_nopic` ingestion through the BullMQ stalled-job auto-resume.
- [x] `connected_clients` held at **21–22 across 5 minutes** of continuous batch dispatch. Pre-fix the same scenario climbed to 10,000+ over hours.
- [x] Typecheck passes (`tsc --noEmit`).
- [x] Idle baseline: admin restart from cold = 21 clients, holds flat with no traffic.
- [ ] (Reviewer welcome to confirm) Triggering a model download or pmtiles extract should not cause connection growth either — same singleton path.

## Why this should ship with v1.32.0

PR #872 made multi-batch ingestion correct, but in this codebase that correctness exposes a latent bug that takes the admin container down over the course of a single big ingestion run. Together with #872, this PR makes multi-batch ZIM ingestion actually usable end-to-end without operator intervention.

Stacks on `rc` after #872 (already merged into rc.4).