### PR TITLE
feat(maps): add notes input to map pin placement popup

### DIFF
--- a/admin/inertia/components/maps/MapComponent.tsx
+++ b/admin/inertia/components/maps/MapComponent.tsx
@@ -72,6 +72,7 @@ export default function MapComponent({
   const [isDraggingMap, setIsDraggingMap] = useState(false)
   const [placingMarker, setPlacingMarker] = useState<{ lng: number; lat: number } | null>(null)
   const [markerName, setMarkerName] = useState('')
+  const [markerNotes, setMarkerNotes] = useState('')
   const [markerColor, setMarkerColor] = useState<PinColorId>('orange')
   const [selectedMarkerId, setSelectedMarkerId] = useState<number | null>(null)
 
@@ -153,18 +154,27 @@ export default function MapComponent({
   const handleMapClick = useCallback((e: MapLayerMouseEvent) => {
     setPlacingMarker({ lng: e.lngLat.lng, lat: e.lngLat.lat })
     setMarkerName('')
+    setMarkerNotes('')
     setMarkerColor('orange')
     setSelectedMarkerId(null)
   }, [])
 
   const handleSaveMarker = useCallback(() => {
     if (placingMarker && markerName.trim()) {
-      addMarker(markerName.trim(), placingMarker.lng, placingMarker.lat, markerColor)
+      const trimmedNotes = markerNotes.trim()
+      addMarker(
+        markerName.trim(),
+        placingMarker.lng,
+        placingMarker.lat,
+        markerColor,
+        trimmedNotes ? trimmedNotes : null
+      )
       setPlacingMarker(null)
       setMarkerName('')
+      setMarkerNotes('')
       setMarkerColor('orange')
     }
-  }, [placingMarker, markerName, markerColor, addMarker])
+  }, [placingMarker, markerName, markerNotes, markerColor, addMarker])
 
   const handleFlyTo = useCallback((longitude: number, latitude: number) => {
     mapRef.current?.flyTo({ center: [longitude, latitude], zoom: 12, duration: 1500 })
@@ -315,6 +325,17 @@ export default function MapComponent({
                     if (e.key === 'Escape') setPlacingMarker(null)
                   }}
                   className="block w-full rounded border border-gray-300 px-2 py-1 text-sm placeholder:text-gray-400 focus:outline-none focus:border-gray-500"
+                />
+
+                <textarea
+                  placeholder="Notes (optional)"
+                  value={markerNotes}
+                  onChange={(e) => setMarkerNotes(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Escape') setPlacingMarker(null)
+                  }}
+                  rows={2}
+                  className="mt-1.5 block w-full resize-y rounded border border-gray-300 px-2 py-1 text-sm placeholder:text-gray-400 focus:outline-none focus:border-gray-500"
                 />
 
                 <div className="mt-1.5 flex gap-1 items-center">

--- a/admin/inertia/hooks/useMapMarkers.ts
+++ b/admin/inertia/hooks/useMapMarkers.ts
@@ -47,8 +47,14 @@ export function useMapMarkers() {
   }, [])
 
   const addMarker = useCallback(
-    async (name: string, longitude: number, latitude: number, color: PinColorId = 'orange') => {
-      const result = await api.createMapMarker({ name, longitude, latitude, color })
+    async (
+      name: string,
+      longitude: number,
+      latitude: number,
+      color: PinColorId = 'orange',
+      notes: string | null = null
+    ) => {
+      const result = await api.createMapMarker({ name, longitude, latitude, color, notes })
       if (result) {
         const marker: MapMarker = {
           id: result.id,

--- a/admin/inertia/lib/api.ts
+++ b/admin/inertia/lib/api.ts
@@ -720,7 +720,7 @@ class API {
     })()
   }
 
-  async createMapMarker(data: { name: string; longitude: number; latitude: number; color?: string }) {
+  async createMapMarker(data: { name: string; longitude: number; latitude: number; color?: string; notes?: string | null }) {
     return catchInternal(async () => {
       const response = await this.client.post<
         { id: number; name: string; longitude: number; latitude: number; color: string; notes: string | null; created_at: string }


### PR DESCRIPTION
## What

Adds a notes textarea to the map pin placement popup so users can actually enter notes when they drop a pin.

## Why

The `map_markers` backend has accepted a `notes` column since PR #770 and the popup display path was wired up to render it (commit 6328256, shipped in v1.32.0). But no commit ever added the input on the client side. The feature shipped two-thirds done: notes get stored if you write them with a curl call, and they display when present, but there's no way for a regular user to actually enter them.

Before this PR:

| Layer | State |
|---|---|
| Backend column + API accepts notes | :white_check_mark: |
| Popup displays notes when populated | :white_check_mark: |
| **Placement UI has notes input** | :x: |

## How

Three files, 32 insertions / 5 deletions:

- **`admin/inertia/lib/api.ts`** - extend the `createMapMarker` request type with optional `notes?: string | null`
- **`admin/inertia/hooks/useMapMarkers.ts`** - `addMarker(name, lng, lat, color, notes)` accepts and forwards notes. The response handler already populated `notes` into local state from `result.notes ?? null`, so the display side already worked.
- **`admin/inertia/components/maps/MapComponent.tsx`** - `markerNotes` state, a 2-row `<textarea>` styled to match the name input, placed between the name field and the color picker. Reset on map-click (new placement), Cancel, and Save. Save trims and null-coalesces empty strings to null.

## Out of scope

Edit-mode for existing markers (so users can backfill notes on already-placed pins) is **not** in this PR. The selected-marker popup at `MapComponent.tsx:236-252` is still read-only. Adding edit mode involves real UX decisions (where the edit toggle lives, two-row layout for name+notes, wiring color editing too) that don't belong in this mechanical fix. Follow-up PR if anyone asks for it.

## Verified live on NOMAD3

Hot-patched NOMAD3 with this branch on top of v1.32.0 and ran a full round-trip via Playwright:

- Placement popup renders the new textarea (rows=2, placeholder "Notes (optional)") between name input and color picker
- Typed a name + 3-line notes, clicked Save - pin appears
- `GET /api/maps/markers` returned the saved row with multi-line notes intact (newlines preserved)
- Clicked the saved pin - read-only popup shows name + all three notes lines with whitespace preserved
- Selected-marker popup confirmed still read-only (no inputs) - confirms Option B scope held

## Test plan

- [ ] Click anywhere on the map; placement popup opens with name input focused and an empty notes textarea below it
- [ ] Type a name + notes, click Save; pin appears
- [ ] Click the new pin; popup shows name + notes
- [ ] Click another spot, leave notes empty, save; pin saves with `notes: null` (verify via `GET /api/maps/markers`)
- [ ] Esc in the notes textarea closes the placement popup (consistent with the name input)
- [ ] Enter in the notes textarea adds a newline (does **not** submit) - diverges from the name input's Enter-to-save on purpose