### PR TITLE
feat(config): respect REDIS_DB env var for queue and transmit

### DIFF
--- a/admin/.env.example
+++ b/admin/.env.example
@@ -12,6 +12,9 @@ DB_PASSWORD=password
 DB_SSL=false
 REDIS_HOST=localhost
 REDIS_PORT=6379
+# Optional: Redis logical database index (0-15). Defaults to 0 if unset.
+# Set this when sharing a Redis instance across services to avoid key collisions.
+# REDIS_DB=0
 # Storage path for NOMAD content (ZIM files, maps, etc.)
 # On Windows dev, use an absolute path like: C:/nomad-storage
 # On Linux production, use: /opt/project-nomad/storage

--- a/admin/config/queue.ts
+++ b/admin/config/queue.ts
@@ -4,6 +4,7 @@ const queueConfig = {
   connection: {
     host: env.get('REDIS_HOST'),
     port: env.get('REDIS_PORT') ?? 6379,
+    db: env.get('REDIS_DB') ?? 0,
   },
 }
 

--- a/admin/config/transmit.ts
+++ b/admin/config/transmit.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     driver: redis({
       host: env.get('REDIS_HOST'),
       port: env.get('REDIS_PORT'),
+      db: env.get('REDIS_DB') ?? 0,
       keyPrefix: 'transmit:',
     })
   }

--- a/admin/start/env.ts
+++ b/admin/start/env.ts
@@ -54,6 +54,7 @@ export default await Env.create(new URL('../', import.meta.url), {
   */
   REDIS_HOST: Env.schema.string({ format: 'host' }),
   REDIS_PORT: Env.schema.number(),
+  REDIS_DB: Env.schema.number.optional(),
 
   /*
   |----------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `REDIS_DB` env var support so operators can pick a Redis logical database (0-15) for the BullMQ queue connection and the `@adonisjs/transmit` Redis transport.
- Without this, both subsystems implicitly used db 0, which causes key collisions when a single Redis instance is shared across services or environments (e.g. a homelab Redis serving multiple stacks).
- `REDIS_DB` is optional; when unset both connections fall back to db 0, preserving today's behavior.

## Changes
- `admin/start/env.ts` — declare `REDIS_DB` as optional number in the env schema.
- `admin/config/queue.ts` — pass `db: env.get('REDIS_DB') ?? 0` to the BullMQ connection.
- `admin/config/transmit.ts` — pass `db: env.get('REDIS_DB') ?? 0` to the Redis transport.
- `admin/.env.example` — document the new variable.

## Test plan
- [x] `npm run typecheck` passes.
- [x] Unset `REDIS_DB` → behaves identically to before (both connections use db 0).
- [x] `REDIS_DB=10` → both queue jobs and SSE transmit keys land in db 10 (verified in a homelab deploy against a shared Redis with `REDIS_DB=10`).
- [ ] CI green.

## Notes for maintainers
- Drop-in additive change, no migration needed. Existing deployments without `REDIS_DB` set continue to use db 0.
- The validator uses `Env.schema.number.optional()` so AdonisJS coerces+validates at boot if set.