### PR TITLE
fix(RAG): report ZIM ingestion progress in overall-file frame

### DIFF
--- a/admin/app/jobs/embed_file_job.ts
+++ b/admin/app/jobs/embed_file_job.ts
@@ -7,6 +7,7 @@ import { OllamaService } from '#services/ollama_service'
 import { createHash } from 'crypto'
 import logger from '@adonisjs/core/services/logger'
 import fs from 'node:fs/promises'
+import { ZIM_BATCH_SIZE } from '../../constants/zim_extraction.js'
 
 export interface EmbedFileJobParams {
   filePath: string
@@ -87,9 +88,25 @@ export class EmbedFileJob {
 
       logger.info(`[EmbedFileJob] Processing file: ${filePath}`)
 
-      // Progress callback: maps service-reported 0-100% into the 5-95% job range
+      // Progress callback. For multi-batch ZIM ingestions, scale the service-reported
+      // 0-100% (which is % through the current batch's chunks) into the overall-file
+      // frame so the UI gauge climbs monotonically across the many continuation jobs
+      // BullMQ creates per file. Without this, every new continuation jobId resets the
+      // gauge to ~5% and the user sees ingestion progress "jumping around" between
+      // each batch's local frame and the end-of-batch overall-file overwrite below.
+      //
+      // For single-batch files (uploaded PDFs, txts) totalArticles is undefined and
+      // we fall back to the original 5-95% per-job range, which is what the UI expects
+      // for a one-shot file with no continuations.
       const onProgress = async (percent: number) => {
-        await this.safeUpdateProgress(job, Math.min(95, Math.round(5 + percent * 0.9)))
+        const useOverallFrame = totalArticles && totalArticles > 0
+        if (useOverallFrame) {
+          const articlesDone = (batchOffset || 0) + (percent / 100) * ZIM_BATCH_SIZE
+          const overallPercent = Math.min(99, Math.round((articlesDone / totalArticles) * 100))
+          await this.safeUpdateProgress(job, overallPercent)
+        } else {
+          await this.safeUpdateProgress(job, Math.min(95, Math.round(5 + percent * 0.9)))
+        }
       }
 
       // Process and embed the file

--- a/admin/app/services/rag_service.ts
+++ b/admin/app/services/rag_service.ts
@@ -500,13 +500,13 @@ export class RagService {
       `[RAG] Extracting ZIM content (batch: offset=${startOffset}, size=${ZIM_BATCH_SIZE})`
     )
 
-    const zimChunks = await zimExtractionService.extractZIMContent(filepath, {
-      startOffset,
-      batchSize: ZIM_BATCH_SIZE,
-    })
+    const { chunks: zimChunks, totalArticles } = await zimExtractionService.extractZIMContent(
+      filepath,
+      { startOffset, batchSize: ZIM_BATCH_SIZE }
+    )
 
     logger.info(
-      `[RAG] Extracted ${zimChunks.length} chunks from ZIM file with enhanced metadata`
+      `[RAG] Extracted ${zimChunks.length} chunks from ZIM file with enhanced metadata (file totalArticles=${totalArticles})`
     )
 
     // Process each chunk individually with its metadata
@@ -582,6 +582,7 @@ export class RagService {
       chunks: totalChunks,
       hasMoreBatches,
       articlesProcessed: articlesInBatch,
+      totalArticles,
     }
   }
 

--- a/admin/app/services/zim_extraction_service.ts
+++ b/admin/app/services/zim_extraction_service.ts
@@ -40,7 +40,10 @@ export class ZIMExtractionService {
      * @param filePath - Path to the ZIM file
      * @param opts - Options including maxArticles, strategy, onProgress, startOffset, and batchSize
      */
-    async extractZIMContent(filePath: string, opts: ExtractZIMContentOptions = {}): Promise<ZIMContentChunk[]> {
+    async extractZIMContent(
+        filePath: string,
+        opts: ExtractZIMContentOptions = {}
+    ): Promise<{ chunks: ZIMContentChunk[]; totalArticles: number }> {
         try {
             logger.info(`[ZIMExtractionService]: Processing ZIM file at path: ${filePath}`)
             
@@ -161,7 +164,7 @@ export class ZIMExtractionService {
                 textPreview: c.text.substring(0, 100)
             })))
             logger.debug("Total structured sections extracted:", toReturn.length)
-            return toReturn
+            return { chunks: toReturn, totalArticles: archive.articleCount }
         } catch (error) {
             logger.error('Error processing ZIM file:', error)
             throw error


### PR DESCRIPTION
Before this change, the Active Downloads / Processing Queue UI showed the ingestion progress gauge **jumping wildly** during multi-batch ZIM ingestion (5% → 88% → 27% → 5% → 56% → 36% over ~60 seconds for cooking SE).

## Root cause

Each continuation batch is a separate BullMQ job (#872), and `EmbedFileJob.handle()` reported `job.progress` in two different reference frames:

- **During-batch** (via onProgress callback): 5-95% scaled across "% through this batch's chunks"
- **End-of-batch**: overwritten to `(nextOffset / totalArticles) * 100` — "% through whole file"
- **Next continuation**: explicitly set back to 5%, climbs through per-batch range again

With GPU-accelerated ingestion completing a batch every ~4 seconds, the UI saw the jobId rotate constantly and the gauge whipsaw between the two frames.

`totalArticles` was already wired through `EmbedFileJobParams` and used at end-of-batch — but `RagService` never actually populated it, so any frame-scaling that depended on it silently fell back to the per-batch range.

## Fix

Three coordinated changes:

1. `ZIMExtractionService.extractZIMContent()` returns `{ chunks, totalArticles }` instead of raw chunks (single caller updated).
2. `RagService.processZimFile()` includes `totalArticles` in its result so the existing `EmbedFileJob.dispatch({ totalArticles: ... })` propagation actually has a value.
3. `EmbedFileJob`'s onProgress callback scales the service-reported per-batch percent into the overall-file frame when `totalArticles` is known:

   ```
   overallPercent = ((batchOffset + (percent/100) * ZIM_BATCH_SIZE) / totalArticles) * 100
   ```

   Capped at 99% to leave room for the explicit 100% at completion. Falls back to the original 5-95% range for single-batch files (PDFs/txts) where `totalArticles` is undefined.

## Test plan

Validated on NOMAD8 (RX 6800):

- **devdocs python** (~1,500 articles): monotonic across continuation jobIds: `1501@30% → 1510@33% → 1514@43% → 1518@52%`. No more reset to 5%.
- **ifixit** (~100k articles): stays near 3% for the first many batches at offset 0..3000 — correct, the file is enormous.
- **wikipedia_en_medicine** (~70k articles): stays near 0-1% for the first batches — also correct.
- Brief 0-5% blip on continuation handoff (the explicit `safeUpdateProgress(job, 5)` at batch start, before the first onProgress fires) — visible but quickly resolves to the overall-frame value. No more 5% ↔ 88% chaos.

## Why this should ship with v1.32.0

PR #872 made multi-batch ingestion work correctly. With it working, the UI gauge is now a visible cue users rely on to understand whether their large ZIM is making progress. The pre-fix jumping pattern looks like the ingestion is broken when it isn't.

## Notes for reviewer

- `ZIMExtractionService.extractZIMContent()` return-type change is breaking for any future caller. Only `RagService.processZimFile()` calls it today; that single caller is updated.
- `ZIM_BATCH_SIZE` is imported from the existing `constants/zim_extraction.ts`.
- The interface field `totalArticles?: number` on `ProcessAndEmbedFileResponse` already existed — this PR just actually populates it.