### PR TITLE
feat(KB): wizard AI policy step (RFC #883 Phase 3 task 13)

### DIFF
--- a/admin/inertia/pages/easy-setup/index.tsx
+++ b/admin/inertia/pages/easy-setup/index.tsx
@@ -122,6 +122,13 @@ export default function EasySetupWizard(props: {
   const [selectedServices, setSelectedServices] = useState<string[]>([])
   const [selectedMapCollections, setSelectedMapCollections] = useState<string[]>([])
   const [selectedAiModels, setSelectedAiModels] = useState<string[]>([])
+  // Auto-index policy for the AI Assistant Knowledge Base. Defaults to
+  // 'Always' so a new user who keeps the default behavior gets the "just
+  // works" experience — downloads become searchable automatically. Persisted
+  // to KVStore['rag.defaultIngestPolicy'] on wizard submit (same key #894's
+  // KB modal toggle reads/writes) so the JIT prompt at first chat sees a
+  // decided policy and doesn't ask again.
+  const [ingestPolicy, setIngestPolicy] = useState<'Always' | 'Manual'>('Always')
   const [isProcessing, setIsProcessing] = useState(false)
   const [showAdditionalTools, setShowAdditionalTools] = useState(false)
   const [remoteOllamaEnabled, setRemoteOllamaEnabled] = useState(
@@ -338,6 +345,23 @@ export default function EasySetupWizard(props: {
     setIsProcessing(true)
 
     try {
+      // Persist the auto-index policy choice before kicking off downloads so
+      // any content that finishes during this same wizard run sees the right
+      // policy. Skipped when the user did not select the AI capability — the
+      // KV stays null and the first-chat JIT prompt (#899) handles the
+      // decision later if/when the user enables AI.
+      const aiSelected =
+        selectedServices.includes(SERVICE_NAMES.OLLAMA) ||
+        installedServices.some((s) => s.service_name === SERVICE_NAMES.OLLAMA)
+      if (aiSelected) {
+        try {
+          await api.updateSetting('rag.defaultIngestPolicy', ingestPolicy)
+        } catch (err) {
+          // Non-fatal: the user can still set the policy from the KB modal.
+          console.warn('Could not persist ingest policy from wizard:', err)
+        }
+      }
+
       // If using remote Ollama, configure it first before other installs
       if (remoteOllamaEnabled && remoteOllamaUrl) {
         const remoteResult = await api.configureRemoteOllama(remoteOllamaUrl)
@@ -921,6 +945,47 @@ export default function EasySetupWizard(props: {
                 <p className="text-text-secondary">No recommended AI models available at this time.</p>
               </div>
             )}
+
+            {/* Auto-index policy — choose now so the JIT prompt at first chat
+                doesn't ask again (RFC #883 Phase 3 task 13). Persisted to
+                rag.defaultIngestPolicy on wizard submit. */}
+            <div className="mt-8 pt-6 border-t border-border-subtle">
+              <h4 className="text-lg font-semibold text-text-primary mb-1">
+                Auto-index new content for {aiAssistantName}?
+              </h4>
+              <p className="text-sm text-text-muted mb-4">
+                When you add new ZIMs, documents, or curated content, should {aiAssistantName} index them automatically so it can search them while answering your questions?
+              </p>
+              <div className="inline-flex rounded-md border border-border-default overflow-hidden" role="group">
+                <button
+                  type="button"
+                  onClick={() => setIngestPolicy('Always')}
+                  className={classNames(
+                    'px-5 py-2 text-sm font-medium transition-colors',
+                    ingestPolicy === 'Always'
+                      ? 'bg-desert-green text-white'
+                      : 'bg-surface-primary text-text-secondary hover:bg-surface-secondary'
+                  )}
+                >
+                  Yes, always
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setIngestPolicy('Manual')}
+                  className={classNames(
+                    'px-5 py-2 text-sm font-medium transition-colors border-l border-border-default',
+                    ingestPolicy === 'Manual'
+                      ? 'bg-desert-green text-white'
+                      : 'bg-surface-primary text-text-secondary hover:bg-surface-secondary'
+                  )}
+                >
+                  Ask me first
+                </button>
+              </div>
+              <p className="text-xs text-text-muted mt-3">
+                You can change this any time from the Knowledge Base panel inside AI Chat.
+              </p>
+            </div>
           </div>
         )}
 
@@ -1154,6 +1219,25 @@ export default function EasySetupWizard(props: {
                     )
                   })}
                 </ul>
+              </div>
+            )}
+
+            {(selectedAiModels.length > 0 || remoteOllamaEnabled) && (
+              <div className="bg-surface-primary rounded-lg border-2 border-desert-stone-light p-6">
+                <h3 className="text-xl font-semibold text-text-primary mb-2">
+                  Auto-index Setting
+                </h3>
+                <p className="text-text-secondary text-sm">
+                  {ingestPolicy === 'Always' ? (
+                    <>
+                      New content will be <strong>indexed automatically</strong> as it arrives so {aiAssistantName} can search it.
+                    </>
+                  ) : (
+                    <>
+                      New content will <strong>wait for you to opt in</strong> from the Knowledge Base panel before {aiAssistantName} indexes it.
+                    </>
+                  )}
+                </p>
               </div>
             )}
 


### PR DESCRIPTION
## Summary

Adds an inline auto-index policy choice inside the Easy Setup wizard's existing AI section (Step 3 \"Content\"). Persisted to \`KVStore['rag.defaultIngestPolicy']\` on wizard submit — same key #894's KB modal toggle reads/writes — so a user who completes the wizard never sees the first-chat JIT prompt (#899) because their decision is already on record.

## Why now

Tonight's PRs (#894 policy toggle + #899 JIT prompt) cover the two main paths users currently land on a policy decision: the KB modal toggle (for users already poking around the AI panel) and the first-chat banner (for everyone else, on opening AI Chat). The wizard is the *third* path — and it's the one new users actually go through. Asking the question there means we never have to ask it again.

## UI

**Step 3 (Content)** — below the AI Models grid (only when AI is selected):

> **Auto-index new content for AI Assistant?**  
> When you add new ZIMs, documents, or curated content, should AI Assistant index them automatically so it can search them while answering your questions?  
> [ Yes, always ] [ Ask me first ]  
> *You can change this any time from the Knowledge Base panel inside AI Chat.*

Two-button radio matches #894's KB-modal toggle pattern for visual consistency.

**Step 4 (Review)** — new \"Auto-index Setting\" summary card:

> New content will be **indexed automatically** as it arrives so AI Assistant can search it.

(or \"…wait for you to opt in from the Knowledge Base panel…\" when Manual).

## Default

\`'Always'\`. New users who keep the default get the \"just works\" experience — content downloaded by the wizard becomes searchable as soon as it finishes embedding. Users who prefer explicit opt-in flip to Manual before submitting. Either way the decision sticks.

## Skipped when AI isn't selected

If the user doesn't pick the AI capability in Step 1, the radio doesn't appear in Step 3, the summary card doesn't appear in Step 4, and \`rag.defaultIngestPolicy\` stays null. The JIT prompt (#899) then handles the decision later if/when they enable AI from Settings. No silent policy lock-in for users who opted out of AI.

## handleFinish change

A new \`api.updateSetting('rag.defaultIngestPolicy', ingestPolicy)\` call runs FIRST in the finish flow, before service installs / downloads, so any content that finishes embedding during this same wizard run sees the right policy from the start. Wrapped in its own try/catch — a transient KV write failure doesn't abort the rest of the wizard.

## Stacks on #894

Base is \`feat/kb-policy-toggle\` because the policy KV mechanism this PR writes through is introduced there. Auto-rebases to \`rc\` when #894 merges.

## Pairs with #899

Wizard users decide in the wizard; non-wizard users (existing v1.31.x upgrades, users who skipped the wizard, etc.) decide at first chat. Together they cover every entry path to v1.32.0 without double-prompting.

## Test plan

- [x] \`npm run typecheck\` clean
- [ ] After rc.5 build:
  - [ ] Walk wizard with AI selected → radio appears in Step 3 with \"Always\" pre-selected
  - [ ] Toggle to \"Ask me first\" → Step 4 Review shows \"wait for you to opt in\" copy
  - [ ] Complete wizard → \`GET /api/system/settings?key=rag.defaultIngestPolicy\` returns the chosen value
  - [ ] Visit /chat → JIT banner does NOT appear (policy is set)
  - [ ] Walk wizard WITHOUT AI selected → no policy UI in Step 3 or Step 4
  - [ ] Complete wizard without AI → KV still null → enable AI later from Settings → JIT banner appears on next /chat visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)