### PR TITLE
fix(KB): union Stored Files list with state-machine file paths (I1)

### DIFF
--- a/admin/app/services/rag_service.ts
+++ b/admin/app/services/rag_service.ts
@@ -1082,6 +1082,28 @@ export class RagService {
         offset = scrollResult.next_page_offset || null
       } while (offset !== null)
 
+      // Union the Qdrant-derived list with the disk-backed file paths the
+      // state machine has tracked. Without this, files known to the scanner
+      // but with zero embedded chunks (video-only ZIMs, failed-before-first-
+      // chunk ingestions, browse_only opt-outs) never get a row in Stored
+      // Files — which means warnings keyed off those files (#895 zero_chunks
+      // in particular) have no row to attach to. The state machine is the
+      // authoritative "what's on disk?" view; Qdrant is "what made it into
+      // the vector store?". Both are needed to render the KB UI honestly.
+      try {
+        const stateRows = await KbIngestState.query().select('file_path')
+        for (const row of stateRows) {
+          sources.add(row.file_path)
+        }
+      } catch (error) {
+        // Non-fatal: if the state machine query fails for any reason we'd
+        // rather return the Qdrant-derived list than 500 the whole panel.
+        logger.warn(
+          { err: error },
+          '[RagService.getStoredFiles] state-machine union skipped; returning Qdrant-only list'
+        )
+      }
+
       return Array.from(sources)
     } catch (error) {
       logger.error('Error retrieving stored files:', error)


### PR DESCRIPTION
## Summary

Closes the "zero_chunks warning has no row to attach to" gap surfaced by tonight's integration test of the RFC #883 PR batch. After tonight's PRs land, the KB modal can compute two warning kinds: \`partial_stall\` (file embedded but fell short of expected chunks) and \`zero_chunks\` (file produced no chunks at all). \`partial_stall\` works end-to-end — verified on NOMAD3, the \`Survival-and-Austere-Medicine.pdf\` row shows the amber chip. \`zero_chunks\` was structurally unreachable because the files that trigger it never appear in the Stored Files table.

## Root cause

\`RagService.getStoredFiles()\` derives the list by scrolling Qdrant for unique \`payload.source\` values:

\`\`\`ts
const sources = new Set<string>()
do {
  const scrollResult = await this.qdrant.scroll(...)
  scrollResult.points.forEach((point) => {
    if (point.payload?.source) sources.add(point.payload.source)
  })
  ...
} while (offset !== null)
return Array.from(sources)
\`\`\`

A file with 0 chunks in Qdrant has 0 points — so no \`source\` value to add — so it's invisible to the panel. \`lrnselfreliance_en_all_2025-12.zim\` (3.97 GB, video-only) is the canonical example: \`/api/rag/file-warnings\` correctly returns a \`zero_chunks\` warning for it, but the warning has no row to render against.

This was always the right behavior pre-#888 (no state machine, no concept of "known but unindexed"). With #888 in flight, the state machine is now the authoritative "what's on disk?" view; Qdrant remains "what made it into the vector store?". The KB panel needs both.

## Fix

After the Qdrant scroll loop in \`getStoredFiles()\`, union the result with the disk-backed file paths from \`kb_ingest_state\` (#888's table). +22 lines, one file. The state-machine query is wrapped in its own try/catch so a transient DB error degrades to the Qdrant-only list rather than 500-ing the whole panel.

## Effect

- **\`lrnselfreliance_en_all_2025-12.zim\` now appears** in the Stored Files table → picks up its \`zero_chunks\` warning chip ("Embedded 0 chunks — this file has no text content. AI Assistant cannot reference it.")
- Files in \`pending_decision\` under Manual policy show up so the user can see what's waiting for opt-in (preparation for per-card opt-in actions blocked on #886)
- Files in \`browse_only\` and \`failed\` states have a row for the future per-card Retry / Re-index buttons

## Stacks on #888

Base is \`feat/kb-ingest-state-machine\` because the union depends on \`KbIngestState\` which #888 introduces. GitHub auto-rebases to \`rc\` once #888 merges. Functionally pairs with #895 (warning rendering) to complete the warning UX in v1.32.0 GA.

## Test plan

- [x] \`npm run typecheck\` clean
- [ ] After rc.5 build:
  - [ ] Visual: \`/api/rag/files\` on NOMAD3 includes \`lrnselfreliance_en_all_2025-12.zim\` (currently returns the file only when chunks exist)
  - [ ] Visual: KB modal → Stored Files row for \`lrnselfreliance\` shows the amber \`zero_chunks\` warning chip
  - [ ] Negative: no spurious rows for files that aren't on disk (the state machine only writes rows for files the scanner has actually seen, but worth confirming on a clean install)

## Side note

The Qdrant scroll path is preserved unchanged — files that have chunks but no state-machine row (legacy data from before #888) still surface correctly. Net effect is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)