### PR TITLE
fix(KB): remove redundant Refresh button from Processing Queue

### DIFF
--- a/admin/inertia/components/ActiveEmbedJobs.tsx
+++ b/admin/inertia/components/ActiveEmbedJobs.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import useEmbedJobs from '~/hooks/useEmbedJobs'
 import HorizontalBarChart from './HorizontalBarChart'
-import StyledButton from './StyledButton'
 import StyledSectionHeader from './StyledSectionHeader'
 import {
   JOB_HEALTH_DISPLAY,
@@ -14,10 +13,9 @@ interface ActiveEmbedJobsProps {
 }
 
 const ActiveEmbedJobs = ({ withHeader = false }: ActiveEmbedJobsProps) => {
-  const { data: jobs, invalidate, dataUpdatedAt } = useEmbedJobs()
+  const { data: jobs } = useEmbedJobs()
 
-  // Live "last refreshed Xs ago" tick. We re-render every 5s purely to keep
-  // the relative timestamp current, without touching React Query state.
+  // Re-render every 5s to keep per-job "last activity Xs ago" timestamps fresh.
   const [tick, setTick] = useState(() => Date.now())
   useEffect(() => {
     const id = setInterval(() => setTick(Date.now()), 5000)
@@ -28,21 +26,6 @@ const ActiveEmbedJobs = ({ withHeader = false }: ActiveEmbedJobsProps) => {
     <>
       {withHeader && (
         <StyledSectionHeader title="Processing Queue" className="mt-12 mb-4" />
-      )}
-
-      {/* Refresh row — only shown when at least one job exists so the empty
-          state stays clean. */}
-      {jobs && jobs.length > 0 && (
-        <div className="flex items-center justify-between mb-3 text-sm">
-          <span className="text-text-muted">
-            {dataUpdatedAt > 0
-              ? `Last updated ${formatTimeAgo(dataUpdatedAt, tick)}`
-              : 'Loading…'}
-          </span>
-          <StyledButton variant="ghost" size="sm" icon="IconRefresh" onClick={invalidate}>
-            Refresh
-          </StyledButton>
-        </div>
       )}
 
       <div className="space-y-4">


### PR DESCRIPTION
## Summary

The Processing Queue's manual **Refresh** button (introduced in #893) is redundant. `useEmbedJobs` already:

- Polls `/api/rag/active-jobs` every **2s** while jobs are active, every **30s** when idle (`useEmbedJobs.ts:12-16`)
- Auto-invalidates `storedFiles` when the queue drains to zero (`useEmbedJobs.ts:21-27`)

So clicking Refresh doesn't change anything the auto-polling wasn't already going to do in the next 2 seconds. Reported via UAT — the button confuses users who click it and see no visible effect.

Per-job **"last activity Xs ago"** chips remain as the live-recency indicator, which is more meaningful than a generic "Last updated" line because it reflects actual embedding activity per file.

## Diff

- Drop the entire Refresh row (button + "Last updated" text)
- Drop now-unused `invalidate` and `dataUpdatedAt` from the `useEmbedJobs` destructure
- Drop the `StyledButton` import that only this row used
- Tighten the kept `tick` comment to reflect what it's actually for now

## Stacks on #893

Base is `feat/kb-job-status-pill` because the Refresh button only exists in #893's diff. Once #893 merges to `rc`, GitHub will auto-rebase this PR to target `rc`. Both can land in rc.5.

## Test plan

- [x] `npm run typecheck` clean
- [ ] Visual confirm in NOMAD3 after rc.5 build: Processing Queue card has no Refresh button or "Last updated" line; per-job pills still show "last activity Xs ago"

🤖 Generated with [Claude Code](https://claude.com/claude-code)