### PR TITLE
fix(KB): blank-screen on panel open + tooltips on bulk-action buttons

### DIFF
--- a/admin/inertia/components/chat/KnowledgeBaseModal.tsx
+++ b/admin/inertia/components/chat/KnowledgeBaseModal.tsx
@@ -420,6 +420,7 @@ export default function KnowledgeBaseModal({ aiAssistantName = "AI Assistant", o
                   onClick={() => { setResetTyped(''); setBulkMode('reset') }}
                   disabled={isUploading || qdrantOffline || bulkBusy}
                   loading={resetMutation.isPending}
+                  title="Drop the entire embeddings collection and re-embed everything from scratch. Permanently removes vectors for files no longer on disk. Destructive: requires typing RESET to confirm."
                 >
                   Reset & Rebuild
                 </StyledButton>
@@ -430,6 +431,7 @@ export default function KnowledgeBaseModal({ aiAssistantName = "AI Assistant", o
                   onClick={() => setBulkMode('reembed')}
                   disabled={isUploading || qdrantOffline || bulkBusy || storedFiles.length === 0}
                   loading={reembedMutation.isPending}
+                  title="Re-embed every file on disk, replacing existing vectors file-by-file. Vectors for files no longer on disk are preserved. Use this if the chunker or embedding model has changed."
                 >
                   Re-embed All
                 </StyledButton>
@@ -440,6 +442,7 @@ export default function KnowledgeBaseModal({ aiAssistantName = "AI Assistant", o
                   onClick={handleConfirmSync}
                   disabled={syncMutation.isPending || isUploading || qdrantOffline || bulkBusy}
                   loading={syncMutation.isPending || isUploading}
+                  title="Scan storage for new files and queue any that haven't been embedded yet. Safe to run anytime; won't touch already-embedded content."
                 >
                   Sync Storage
                 </StyledButton>
@@ -454,7 +457,7 @@ export default function KnowledgeBaseModal({ aiAssistantName = "AI Assistant", o
                 </span>
               </div>
             )}
-            <StyledTable<{ source: string }>
+            <StyledTable<KbFileGroup>
               className="font-semibold"
               rowLines={true}
               columns={[
@@ -466,7 +469,7 @@ export default function KnowledgeBaseModal({ aiAssistantName = "AI Assistant", o
                     return (
                       <div className="flex flex-col gap-1">
                         <span className="text-text-primary">
-                          {sourceToDisplayName(record.source)}
+                          {record.displayName}
                         </span>
                         {warnings.map((w, i) => (
                           <span


### PR DESCRIPTION
## Summary

- Restore `KbFileGroup` as the StyledTable generic and render `record.displayName` instead of calling the unimported `sourceToDisplayName`. Fixes a `ReferenceError` that unmounts the entire React tree the first time a user opens the Knowledge Base panel on v1.32.0-rc.5.
- Add `title` attributes on the three bulk-action buttons (Reset & Rebuild, Re-embed All, Sync Storage) so users can hover to learn the difference in destructiveness.

## Repro (rc.5, NOMAD2 and NOMAD3)

1. AI → Knowledge Base panel.
2. Spinner shows on Stored Knowledge Base Files.
3. After ~20 sec (NOMAD3, 15 files) or almost immediately (NOMAD2, only admin docs), the entire chat screen goes blank.
4. Console: `ReferenceError: sourceToDisplayName is not defined at ...StyledTable.../Array.map`.

## Root cause

- **PR #892** extracted the local `sourceToDisplayName` into `lib/kb_file_grouping.ts` and switched the render to `record.displayName` (KbFileGroup carries the precomputed name).
- **PR #895** rewrote the column render() to add the `fileWarnings[record.source]` lookup. In the process, it changed the display call back to `sourceToDisplayName(record.source)` but didn't re-add the import.
- **PR #895 review fix (cbae48a)** narrowed the StyledTable generic from `KbFileGroup` to `{source: string}`, which hid the type drift from the inertia tsconfig. The Vite build doesn't fail on unresolved identifiers, so it shipped.

Why TypeScript didn't catch it pre-merge: the pre-push hook runs `tsc --noEmit` against the backend tsconfig (`admin/tsconfig.json`), which `exclude`s `inertia/**`. The frontend tsconfig (`admin/inertia/tsconfig.json`) does flag both the missing reference and the unused `KbFileGroup` import, but nothing runs it on push. Tracking that gap as a follow-up; addressing it would have caught this before the rc cut.

## Fix

```ts
// Before
<StyledTable<{ source: string }>
  ...
  {sourceToDisplayName(record.source)}

// After
<StyledTable<KbFileGroup>
  ...
  {record.displayName}
```

`record.displayName` is what PR #892 designed the row shape around. It also correctly handles the collapsed admin-docs row, whose `source` is the synthetic `__admin_docs_group__` marker that `sourceToDisplayName` would have rendered as literal text.

## Tooltips

Native HTML `title` attribute via StyledButton's prop pass-through (no new dependency). Wording:

- **Reset & Rebuild**: "Drop the entire embeddings collection and re-embed everything from scratch. Permanently removes vectors for files no longer on disk. Destructive: requires typing RESET to confirm."
- **Re-embed All**: "Re-embed every file on disk, replacing existing vectors file-by-file. Vectors for files no longer on disk are preserved. Use this if the chunker or embedding model has changed."
- **Sync Storage**: "Scan storage for new files and queue any that haven't been embedded yet. Safe to run anytime; won't touch already-embedded content."

## Verification

- Reproduced on NOMAD2 (rc.5) and NOMAD3 (rc.5) via Playwright; console error captured.
- After fix: inertia tsconfig clean for KnowledgeBaseModal.tsx (the three errors at lines 11, 469, 503 are resolved); 64 unrelated pre-existing errors elsewhere in inertia/** remain untouched.
- Backend `npm run typecheck` clean.
- Local unit tests can't run on Windows due to the libzim native binding (pre-existing); CI will run them on the PR.

## Test plan

- [ ] CI passes.
- [ ] On a rebuilt rc.6 image, open AI → Knowledge Base on an install with KB content (NOMAD3) and one without (NOMAD2). Both should render the Stored Files table cleanly, not blank.
- [ ] Hover each of the three bulk-action buttons and confirm the OS tooltip appears with the wording above.
- [ ] Admin-docs collapsed row renders as "Project NOMAD documentation · N files" (not as the literal `__admin_docs_group__`).

## Disposition

GA blocker for v1.32.0. The KB panel is core to RFC #883 and currently unusable on every install. Recommend rc.6 cut to ship this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)