### PR TITLE
fix(KB): respect Manual ingest policy on post-download dispatch

### DIFF
--- a/admin/app/jobs/run_download_job.ts
+++ b/admin/app/jobs/run_download_job.ts
@@ -147,13 +147,40 @@ export class RunDownloadJob {
               // Only dispatch embedding job if AI Assistant (Ollama) is installed
               const ollamaUrl = await dockerService.getServiceURL('nomad_ollama')
               if (ollamaUrl) {
-                try {
-                  await EmbedFileJob.dispatch({
-                    fileName: url.split('/').pop() || '',
-                    filePath: filepath,
-                  })
-                } catch (error) {
-                  console.error(`[RunDownloadJob] Error dispatching EmbedFileJob for URL ${url}:`, error)
+                // Respect the global ingest policy. Under Manual, record the file
+                // as pending_decision so the KB panel surfaces the per-file Index
+                // affordance (PR #909) instead of silently auto-embedding behind
+                // the user's back. Unset is treated as Always to preserve legacy
+                // behavior — mirrors rag_service.ts:1587-1588.
+                const { default: KVStore } = await import('#models/kv_store')
+                const { default: KbIngestState } = await import('#models/kb_ingest_state')
+                const policyRaw = await KVStore.getValue('rag.defaultIngestPolicy')
+                const policy: 'Always' | 'Manual' = policyRaw === 'Manual' ? 'Manual' : 'Always'
+
+                if (policy === 'Manual') {
+                  try {
+                    // firstOrCreate so a re-download doesn't demote an existing
+                    // indexed/failed row — user keeps prior state and can re-index
+                    // explicitly from the KB panel if they want fresh content.
+                    await KbIngestState.firstOrCreate(
+                      { file_path: filepath },
+                      { file_path: filepath, state: 'pending_decision', chunks_embedded: 0 }
+                    )
+                  } catch (error) {
+                    console.error(
+                      `[RunDownloadJob] Error recording pending_decision state for ${filepath}:`,
+                      error
+                    )
+                  }
+                } else {
+                  try {
+                    await EmbedFileJob.dispatch({
+                      fileName: url.split('/').pop() || '',
+                      filePath: filepath,
+                    })
+                  } catch (error) {
+                    console.error(`[RunDownloadJob] Error dispatching EmbedFileJob for URL ${url}:`, error)
+                  }
                 }
               }
             } else if (filetype === 'map') {


### PR DESCRIPTION
## Problem

Chris hit this on NOMAD3 (rc.6 + #917 + #918 integration build) immediately after PR #918's verification downloads:

> I have Auto-index new content for AI set to 'Manual' and yet everything that we just downloaded via the Content Explorer is queued for ingestion — why?

`rag.defaultIngestPolicy='Manual'` is honored by `RagService.scanAndSync` (`rag_service.ts:1587-1638` via `decideScanAction`'s `create_pending` branch), but the post-download auto-dispatch path in `run_download_job.ts:147-158` skips the gate entirely:

```ts
if (filetype === 'zim') {
  // ...
  const ollamaUrl = await dockerService.getServiceURL('nomad_ollama')
  if (ollamaUrl) {
    await EmbedFileJob.dispatch({ ... })   // unconditional
  }
}
```

Result: every newly-downloaded ZIM auto-embeds regardless of the user's Manual setting.

## Evidence

NOMAD3 KV: `rag.defaultIngestPolicy = 'Manual'`.

`kb_ingest_state` after today's PR #918 verification downloads (agriculture-essential, computing-essential, ~62 MB across 7 files):

| file | state |
|---|---|
| `based.cooking_en_all_2026-02.zim` | indexed |
| `freecodecamp_en_all_2026-02.zim` | indexed |
| `foss.cooking_en_all_2026-02.zim` | indexed |

All `indexed`, none `pending_decision`. The user's opt-out was silently overridden.

## Fix

At the dispatch site in `run_download_job.ts`, read `rag.defaultIngestPolicy` first. If `Manual`, `firstOrCreate` a `pending_decision` row in `kb_ingest_state` so the per-file Index affordance from PR #909 surfaces the file. Otherwise dispatch as before.

```ts
const policyRaw = await KVStore.getValue('rag.defaultIngestPolicy')
const policy: 'Always' | 'Manual' = policyRaw === 'Manual' ? 'Manual' : 'Always'

if (policy === 'Manual') {
  await KbIngestState.firstOrCreate(
    { file_path: filepath },
    { file_path: filepath, state: 'pending_decision', chunks_embedded: 0 }
  )
} else {
  await EmbedFileJob.dispatch({ ... })
}
```

`firstOrCreate` (not `create`) so a re-download doesn't demote an existing `indexed` / `failed` row — the user keeps prior state and can explicitly re-index from the KB panel if they want fresh content. Unset policy is treated as `Always` to preserve legacy behavior, mirroring `rag_service.ts:1587-1588`.

## Scope

One file, +34/-7. Touches only the post-ZIM-download branch — map downloads, model downloads, and the manual KB upload path are unaffected.

## Why this belongs in rc.6

User-facing correctness issue on a setting users explicitly opt into. Without this, the Manual toggle is misleading: it gates scan-time discovery but not post-download dispatch, so anyone who picks a tier in Content Explorer or Easy Setup gets auto-embedding regardless of their stated preference.

## Out of scope

- Re-download / file-update invalidation: if a ZIM is re-downloaded with new content, the existing `kb_ingest_state` row may show stale chunk counts. Separate concern, pre-existing in both Always and Manual paths — not introduced by this PR.
- The map/model auto-dispatch paths don't have an equivalent ingestion step today, so no parallel gate is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)