### PR TITLE
feat(chat): confirm-on-switch + one-chat-model-at-a-time enforcement

### DIFF
--- a/admin/app/controllers/ollama_controller.ts
+++ b/admin/app/controllers/ollama_controller.ts
@@ -5,7 +5,7 @@ import { RagService } from '#services/rag_service'
 import Service from '#models/service'
 import KVStore from '#models/kv_store'
 import { modelNameSchema } from '#validators/download'
-import { chatSchema, getAvailableModelsSchema } from '#validators/ollama'
+import { chatSchema, getAvailableModelsSchema, unloadChatModelsSchema } from '#validators/ollama'
 import { inject } from '@adonisjs/core'
 import type { HttpContext } from '@adonisjs/core/http'
 import { RAG_CONTEXT_LIMITS, SYSTEM_PROMPTS } from '../../constants/ollama.js'
@@ -31,6 +31,19 @@ export default class OllamaController {
       limit: reqData.limit || 15,
       force: reqData.force,
     })
+  }
+
+  /**
+   * Send Ollama `keep_alive: 0` hints to every currently-loaded chat model
+   * except the embedding model and (optionally) a target model to preserve.
+   * Used by the chat UI to enforce the "one chat model at a time" invariant
+   * on model-switch, session-switch, and page-load. Best-effort: a failure
+   * here should not block the calling flow.
+   */
+  async unloadChatModels({ request, response }: HttpContext) {
+    const { targetModel } = await request.validateUsing(unloadChatModelsSchema)
+    const unloaded = await this.ollamaService.unloadAllChatModelsExcept(targetModel ?? null)
+    return response.status(200).json({ unloaded })
   }
 
   async chat({ request, response }: HttpContext) {

--- a/admin/app/services/ollama_service.ts
+++ b/admin/app/services/ollama_service.ts
@@ -3,7 +3,7 @@ import OpenAI from 'openai'
 import type { ChatCompletionChunk, ChatCompletionMessageParam } from 'openai/resources/chat/completions.js'
 import type { Stream } from 'openai/streaming.js'
 import { NomadOllamaModel } from '../../types/ollama.js'
-import { FALLBACK_RECOMMENDED_OLLAMA_MODELS } from '../../constants/ollama.js'
+import { EMBEDDING_MODEL_NAME, FALLBACK_RECOMMENDED_OLLAMA_MODELS } from '../../constants/ollama.js'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import logger from '@adonisjs/core/services/logger'
@@ -595,13 +595,6 @@ export class OllamaService {
   }
 
   /**
-   * Embedding model name exempt from the chat-model unload sweep. Hardcoded
-   * to avoid a circular import with `RagService.EMBEDDING_MODEL`; keep in
-   * sync with that constant if it ever changes.
-   */
-  private static readonly EMBEDDING_MODEL_EXEMPT = 'nomic-embed-text:v1.5'
-
-  /**
    * Enforces the "at most one chat model resident in VRAM" invariant by firing
    * `keep_alive: 0` against every currently-loaded model except (a) the
    * embedding model (always exempt) and (b) `targetModel` (the one we want
@@ -641,7 +634,7 @@ export class OllamaService {
     }
 
     const toUnload = loadedModels.filter(
-      (name) => name !== OllamaService.EMBEDDING_MODEL_EXEMPT && name !== targetModel
+      (name) => name !== EMBEDDING_MODEL_NAME && name !== targetModel
     )
 
     await Promise.all(

--- a/admin/app/services/ollama_service.ts
+++ b/admin/app/services/ollama_service.ts
@@ -594,6 +594,80 @@ export class OllamaService {
     }
   }
 
+  /**
+   * Embedding model name exempt from the chat-model unload sweep. Hardcoded
+   * to avoid a circular import with `RagService.EMBEDDING_MODEL`; keep in
+   * sync with that constant if it ever changes.
+   */
+  private static readonly EMBEDDING_MODEL_EXEMPT = 'nomic-embed-text:v1.5'
+
+  /**
+   * Enforces the "at most one chat model resident in VRAM" invariant by firing
+   * `keep_alive: 0` against every currently-loaded model except (a) the
+   * embedding model (always exempt) and (b) `targetModel` (the one we want
+   * loaded next — leaving it alone preserves a hot model when the target is
+   * already loaded).
+   *
+   * Best-effort: queries `/api/ps` and POSTs unload hints in parallel. Network
+   * or Ollama errors are swallowed and logged — neither chat nor page-load
+   * should fail just because the unload housekeeping didn't go through.
+   *
+   * Returns the list of model names that were sent the unload hint, so the
+   * caller (and tests) can confirm what actually happened.
+   *
+   * Pass `targetModel: null` to unload every chat model (used for the future
+   * "free up VRAM" path; not exposed yet but the helper supports it).
+   *
+   * Note that `keep_alive: 0` is a post-completion hint, not a force-kill —
+   * Ollama defers eviction until the runner is idle, so in-flight inference
+   * on the same model is never interrupted. See the design doc for the race
+   * analysis behind this.
+   */
+  public async unloadAllChatModelsExcept(targetModel: string | null): Promise<string[]> {
+    await this._ensureDependencies()
+    if (!this.baseUrl) return []
+
+    let loadedModels: string[] = []
+    try {
+      const response = await axios.get(`${this.baseUrl}/api/ps`, { timeout: 5000 })
+      loadedModels = (response.data?.models ?? [])
+        .map((m: { name?: string }) => m.name)
+        .filter((name: unknown): name is string => typeof name === 'string')
+    } catch (err: any) {
+      logger.warn(
+        `[OllamaService] unloadAllChatModelsExcept: /api/ps unreachable, skipping unload sweep: ${err?.message ?? err}`
+      )
+      return []
+    }
+
+    const toUnload = loadedModels.filter(
+      (name) => name !== OllamaService.EMBEDDING_MODEL_EXEMPT && name !== targetModel
+    )
+
+    await Promise.all(
+      toUnload.map(async (modelName) => {
+        try {
+          await axios.post(
+            `${this.baseUrl}/api/generate`,
+            { model: modelName, prompt: '', keep_alive: 0 },
+            { timeout: 10000 }
+          )
+        } catch (err: any) {
+          logger.warn(
+            `[OllamaService] Failed to send unload hint for ${modelName}: ${err?.message ?? err}`
+          )
+        }
+      })
+    )
+
+    if (toUnload.length > 0) {
+      logger.info(
+        `[OllamaService] Sent unload hint for ${toUnload.length} chat model(s): ${toUnload.join(', ')}`
+      )
+    }
+    return toUnload
+  }
+
   public async getModels(includeEmbeddings = false): Promise<NomadInstalledModel[]> {
     await this._ensureDependencies()
     if (!this.baseUrl) {

--- a/admin/app/services/rag_service.ts
+++ b/admin/app/services/rag_service.ts
@@ -24,6 +24,7 @@ import type { FileWarning, FileWarningsResult, StoredFileInfo } from '../../type
 import type { KbIngestStateValue } from '../../types/kb_ingest_state.js'
 import { ZIMExtractionService } from './zim_extraction_service.js'
 import { ZIM_BATCH_SIZE } from '../../constants/zim_extraction.js'
+import { EMBEDDING_MODEL_NAME } from '../../constants/ollama.js'
 import { ProcessAndEmbedFileResponse, ProcessZIMFileResponse, RAGResult, RerankedRAGResult } from '../../types/rag.js'
 
 export type EmbedSingleFileFailureCode =
@@ -44,7 +45,6 @@ export class RagService {
   private resolvedEmbeddingModel: string | null = null
   public static UPLOADS_STORAGE_PATH = 'storage/kb_uploads'
   public static CONTENT_COLLECTION_NAME = 'nomad_knowledge_base'
-  public static EMBEDDING_MODEL = 'nomic-embed-text:v1.5'
   public static EMBEDDING_DIMENSION = 768 // Nomic Embed Text v1.5 dimension is 768
   public static MODEL_CONTEXT_LENGTH = 2048 // nomic-embed-text has 2K token context
   public static MAX_SAFE_TOKENS = 1600 // Leave buffer for prefix and tokenization variance
@@ -286,25 +286,25 @@ export class RagService {
       if (!this.embeddingModelVerified) {
         const allModels = await this.ollamaService.getModels(true)
         const embeddingModel =
-          allModels.find((model) => model.name === RagService.EMBEDDING_MODEL) ??
+          allModels.find((model) => model.name === EMBEDDING_MODEL_NAME) ??
           allModels.find((model) => model.name.toLowerCase().includes('nomic-embed-text'))
 
         if (!embeddingModel) {
           try {
-            const downloadResult = await this.ollamaService.downloadModel(RagService.EMBEDDING_MODEL)
+            const downloadResult = await this.ollamaService.downloadModel(EMBEDDING_MODEL_NAME)
             if (!downloadResult.success) {
               throw new Error(downloadResult.message || 'Unknown error during model download')
             }
           } catch (modelError) {
             logger.error(
-              `[RAG] Embedding model ${RagService.EMBEDDING_MODEL} not found locally and failed to download:`,
+              `[RAG] Embedding model ${EMBEDDING_MODEL_NAME} not found locally and failed to download:`,
               modelError
             )
             this.embeddingModelVerified = false
             return null
           }
         }
-        this.resolvedEmbeddingModel = embeddingModel?.name ?? RagService.EMBEDDING_MODEL
+        this.resolvedEmbeddingModel = embeddingModel?.name ?? EMBEDDING_MODEL_NAME
         this.embeddingModelVerified = true
       }
 
@@ -361,7 +361,7 @@ export class RagService {
 
         logger.debug(`[RAG] Embedding batch ${batchIdx + 1}/${totalBatches} (${batch.length} chunks)`)
 
-        const response = await this.ollamaService.embed(this.resolvedEmbeddingModel ?? RagService.EMBEDDING_MODEL, batch)
+        const response = await this.ollamaService.embed(this.resolvedEmbeddingModel ?? EMBEDDING_MODEL_NAME, batch)
 
         embeddings.push(...response.embeddings)
 
@@ -818,12 +818,12 @@ export class RagService {
       if (!this.embeddingModelVerified) {
         const allModels = await this.ollamaService.getModels(true)
         const embeddingModel =
-          allModels.find((model) => model.name === RagService.EMBEDDING_MODEL) ??
+          allModels.find((model) => model.name === EMBEDDING_MODEL_NAME) ??
           allModels.find((model) => model.name.toLowerCase().includes('nomic-embed-text'))
 
         if (!embeddingModel) {
           logger.warn(
-            `[RAG] ${RagService.EMBEDDING_MODEL} not found. Cannot perform similarity search.`
+            `[RAG] ${EMBEDDING_MODEL_NAME} not found. Cannot perform similarity search.`
           )
           this.embeddingModelVerified = false
           return []
@@ -855,7 +855,7 @@ export class RagService {
         return []
       }
 
-      const response = await this.ollamaService.embed(this.resolvedEmbeddingModel ?? RagService.EMBEDDING_MODEL, [prefixedQuery])
+      const response = await this.ollamaService.embed(this.resolvedEmbeddingModel ?? EMBEDDING_MODEL_NAME, [prefixedQuery])
 
       // Perform semantic search with a higher limit to enable reranking
       const searchLimit = limit * 3 // Get more results for reranking

--- a/admin/app/validators/ollama.ts
+++ b/admin/app/validators/ollama.ts
@@ -14,6 +14,12 @@ export const chatSchema = vine.compile(
   })
 )
 
+export const unloadChatModelsSchema = vine.compile(
+  vine.object({
+    targetModel: vine.string().trim().minLength(1).nullable().optional(),
+  })
+)
+
 export const getAvailableModelsSchema = vine.compile(
   vine.object({
     sort: vine.enum(['pulls', 'name'] as const).optional(),

--- a/admin/constants/ollama.ts
+++ b/admin/constants/ollama.ts
@@ -64,6 +64,8 @@ export const FALLBACK_RECOMMENDED_OLLAMA_MODELS: NomadOllamaModel[] = [
 
 export const DEFAULT_QUERY_REWRITE_MODEL = 'qwen2.5:3b' // default to qwen2.5 for query rewriting with good balance of text task performance and resource usage
 
+export const EMBEDDING_MODEL_NAME = 'nomic-embed-text:v1.5'
+
 /**
  * Adaptive RAG context limits based on model size.
  * Smaller models get overwhelmed with too much context, so we cap it.

--- a/admin/inertia/components/chat/index.tsx
+++ b/admin/inertia/components/chat/index.tsx
@@ -33,6 +33,8 @@ export default function Chat({
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [selectedModel, setSelectedModel] = useState<string>('')
+  const [pendingModelSwitch, setPendingModelSwitch] = useState<string | null>(null)
+  const pageLoadNormalizedRef = useRef(false)
   const [isStreamingResponse, setIsStreamingResponse] = useState(false)
   const streamAbortRef = useRef<AbortController | null>(null)
 
@@ -151,6 +153,62 @@ export default function Chat({
     }
   }, [selectedModel])
 
+  // Page-load normalization: enforce the "one chat model at a time" invariant
+  // when the chat page first mounts. Anything stacked from a prior session
+  // gets `keep_alive: 0` so it can be evicted; the embedding model is exempt
+  // server-side. We wait for `selectedModel` to be populated by the
+  // first-installed / lastModel effect so the request has a target to preserve.
+  useEffect(() => {
+    if (!enabled) return
+    if (!selectedModel) return
+    if (pageLoadNormalizedRef.current) return
+    pageLoadNormalizedRef.current = true
+    api.unloadChatModels(selectedModel).catch((err) => {
+      console.warn('Failed to normalize loaded models on chat-page mount:', err)
+    })
+  }, [enabled, selectedModel])
+
+  const handleUserSelectedModel = useCallback(
+    (newModel: string) => {
+      if (newModel === selectedModel) return
+      // No active chat session yet → no conversation to lose, no popup needed.
+      // Just update the dropdown silently; the next "New Chat" will use it.
+      if (!activeSessionId) {
+        setSelectedModel(newModel)
+        return
+      }
+      // Active session: defer the actual model swap until the user confirms.
+      // Setting `pendingModelSwitch` drives the dropdown's effective value
+      // *and* opens the confirm modal — clearing it on cancel reverts the
+      // visible selection without us having to touch `selectedModel`.
+      setPendingModelSwitch(newModel)
+    },
+    [selectedModel, activeSessionId]
+  )
+
+  const handleConfirmModelSwitch = useCallback(async () => {
+    const newModel = pendingModelSwitch
+    if (!newModel) return
+    // Best-effort unload of the previously-active chat model. Fire-and-forget:
+    // Ollama queues the eviction until the runner is idle, so an in-flight
+    // request on the old model finishes cleanly. We don't await this before
+    // clearing the session — UI responsiveness wins over housekeeping.
+    api.unloadChatModels(newModel).catch((err) => {
+      console.warn('Failed to unload previous chat model:', err)
+    })
+    setSelectedModel(newModel)
+    setPendingModelSwitch(null)
+    // Clear the active session and messages — the next user message will
+    // lazily create a new session via the existing handleSendMessage path,
+    // which already calls api.createChatSession with `selectedModel`.
+    setActiveSessionId(null)
+    setMessages([])
+  }, [pendingModelSwitch])
+
+  const handleCancelModelSwitch = useCallback(() => {
+    setPendingModelSwitch(null)
+  }, [])
+
   const handleNewChat = useCallback(() => {
     // Just clear the active session and messages - don't create a session yet
     setActiveSessionId(null)
@@ -202,8 +260,19 @@ export default function Chat({
       if (sessionData?.model) {
         setSelectedModel(sessionData.model)
       }
+
+      // Enforce the one-chat-model-at-a-time invariant: ask the backend to
+      // unload anything that isn't the target session's model. Fire-and-forget;
+      // this is housekeeping. Note we pass the *session's* model here rather
+      // than reading `selectedModel`, because setSelectedModel above is async
+      // and the effect-driven page-load normalize wouldn't catch a sidebar
+      // click after the first render.
+      const targetModel = sessionData?.model ?? selectedModel ?? null
+      api.unloadChatModels(targetModel).catch((err) => {
+        console.warn('Failed to unload non-target chat models on session switch:', err)
+      })
     },
-    [installedModels, queryClient]
+    [installedModels, queryClient, selectedModel]
   )
 
   const handleSendMessage = useCallback(
@@ -352,6 +421,23 @@ export default function Chat({
   )
 
   return (
+    <>
+    {pendingModelSwitch && (
+      <StyledModal
+        title={`Switch to ${pendingModelSwitch}?`}
+        onConfirm={handleConfirmModelSwitch}
+        onCancel={handleCancelModelSwitch}
+        open={true}
+        confirmText="Switch & New Chat"
+        cancelText="Cancel"
+        confirmVariant="primary"
+      >
+        <p className="text-text-primary">
+          Switching to <strong>{pendingModelSwitch}</strong> will start a new chat. Your current
+          conversation stays available in the sidebar.
+        </p>
+      </StyledModal>
+    )}
     <div
       className={classNames(
         'flex border border-border-subtle overflow-hidden shadow-sm w-full',
@@ -396,8 +482,8 @@ export default function Chat({
               ) : (
                 <select
                   id="model-select"
-                  value={selectedModel}
-                  onChange={(e) => setSelectedModel(e.target.value)}
+                  value={pendingModelSwitch ?? selectedModel}
+                  onChange={(e) => handleUserSelectedModel(e.target.value)}
                   className="px-3 py-1.5 border border-border-default rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-desert-green focus:border-transparent bg-surface-primary"
                 >
                   {installedModels.map((model) => (
@@ -433,5 +519,6 @@ export default function Chat({
         />
       </div>
     </div>
+    </>
   )
 }

--- a/admin/inertia/lib/api.ts
+++ b/admin/inertia/lib/api.ts
@@ -272,6 +272,24 @@ class API {
     })()
   }
 
+  /**
+   * Ask the backend to send Ollama `keep_alive: 0` to every currently-loaded
+   * chat model except `targetModel` (and the embedding model, which is always
+   * exempt server-side). Fire-and-forget — the chat UI doesn't await this
+   * before creating a new session, since unload is housekeeping.
+   *
+   * Pass `null` to unload every chat model.
+   */
+  async unloadChatModels(targetModel: string | null) {
+    return catchInternal(async () => {
+      const response = await this.client.post<{ unloaded: string[] }>(
+        '/ollama/unload-chat-models',
+        { targetModel }
+      )
+      return response.data
+    })()
+  }
+
   async getAvailableModels(params: { query?: string; recommendedOnly?: boolean; limit?: number; force?: boolean }) {
     return catchInternal(async () => {
       const response = await this.client.get<{

--- a/admin/start/routes.ts
+++ b/admin/start/routes.ts
@@ -118,6 +118,7 @@ router
     router.post('/models', [OllamaController, 'dispatchModelDownload'])
     router.delete('/models', [OllamaController, 'deleteModel'])
     router.get('/installed-models', [OllamaController, 'installedModels'])
+    router.post('/unload-chat-models', [OllamaController, 'unloadChatModels'])
     router.post('/configure-remote', [OllamaController, 'configureRemote'])
     router.get('/remote-status', [OllamaController, 'remoteStatus'])
   })


### PR DESCRIPTION
## Summary

Surfaces NOMAD's previously-silent model-stacking behavior and enforces a "one chat model in VRAM at a time" invariant (the embedding model is always exempt). Addresses the NOMAD3 testing observation that switching the dropdown in the chat header was invisibly slow on low-VRAM hardware because the prior model was never unloaded — Ollama would either evict it under memory pressure or load the new one on CPU after the runner choked.

## Behavior

Three integration points all funnel through one new helper:

- **User changes the model dropdown** in an active chat session → confirm modal *"Switch to {newModel}? Switching to {newModel} will start a new chat. Your current conversation stays available in the sidebar."* On confirm, fire `keep_alive: 0` against the previous chat model, clear active session, set the new selection. Cancel snaps the visible dropdown back to the previous value (no popup state leaks into `selectedModel`).
- **User clicks a session in the sidebar** → no popup (system-initiated). Restore the session's stored model into the dropdown and fire `unloadChatModels(targetModel)` so anything that isn't the target gets the unload hint.
- **Chat page first mount** → page-load normalization. Anything stacked from a prior session gets the unload hint with the current selected model as the target-to-preserve. Guarded by a ref so it only fires once per page lifetime.

Backend is a single new helper and a single new route:

- `OllamaService.unloadAllChatModelsExcept(targetModel: string | null)` queries `/api/ps`, filters out (a) the embedding model name (hardcoded `nomic-embed-text:v1.5` to avoid the RagService circular import) and (b) `targetModel`, then fires `POST /api/generate` with empty prompt + `keep_alive: 0` in parallel against everything else. Returns the names that were hinted. Best-effort: network or Ollama errors are logged and swallowed so callers don't fail on housekeeping.
- `POST /api/ollama/unload-chat-models` wraps it with a validator.

## In-flight inference safety

`keep_alive: 0` is a post-completion hint, not a force-kill. If Session A is mid-response on gemma when Session B fires the unload, gemma stays resident until A's request completes, then evicts. The user-visible worst case is the race where A's longer-running request re-extends the timer back to the default and the unload is no-op'd; the next transition (or page reload) gets another chance, and Ollama's own LRU catches up under memory pressure regardless. Robust in-flight tracking (counter of active streams per model) deferred to a follow-up if we see stale-state in the wild.

## What's NOT in this PR

- Auto-unload chat models before `EmbedFileJob` ingestion (separate concern, separate PR)
- "Free up VRAM" manual button on Models & Settings
- VRAM-usage display on chat header / Models & Settings
- Formal "default model" picker (the existing `chat.lastModel` persistence already covers this case implicitly)
- Dedicated unit / Playwright tests (will follow as a separate PR per established cadence)

## Coordination notes

Base `rc` rather than `dev`: `dev` is significantly behind `rc` (none of the RFC #883 / rc.6 work has been backmerged yet), so branching off `dev` would put the new code in a context missing two weeks of fixes. v1.40.0 will inherit everything from rc.6 via the eventual backmerge, so landing this on `rc` is the cleanest path.

## Test plan

- [ ] CI passes (backend tsc clean; existing inertia tsconfig errors are pre-existing, unrelated to this PR)
- [ ] Manual UAT once integration image lands on NOMAD3:
  - [ ] Open chat with model A loaded → switch dropdown to B → confirm modal appears with correct copy ("Switch to B? Switching to B will start a new chat...") → confirm → new chat created → `/api/ps` shows A unloaded
  - [ ] Same as above but click Cancel → dropdown reverts to A → original session intact → `/api/ps` unchanged
  - [ ] Open chat → click a sidebar session whose model differs from currently-loaded → dropdown updates silently (no popup) → `/api/ps` shows old model unloaded
  - [ ] Load chat page with two chat models stacked → page-load normalize fires once → `/api/ps` shows only the current session's model
  - [ ] With Session A streaming a long response on gemma, switch Session B's dropdown → confirm → Session A continues streaming normally (Ollama defers the eviction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)