### PR TITLE
fix(KB): cursor on Always/Manual ingest policy buttons

### DIFF
--- a/admin/inertia/components/chat/KnowledgeBaseModal.tsx
+++ b/admin/inertia/components/chat/KnowledgeBaseModal.tsx
@@ -474,7 +474,7 @@ export default function KnowledgeBaseModal({ aiAssistantName = "AI Assistant", o
                         isActive
                           ? 'bg-desert-green text-white'
                           : 'bg-surface-primary text-text-secondary hover:bg-surface-tertiary'
-                      } ${updateIngestPolicyMutation.isPending ? 'opacity-50 cursor-not-allowed' : ''}`}
+                      } ${updateIngestPolicyMutation.isPending ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
                     >
                       {option}
                     </button>


### PR DESCRIPTION
## What

Add `cursor-pointer` to the Always/Manual ingest policy toggle buttons in the Knowledge Base modal.

## Why

Tailwind v4 dropped the default `button { cursor: pointer }` preflight rule that v3 had. Most clickable buttons in the KB modal go through the `StyledButton` wrapper which sets `cursor-pointer` explicitly, so they hover correctly. The Always/Manual toggle (added in PR #894 for the RFC #883 redesign) uses inline `<button>` elements that don't go through that wrapper, so they hover with the default arrow cursor instead of the pointer. Reported during v1.32.0 dogfooding on NOMAD1.

## How

One-line change to the trailing template expression on the `className`:

- Before: `${pending ? 'opacity-50 cursor-not-allowed' : ''}`
- After:  `${pending ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`

Pending state keeps `cursor-not-allowed`, idle state now gets `cursor-pointer`.

## Test plan

- [ ] Hover Always/Manual in the KB modal -> pointer cursor
- [ ] Click to switch -> pointer cursor stays during the brief mutation, then resolves
- [ ] Slow-mode-test (throttle network) -> cursor flips to not-allowed while mutation in flight (`disabled` state)