### PR TITLE
fix(ZIM): preserve co-existing Wikipedia corpora on cleanup (#884)

### DIFF
--- a/admin/app/services/zim_service.ts
+++ b/admin/app/services/zim_service.ts
@@ -7,6 +7,7 @@ import axios from 'axios'
 import * as cheerio from 'cheerio'
 import { XMLParser } from 'fast-xml-parser'
 import { isRawListRemoteZimFilesResponse, isRawRemoteZimFileEntry } from '../../util/zim.js'
+import { findReplacedWikipediaFiles } from '../utils/zim_filename.js'
 import logger from '@adonisjs/core/services/logger'
 import { DockerService } from './docker_service.js'
 import { inject } from '@adonisjs/core'
@@ -627,18 +628,21 @@ export class ZimService {
 
       logger.info(`[ZimService] Wikipedia download completed successfully: ${filename}`)
 
-      // Delete old Wikipedia files (keep only the newly installed one)
+      // Delete prior versions of THIS specific Wikipedia variant only.
+      // Earlier logic deleted anything starting with `wikipedia_en_`, which silently
+      // wiped distinct corpora the user had installed independently (issue #884).
       const existingFiles = await this.list()
-      const wikipediaFiles = existingFiles.files.filter((f) =>
-        f.name.startsWith('wikipedia_en_') && f.name !== filename
+      const wikipediaFiles = findReplacedWikipediaFiles(
+        filename,
+        existingFiles.files.map((f) => f.name)
       )
 
       for (const oldFile of wikipediaFiles) {
         try {
-          await this.delete(oldFile.name)
-          logger.info(`[ZimService] Deleted old Wikipedia file: ${oldFile.name}`)
+          await this.delete(oldFile)
+          logger.info(`[ZimService] Deleted old Wikipedia file: ${oldFile}`)
         } catch (error) {
-          logger.warn(`[ZimService] Could not delete old Wikipedia file: ${oldFile.name}`, error)
+          logger.warn(`[ZimService] Could not delete old Wikipedia file: ${oldFile}`, error)
         }
       }
     } else {

--- a/admin/app/utils/zim_filename.ts
+++ b/admin/app/utils/zim_filename.ts
@@ -1,0 +1,26 @@
+/**
+ * Strip the trailing `_YYYY-MM(-DD).zim` date suffix from a Kiwix-style ZIM
+ * filename so different release dates of the same variant share a stem
+ * (e.g., `wikipedia_en_all_nopic`) while distinct corpora keep distinct stems
+ * (`wikipedia_en_simple_all_nopic`, `wikipedia_en_medicine_nopic`, etc.).
+ */
+export function zimFilenameStem(name: string): string {
+  return name.replace(/_\d{4}-\d{2}(?:-\d{2})?\.zim$/i, '')
+}
+
+/**
+ * Of the existing files, return only those that are prior-version replacements
+ * of `currentFilename` — same Wikipedia variant stem, different release. Used
+ * by the post-download cleanup to avoid deleting unrelated Wikipedia corpora
+ * the user has installed independently (issue #884).
+ */
+export function findReplacedWikipediaFiles(
+  currentFilename: string,
+  existingNames: string[]
+): string[] {
+  const currentStem = zimFilenameStem(currentFilename)
+  return existingNames.filter(
+    (n) =>
+      n.startsWith('wikipedia_en_') && n !== currentFilename && zimFilenameStem(n) === currentStem
+  )
+}

--- a/admin/tests/unit/zim_filename.spec.ts
+++ b/admin/tests/unit/zim_filename.spec.ts
@@ -1,0 +1,73 @@
+import * as assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { findReplacedWikipediaFiles, zimFilenameStem } from '../../app/utils/zim_filename.js'
+
+test('zimFilenameStem strips YYYY-MM date suffix', () => {
+  assert.equal(zimFilenameStem('wikipedia_en_all_nopic_2026-02.zim'), 'wikipedia_en_all_nopic')
+})
+
+test('zimFilenameStem strips YYYY-MM-DD date suffix', () => {
+  assert.equal(zimFilenameStem('wikipedia_en_all_nopic_2026-02-15.zim'), 'wikipedia_en_all_nopic')
+})
+
+test('zimFilenameStem returns input unchanged when no date suffix present', () => {
+  assert.equal(
+    zimFilenameStem('wikipedia_en_my_custom_extract.zim'),
+    'wikipedia_en_my_custom_extract.zim'
+  )
+})
+
+test('findReplacedWikipediaFiles cleans up older version of same variant', () => {
+  assert.deepEqual(
+    findReplacedWikipediaFiles('wikipedia_en_all_nopic_2026-04.zim', [
+      'wikipedia_en_all_nopic_2026-02.zim',
+      'wikipedia_en_all_nopic_2026-04.zim',
+    ]),
+    ['wikipedia_en_all_nopic_2026-02.zim']
+  )
+})
+
+test('findReplacedWikipediaFiles preserves co-existing distinct corpora — the #884 regression case', () => {
+  assert.deepEqual(
+    findReplacedWikipediaFiles('wikipedia_en_medicine_nopic_2026-04.zim', [
+      'wikipedia_en_simple_all_nopic_2026-02.zim',
+      'wikipedia_en_medicine_nopic_2026-04.zim',
+    ]),
+    []
+  )
+})
+
+test('findReplacedWikipediaFiles preserves all unrelated variants when a new variant lands', () => {
+  assert.deepEqual(
+    findReplacedWikipediaFiles('wikipedia_en_all_nopic_2026-04.zim', [
+      'wikipedia_en_simple_all_nopic_2026-02.zim',
+      'wikipedia_en_medicine_nopic_2026-04.zim',
+      'wikipedia_en_wikivoyage_2026-02.zim',
+      'wikipedia_en_climate_change_2025-08.zim',
+      'wikipedia_en_all_nopic_2026-04.zim',
+    ]),
+    []
+  )
+})
+
+test('findReplacedWikipediaFiles ignores files without wikipedia_en_ prefix', () => {
+  assert.deepEqual(
+    findReplacedWikipediaFiles('wikipedia_en_all_nopic_2026-04.zim', [
+      'wiktionary_en_all_2026-02.zim',
+      'gutenberg_en_all_2026-01.zim',
+      'wikipedia_en_all_nopic_2026-04.zim',
+    ]),
+    []
+  )
+})
+
+test('findReplacedWikipediaFiles preserves manually-named files without a date suffix', () => {
+  assert.deepEqual(
+    findReplacedWikipediaFiles('wikipedia_en_all_nopic_2026-04.zim', [
+      'wikipedia_en_my_custom_extract.zim',
+      'wikipedia_en_all_nopic_2026-04.zim',
+    ]),
+    []
+  )
+})


### PR DESCRIPTION
Closes #884.

## Problem

`ZimService.onWikipediaDownloadComplete()` was deleting every file whose name starts with `wikipedia_en_` after a Wikipedia download, treating distinct corpora as competing versions of the same selection slot. Downloading `wikipedia_en_medicine_nopic_2026-04.zim` while `wikipedia_en_simple_all_nopic_2026-02.zim` was already installed silently deleted the simple wiki — and vice versa. Hit directly during multi-ZIM ingestion testing on NOMAD1 (see issue body for full repro).

## Fix

Match by **filename stem** — strip the trailing `_YYYY-MM(-DD).zim` date suffix and only delete files whose stem equals the new download's stem.

- `wikipedia_en_all_nopic_2026-02.zim` and `wikipedia_en_all_nopic_2026-04.zim` share a stem (`wikipedia_en_all_nopic`) → older version cleaned up. ✓
- `wikipedia_en_simple_all_nopic_*` and `wikipedia_en_medicine_nopic_*` have distinct stems → both preserved. ✓
- Manually-named files without a date suffix (e.g., `wikipedia_en_my_custom_extract.zim`) keep their full name as their stem → never match anything except an exact duplicate, which is already filtered out. ✓

## Implementation

The predicate is extracted to `app/utils/zim_filename.ts` so the boundary is covered by unit tests rather than living inline. 8 cases including the literal #884 repro scenario.

## Testing

- `npm run typecheck` — clean
- New tests pass (8/8) — compiled with `tsc` and run via `node --test`; can't run `node ace test` locally on Windows due to libzim native bindings, but the tests use only `node:test` and pure functions, so CI on Linux will execute them
- Existing pre-existing lint errors in `zim_service.ts` (519, 520, 655, 705, 717, 773, 774, 779) are unrelated to this change

## Why ship in v1.32.0 GA

Silent data destruction — a user has no signal that their other wiki was deleted. The cleanup logic was added to manage curated-selection upgrades; preserving unrelated corpora aligns it with user intent.