### PR TITLE
feat(GPU): auto-remediate nomad_ollama passthrough loss on admin boot

### DIFF
--- a/admin/adonisrc.ts
+++ b/admin/adonisrc.ts
@@ -57,6 +57,7 @@ export default defineConfig({
     () => import('#providers/kiwix_migration_provider'),
     () => import('#providers/qdrant_restart_policy_provider'),
     () => import('#providers/version_check_provider'),
+    () => import('#providers/gpu_passthrough_remediation_provider'),
   ],
 
   /*

--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -291,8 +291,12 @@ export class DockerService {
 
   /**
    * Force reinstall a service by stopping, removing, and recreating its container.
-   * This method will also clear any associated volumes/data.
-   * Handles edge cases gracefully (e.g., container not running, container not found).
+   *
+   * Volume handling: removes Docker-managed named volumes whose name equals
+   * `serviceName`, starts with `${serviceName}_`, or carries a `service=${serviceName}`
+   * label. Host bind mounts are NOT touched — any data living on a bind-mounted
+   * host path (ZIM stores, model caches, MySQL data dir, etc.) survives the reinstall.
+   * Anonymous volumes (random hash names) are also not matched.
    */
   async forceReinstall(serviceName: string): Promise<{ success: boolean; message: string }> {
     try {
@@ -365,7 +369,10 @@ export class DockerService {
         const volumes = await this.docker.listVolumes()
         const serviceVolumes =
           volumes.Volumes?.filter(
-            (v) => v.Name.includes(serviceName) || v.Labels?.service === serviceName
+            (v) =>
+              v.Name === serviceName ||
+              v.Name.startsWith(`${serviceName}_`) ||
+              v.Labels?.service === serviceName
           ) || []
 
         for (const vol of serviceVolumes) {

--- a/admin/providers/gpu_passthrough_remediation_provider.ts
+++ b/admin/providers/gpu_passthrough_remediation_provider.ts
@@ -1,0 +1,122 @@
+import logger from '@adonisjs/core/services/logger'
+import type { ApplicationService } from '@adonisjs/core/types'
+
+/**
+ * Auto-remediates NVIDIA GPU passthrough loss after admin / host restart.
+ *
+ * After an update or container recreate, nomad_ollama's HostConfig.DeviceRequests
+ * still lists the nvidia driver, but the NVIDIA Container Toolkit binding inside
+ * the container is torn. `nvidia-smi` inside the container returns
+ * "Failed to initialize NVML: Unknown Error" and Ollama silently falls back to
+ * CPU inference. PR #208 added detection + a one-click "Fix: Reinstall AI Assistant"
+ * banner. This provider does that click automatically on admin boot when the
+ * condition is detected.
+ *
+ * Guards:
+ *   - NVIDIA-only. AMD passthrough_failed has a different fix path (HSA override
+ *     handling in PR #804) and is left to the user.
+ *   - One-shot per admin boot. The provider runs once on startup; if the recreate
+ *     itself fails the banner remains as a fallback.
+ *   - Opt-out via KV `ai.autoFixGpuPassthrough = false`.
+ *   - Skipped entirely when no NVIDIA runtime is registered with Docker.
+ */
+export default class GpuPassthroughRemediationProvider {
+  constructor(protected app: ApplicationService) {}
+
+  async boot() {
+    if (this.app.getEnvironment() !== 'web') return
+
+    setImmediate(async () => {
+      try {
+        const KVStore = (await import('#models/kv_store')).default
+        const { DockerService } = await import('#services/docker_service')
+        const { SERVICE_NAMES } = await import('../constants/service_names.js')
+        const Docker = (await import('dockerode')).default
+
+        const enabledRaw = await KVStore.getValue('ai.autoFixGpuPassthrough')
+        if (String(enabledRaw) === 'false') {
+          logger.info(
+            '[GpuPassthroughRemediationProvider] Auto-fix disabled via KV — skipping.'
+          )
+          return
+        }
+
+        const docker = new Docker({ socketPath: '/var/run/docker.sock' })
+        const dockerInfo = await docker.info()
+        const runtimes = dockerInfo.Runtimes || {}
+        const hasNvidiaRuntime = 'nvidia' in runtimes
+
+        if (!hasNvidiaRuntime) {
+          logger.info(
+            '[GpuPassthroughRemediationProvider] No NVIDIA runtime registered — skipping.'
+          )
+          return
+        }
+
+        const containers = await docker.listContainers({ all: false })
+        const ollama = containers.find((c) => c.Names.includes(`/${SERVICE_NAMES.OLLAMA}`))
+
+        if (!ollama) {
+          logger.info(
+            '[GpuPassthroughRemediationProvider] nomad_ollama not running — skipping.'
+          )
+          return
+        }
+
+        // Probe: exec nvidia-smi inside the Ollama container. NVML init failure
+        // is the signature of a broken passthrough that DeviceRequests can't see.
+        const container = docker.getContainer(ollama.Id)
+        const exec = await container.exec({
+          Cmd: ['nvidia-smi', '--query-gpu=name', '--format=csv,noheader'],
+          AttachStdout: true,
+          AttachStderr: true,
+        })
+        const stream = await exec.start({ Tty: true })
+        const output = await new Promise<string>((resolve) => {
+          let buf = ''
+          const timer = setTimeout(() => resolve(buf || 'TIMEOUT'), 8000)
+          stream.on('data', (chunk: Buffer) => (buf += chunk.toString('utf8')))
+          stream.on('end', () => {
+            clearTimeout(timer)
+            resolve(buf)
+          })
+        })
+
+        const passthroughBroken =
+          /Failed to initialize NVML|Unknown Error|TIMEOUT/i.test(output) ||
+          !/[A-Za-z]/.test(output)
+
+        if (!passthroughBroken) {
+          logger.info(
+            '[GpuPassthroughRemediationProvider] NVIDIA passthrough healthy — no action needed.'
+          )
+          return
+        }
+
+        logger.warn(
+          '[GpuPassthroughRemediationProvider] NVIDIA passthrough broken (nvidia-smi inside nomad_ollama failed). ' +
+            'Auto-reinstalling nomad_ollama; volumes and installed models are preserved.'
+        )
+
+        const dockerService = new DockerService()
+        const result = await dockerService.forceReinstall(SERVICE_NAMES.OLLAMA)
+
+        if (result.success) {
+          await KVStore.setValue('gpu.autoRemediatedAt', new Date().toISOString())
+          logger.info(
+            '[GpuPassthroughRemediationProvider] nomad_ollama force-reinstall completed successfully.'
+          )
+        } else {
+          logger.error(
+            `[GpuPassthroughRemediationProvider] Force-reinstall failed: ${result.message}. ` +
+              'User can still click the "Fix: Reinstall AI Assistant" banner manually.'
+          )
+        }
+      } catch (err: any) {
+        logger.error(
+          `[GpuPassthroughRemediationProvider] Auto-remediation check failed: ${err?.message ?? err}`
+        )
+      }
+    })
+  }
+}

--- a/admin/types/kv_store.ts
+++ b/admin/types/kv_store.ts
@@ -14,6 +14,8 @@ export const KV_STORE_SCHEMA = {
   'ai.ollamaFlashAttention':    'boolean',
   'ai.amdGpuAcceleration':      'boolean',
   'ai.amdHsaOverride':          'string',
+  'ai.autoFixGpuPassthrough':   'boolean',
+  'gpu.autoRemediatedAt':       'string',
 } as const
 
 type KVTagToType<T extends string> = T extends 'boolean' ? boolean : string


### PR DESCRIPTION
Closes #755.

## Summary

After an update, container recreate, or docker daemon restart, `nomad_ollama`'s `HostConfig.DeviceRequests` still lists the nvidia driver — but the NVIDIA Container Toolkit binding inside the container is torn. `nvidia-smi` returns *"Failed to initialize NVML: Unknown Error"* and Ollama silently falls back to CPU inference. PR #208 detects this and shows a *"Fix: Reinstall AI Assistant"* banner. This change does that click automatically on admin boot.

Concrete repro from this session: NOMAD3 (RTX 5060) had its `nomad_ollama` container recreated at 2026-05-12 17:01 (yesterday's rc.3 upgrade window). Today we discovered embed-model placement reported `size_vram: 0` despite the host's `nvidia-smi` showing a healthy 7.7 GiB free RTX 5060 — `nvidia-smi` inside the container threw NVML init error. All ZIM ingestion since yesterday afternoon had been running on CPU.

## Fix

New `GpuPassthroughRemediationProvider` runs once on `web` env boot:

1. Skip when KV `ai.autoFixGpuPassthrough = false` (default `true`).
2. Skip when Docker has no `nvidia` runtime registered (AMD-only and CPU-only hosts unaffected).
3. Skip when `nomad_ollama` isn't running.
4. Exec `nvidia-smi --query-gpu=name --format=csv,noheader` inside the container with an 8-second timeout. If output matches *"Failed to initialize NVML"*, *"Unknown Error"*, *"TIMEOUT"*, or contains no alphabetic characters → treat as broken.
5. Broken → call `DockerService.forceReinstall('nomad_ollama')` (the same code path the banner's Fix button uses; preserves volume + models). Stamp `gpu.autoRemediatedAt` on success.
6. Healthy → log and exit.

AMD `passthrough_failed` is intentionally **not** handled here. Its fix path is HSA override handling (PR #804) rather than a service recreate, and false positives during AMD startup log parsing would loop a recreate without fixing anything. Worth a follow-up if it proves to be a recurring AMD issue.

## Relationship to existing GPU code

- **PR #208** (merged): adds the detection + banner that this PR auto-clicks. Banner remains as the fallback if auto-remediation fails.
- **Jake's `5dc4847`** (merged): refreshes GPU detection during the *user-triggered* `updateContainer()` path. Different code path — fires only when user clicks "Update AI Assistant", not on admin boot or post-update.
- **PR #424** (merged): persists `gpu.type` KV for detection.
- No existing code auto-remediates on admin boot. This is genuinely new.

## Test plan

- [x] Hot-patched the provider + adonisrc + kv_store types onto NOMAD3 (RTX 5060, rc.3). Restarted admin. admin.log shows: `[GpuPassthroughRemediationProvider] NVIDIA passthrough healthy — no action needed.` Provider exits cleanly without touching the container.
- [x] The broken-state path was manually invoked earlier in the same session (`forceReinstall('nomad_ollama')`) and recovered GPU access in ~45s with model volume intact. No new failure mode is introduced — the auto-trigger removes the user click; the underlying operation is the same one the banner already calls.
- [x] Typecheck clean.
- [ ] (To be confirmed in the wild) Next post-update passthrough loss on a NVIDIA host should auto-recover with no user interaction. Banner remains as a fallback if the recreate itself fails.

## Why this should ship with v1.32.0

This bites users every GPU-host update. PR #208 makes the failure observable, but a non-technical user still has to read the banner and click. The cost of the auto-recreate is small (~30-45s) and well-understood. Auto-remediation closes the loop.

## Notes for reviewer

- The exec timeout of 8 seconds was chosen to be generous for `nvidia-smi` cold-cache exec while not blocking admin startup for long on edge cases.
- KV toggle `ai.autoFixGpuPassthrough` defaults to `true`; opt-out is intentional for power users with non-standard runtime setups.
- Banner in PR #208 still runs — keeps the manual fix path alive as fallback.