### PR TITLE
fix(models): correct inverted belongsTo keys on ChatMessage.session

### DIFF
--- a/admin/app/models/chat_message.ts
+++ b/admin/app/models/chat_message.ts
@@ -18,7 +18,7 @@ export default class ChatMessage extends BaseModel {
   @column()
   declare content: string
 
-  @belongsTo(() => ChatSession, { foreignKey: 'id', localKey: 'session_id' })
+  @belongsTo(() => ChatSession, { foreignKey: 'session_id', localKey: 'id' })
   declare session: BelongsTo<typeof ChatSession>
 
   @column.dateTime({ autoCreate: true })


### PR DESCRIPTION
`foreignKey/localKey` were swapped on the `ChatMessage` → `ChatSession` relation. Per Lucid's `belongsTo` [contract](https://lucid.adonisjs.com/docs/belongs-to#options), `foreignKey` is the column on the child model and `localKey` is on the parent — so this must be `{ foreignKey: 'session_id', localKey: 'id' }`, mirroring the inverse `hasMany` on `ChatSession`.

The relation is not currently preloaded anywhere in the codebase, so no runtime behavior changes today; justs a latent bug that would have broken any future `preload('session')` call.