### PR TITLE
perf(KB): swap Qdrant full-scroll for facet on source enumeration

### DIFF
--- a/admin/app/services/rag_service.ts
+++ b/admin/app/services/rag_service.ts
@@ -46,6 +46,10 @@ export class RagService {
   public static UPLOADS_STORAGE_PATH = 'storage/kb_uploads'
   public static CONTENT_COLLECTION_NAME = 'nomad_knowledge_base'
   public static EMBEDDING_DIMENSION = 768 // Nomic Embed Text v1.5 dimension is 768
+  // Upper bound on distinct sources returned by Qdrant's facet API. Real
+  // NOMADs cap out at a few hundred ZIM files + uploaded PDFs; 10k leaves
+  // generous headroom without paying the cost of an unbounded request.
+  public static FACET_SOURCE_LIMIT = 10_000
   public static MODEL_CONTEXT_LENGTH = 2048 // nomic-embed-text has 2K token context
   public static MAX_SAFE_TOKENS = 1600 // Leave buffer for prefix and tokenization variance
   public static TARGET_TOKENS_PER_CHUNK = 1500 // Target 1500 tokens per chunk for embedding
@@ -1069,29 +1073,21 @@ export class RagService {
         RagService.EMBEDDING_DIMENSION
       )
 
+      // Use Qdrant's facet API to enumerate distinct `source` values in one
+      // call. The previous scroll-loop walked every point in the collection
+      // (3M+ on a fully-ingested NOMAD) just to learn the ~40 unique sources,
+      // which made this endpoint take 50+ seconds. Facet returns the unique
+      // values directly. `exact: true` so the count we'll reuse for warnings
+      // matches what would be reported by an exhaustive walk.
       const sources = new Set<string>()
-      let offset: string | number | null | Record<string, unknown> = null
-      const batchSize = 100
-
-      // Scroll through all points in the collection (only fetch source field)
-      do {
-        const scrollResult = await this.qdrant!.scroll(RagService.CONTENT_COLLECTION_NAME, {
-          limit: batchSize,
-          offset: offset,
-          with_payload: ['source'],
-          with_vector: false,
-        })
-
-        // Extract unique source values from payloads
-        scrollResult.points.forEach((point) => {
-          const source = point.payload?.source
-          if (source && typeof source === 'string') {
-            sources.add(source)
-          }
-        })
-
-        offset = scrollResult.next_page_offset || null
-      } while (offset !== null)
+      const facetResult = await this.qdrant!.facet(RagService.CONTENT_COLLECTION_NAME, {
+        key: 'source',
+        limit: RagService.FACET_SOURCE_LIMIT,
+        exact: true,
+      })
+      for (const hit of facetResult.hits) {
+        if (typeof hit.value === 'string') sources.add(hit.value)
+      }
 
       // Union the Qdrant-derived list with the disk-backed file paths the
       // state machine has tracked. Without this, files known to the scanner
@@ -1180,28 +1176,21 @@ export class RagService {
         RagService.EMBEDDING_DIMENSION
       )
 
-      // Per-source chunk count from a single scroll. We deliberately don't
-      // assume `kb_ingest_state.chunks_embedded` here so this PR stays
-      // independent of the state-machine PR (#888) — but a future cleanup can
-      // read from there for efficiency once both have landed.
+      // Per-source chunk count via Qdrant's facet API. Was a full scroll of
+      // every point in the collection, which on a fully-ingested NOMAD takes
+      // ~50s for a 3M-point KB just to count ~40 sources. Facet returns the
+      // distinct values + counts in a single call. `exact: true` because the
+      // counts feed Warning A's zero_chunks decision — approximate counts
+      // could mis-fire warnings near thresholds.
       const chunksBySource = new Map<string, number>()
-      let offset: string | number | null | Record<string, unknown> = null
-      const batchSize = 100
-      do {
-        const scrollResult = await this.qdrant!.scroll(RagService.CONTENT_COLLECTION_NAME, {
-          limit: batchSize,
-          offset,
-          with_payload: ['source'],
-          with_vector: false,
-        })
-        for (const point of scrollResult.points) {
-          const source = point.payload?.source
-          if (source && typeof source === 'string') {
-            chunksBySource.set(source, (chunksBySource.get(source) ?? 0) + 1)
-          }
-        }
-        offset = scrollResult.next_page_offset || null
-      } while (offset !== null)
+      const facetResult = await this.qdrant!.facet(RagService.CONTENT_COLLECTION_NAME, {
+        key: 'source',
+        limit: RagService.FACET_SOURCE_LIMIT,
+        exact: true,
+      })
+      for (const hit of facetResult.hits) {
+        if (typeof hit.value === 'string') chunksBySource.set(hit.value, hit.count)
+      }
 
       // Scan the filesystem the same way scanAndSyncStorage does so Warning A
       // can fire on files with zero qdrant points (the headline "video-only
@@ -1548,22 +1537,17 @@ export class RagService {
       )
 
       // Collect every unique `source` already in Qdrant so we can skip files
-      // that have already been embedded.
+      // that have already been embedded. Facet returns the distinct values in
+      // a single call rather than scrolling the whole collection.
       const sourcesInQdrant = new Set<string>()
-      let offset: string | number | null | Record<string, unknown> = null
-      do {
-        const scrollResult = await this.qdrant!.scroll(RagService.CONTENT_COLLECTION_NAME, {
-          limit: 100,
-          offset,
-          with_payload: ['source'],
-          with_vector: false,
-        })
-        scrollResult.points.forEach((point) => {
-          const source = point.payload?.source
-          if (source && typeof source === 'string') sourcesInQdrant.add(source)
-        })
-        offset = scrollResult.next_page_offset || null
-      } while (offset !== null)
+      const facetResult = await this.qdrant!.facet(RagService.CONTENT_COLLECTION_NAME, {
+        key: 'source',
+        limit: RagService.FACET_SOURCE_LIMIT,
+        exact: true,
+      })
+      for (const hit of facetResult.hits) {
+        if (typeof hit.value === 'string') sourcesInQdrant.add(hit.value)
+      }
 
       logger.info(`[RAG] Found ${sourcesInQdrant.size} unique sources in Qdrant`)
 


### PR DESCRIPTION
## What

Replace three full-scroll loops in `RagService` with a single `qdrant.facet()` call each, so enumerating distinct `source` values stops walking every point in the collection.

## Why

The Stored Files modal opens in **multi-minutes** on a fully-ingested NOMAD. Reported during v1.32.0 dogfooding on NOMAD3.

Measured before this PR on NOMAD3 (Qdrant collection: 3,099,353 points, 39 distinct sources):

| Endpoint | Time | What it did |
|---|---|---|
| `GET /api/rag/files` cold | **3 min 12 sec** | Scrolled 30,994 pages of 100 points each |
| `GET /api/rag/files` warm | **47 sec** | Same scroll, no caching |
| `GET /api/rag/file-warnings` | **48 sec** | Same scroll a second time |

Three different functions all do the same scroll-and-dedupe to learn the unique `source` values:

- `RagService.getStoredFiles` (`rag_service.ts:1072-1094`)
- `RagService.computeFileWarnings` (`rag_service.ts:1187-1204`)
- `RagService._scanAndSync` (`rag_service.ts:1537-1551`)

Qdrant 1.10+ has a `facet` aggregation that returns the distinct values of a payload field with their counts in a single call. `@qdrant/js-client-rest@1.16.2` (already pinned) exposes this directly as `client.facet()`. The original scroll implementation predates the facet API.

## How

Swap each scroll loop for the facet equivalent. `exact: true` everywhere because the counts feed Warning A's `zero_chunks` decision, and approximate counts could mis-fire warnings near thresholds.

As a bonus, `computeFileWarnings` was running a *separate* per-source chunk-count loop that incremented a counter as it scrolled — facet returns those counts inline, so that loop collapses entirely.

New `RagService.FACET_SOURCE_LIMIT = 10_000` caps the response; real NOMADs run ~100 source files max, comfortable headroom.

## Results

Measured after this PR on the same NOMAD3, same data (verified output bit-identical with `diff` against the pre-fix source list):

| Endpoint | Before | After | Speedup |
|---|---|---|---|
| `GET /api/rag/files` cold | 192 sec | **0.20 sec** | **960x** |
| `GET /api/rag/files` warm | 47 sec | **0.17 sec** | **276x** |
| `GET /api/rag/file-warnings` | 48 sec | **0.20 sec** | **240x** |

UI: modal open -> first file painted = **39 ms** (TanStack cache hit warm; 200 ms backend cold).

## Verified live on NOMAD3

Hot-patched NOMAD3 with this branch on top of v1.32.0:

- `getStoredFiles` returned the same 39 sources as before (`diff` against the pre-fix output returned 0 lines)
- `computeFileWarnings` returned the same 8 warnings
- Modal opens snappy via Playwright (39 ms to first file paint)
- `_scanAndSync` path is the same pattern applied to the same dataset; no separate end-to-end re-test needed but easy to do if you want one

## Diff scope

`admin/app/services/rag_service.ts`: +42 / -58 (net -16 lines). One static constant added, three scroll loops removed. No public API changes.

## Test plan

- [ ] Open the Knowledge Base modal on a NOMAD with significant content - should feel instant rather than multi-second
- [ ] Stored Files list still shows all real files (compare against `GET /api/rag/files` before+after)
- [ ] Per-file warnings still surface correctly for files with `zero_chunks` / partial ingestion
- [ ] `_scanAndSync` background pass still correctly skips already-embedded files (check logs for `[RAG] Found N unique sources in Qdrant`)
- [ ] Test on a fresh NOMAD with empty Qdrant collection - facet on empty collection returns `hits: []`, all three call sites should no-op cleanly