### PR TITLE
fix(RAG): anchor continuation-batch initial progress to overall-file frame

### DIFF
--- a/admin/app/jobs/embed_file_job.ts
+++ b/admin/app/jobs/embed_file_job.ts
@@ -84,8 +84,16 @@ export class EmbedFileJob {
 
       logger.info(`[EmbedFileJob] Services ready. Processing file: ${fileName}`)
 
-      // Update progress starting
-      await this.safeUpdateProgress(job, 5)
+      // Anchor initial progress to where we are in the overall file. For a
+      // continuation batch midway through a multi-batch ZIM (e.g. offset 100k of
+      // 600k), the hardcoded 5 used to make the gauge briefly flash 0→5→real,
+      // which read as a backward jump. Fall back to 5 for single-batch files
+      // where totalArticles isn't set.
+      const initialPercent =
+        totalArticles && totalArticles > 0
+          ? Math.min(99, Math.round(((batchOffset || 0) / totalArticles) * 100))
+          : 5
+      await this.safeUpdateProgress(job, initialPercent)
       await job.updateData({
         ...job.data,
         status: 'processing',


### PR DESCRIPTION
Follow-up to #880 (the overall-frame fix). #880 corrected the per-batch progress scaling, but the *initial* `safeUpdateProgress(job, 5)` at the top of `EmbedFileJob.handle()` was still hardcoded — so every new continuation batch briefly flashed 0→5→real before the next `onProgress` callback caught up. Visually a small backward jump every ~4s through a multi-batch ZIM.

## Fix

Compute `initialPercent` from `batchOffset / totalArticles` when both are set; fall back to 5 for single-batch uploads where `totalArticles` is undefined. Capped at 99 to leave the 100% final-batch marker untouched.

```ts
const initialPercent =
  totalArticles && totalArticles > 0
    ? Math.min(99, Math.round(((batchOffset || 0) / totalArticles) * 100))
    : 5
await this.safeUpdateProgress(job, initialPercent)
```

## Scope

Single-file +10/-2 surgical change. No behavior change for single-batch files. Type-check clean.