### PR TITLE
fix(chat): prefer selected model for suggestions, fall back to smallest

### DIFF
--- a/admin/app/services/chat_service.ts
+++ b/admin/app/services/chat_service.ts
@@ -1,5 +1,6 @@
 import ChatSession from '#models/chat_session'
 import ChatMessage from '#models/chat_message'
+import KVStore from '#models/kv_store'
 import logger from '@adonisjs/core/services/logger'
 import { DateTime } from 'luxon'
 import { inject } from '@adonisjs/core'
@@ -36,17 +37,23 @@ export class ChatService {
         return [] // If no models are available, return empty suggestions
       }
 
-      // Larger models generally give "better" responses, so pick the largest one
-      const largestModel = models.reduce((prev, current) => {
-        return prev.size > current.size ? prev : current
-      })
+      // Prefer the user's selected chat model. Fall back to the smallest
+      // installed model — picking the largest by file size is unsafe: if any
+      // installed model exceeds available VRAM (e.g. llama3.1:405b on a 96 GB
+      // GPU), Ollama spends minutes trying to load it and the request 500s.
+      // Suggestions are short prompts that don't benefit from a flagship model.
+      const lastModel = await KVStore.getValue('chat.lastModel')
+      const preferred = lastModel ? models.find((m) => m.name === lastModel) : undefined
+      const chosen =
+        preferred ??
+        models.reduce((prev, current) => (prev.size < current.size ? prev : current))
 
-      if (!largestModel) {
+      if (!chosen) {
         return []
       }
 
       const response = await this.ollamaService.chat({
-        model: largestModel.name,
+        model: chosen.name,
         messages: [
           {
             role: 'user',


### PR DESCRIPTION
## Summary
`ChatService.getChatSuggestions` picks the largest installed model by file size on the assumption that bigger models give better suggestions. This is unsafe: if any installed model exceeds available VRAM, Ollama spends minutes trying to load it and the request 500s, which surfaces as a red error toast every time the chat page is opened.

Reproduction is easy on a machine with a flagship model on disk: install e.g. `llama3.1:405b` (243 GB) alongside any smaller chat model on a GPU with less VRAM. Open the chat page with suggestions enabled. The XHR to `/api/chat/suggestions` hangs while Ollama paging the 405b through CPU memory, eventually returns 500 (~6 minutes in my reproduction), and meanwhile the chat-page tab evicts whatever was previously loaded.

## Changes
- `admin/app/services/chat_service.ts` — prefer the user's `chat.lastModel` (already tracked in `kv_store`); if not set or not currently installed, fall back to the **smallest** installed model instead of the largest. Suggestions are short prompts that don't benefit from a flagship model.

`OllamaService.getModels()` already filters out embedding models, so the fallback always lands on a chat model.

## Test plan
- [x] `npm run typecheck` passes.
- [x] With `chat.lastModel = qwen3-6-27b:latest` and a `llama3.1:405b` also installed, suggestions now load against Qwen 3.6 in seconds instead of 500ing.
- [x] With `chat.lastModel` unset, suggestions fall back to the smallest chat model rather than the largest.
- [x] With only one chat model installed, both branches converge on it (preserves prior single-model behavior).
- [x] With zero non-embedding models installed, returns `[]` (preserves prior empty-result behavior).
- [ ] CI green.

## Notes for maintainers
- Behavior change is intentional: "largest = best" was the bug. Suggestions are 3 short conversation starters; a small model produces them faster and won't accidentally evict whatever the user actually wants resident in VRAM.
- No DB or migration changes. `chat.lastModel` is already populated by the existing chat session flow.