### PR TITLE
fix(system): prevent false "offline" reports when 1.1.1.1 is blocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For answers to common questions about Project N.O.M.A.D., please see our [FAQ](F
 ## About Internet Usage & Privacy
 Project N.O.M.A.D. is designed for offline usage. An internet connection is only required during the initial installation (to download dependencies) and if you (the user) decide to download additional tools and resources at a later time. Otherwise, N.O.M.A.D. does not require an internet connection and has ZERO built-in telemetry.
 
-To test internet connectivity, N.O.M.A.D. attempts to make a request to Cloudflare's utility endpoint, `https://1.1.1.1/cdn-cgi/trace` and checks for a successful response.
+To test internet connectivity, N.O.M.A.D. first attempts to make a request to Cloudflare's utility endpoint, `https://1.1.1.1/cdn-cgi/trace`. If that endpoint is unreachable (for example, because your network blocks `1.1.1.1`), it falls back to other endpoints the application already contacts (the GitHub API and the Project N.O.M.A.D. API) and considers the connection online if any of them respond. You can override the endpoint used for this check with the `INTERNET_STATUS_TEST_URL` environment variable.
 
 ## About Security
 By design, Project N.O.M.A.D. is intended to be open and available without hurdles — it includes no authentication. If you decide to connect your device to a local network after install (e.g. for allowing other devices to access its resources), you can block/open ports to control which services are exposed.

--- a/admin/.env.example
+++ b/admin/.env.example
@@ -1,6 +1,10 @@
 PORT=8080
 HOST=localhost
 LOG_LEVEL=info
+# Optional: override the URL used to test internet connectivity.
+# Defaults to https://1.1.1.1/cdn-cgi/trace with fallbacks to hosts the app
+# already contacts. Leave unset to use the defaults.
+# INTERNET_STATUS_TEST_URL=https://1.1.1.1/cdn-cgi/trace
 APP_KEY=some_random_key
 NODE_ENV=development
 SESSION_DRIVER=cookie

--- a/admin/app/services/system_service.ts
+++ b/admin/app/services/system_service.ts
@@ -35,29 +35,48 @@ export class SystemService {
   }
 
   async getInternetStatus(): Promise<boolean> {
-    const DEFAULT_TEST_URL = 'https://1.1.1.1/cdn-cgi/trace'
+    // Primary endpoint stays Cloudflare's privacy-respecting utility endpoint.
+    // The fallbacks are hosts the application already contacts elsewhere
+    // (GitHub API for update checks, the Project N.O.M.A.D. API for release-note
+    // subscriptions), so no new third-party services are introduced. They exist
+    // to avoid false "offline" reports on networks that block 1.1.1.1.
+    const DEFAULT_TEST_URLS = [
+      'https://1.1.1.1/cdn-cgi/trace',
+      'https://api.github.com',
+      'https://api.projectnomad.us',
+    ]
     const MAX_ATTEMPTS = 3
 
-    let testUrl = DEFAULT_TEST_URL
-    let customTestUrl = env.get('INTERNET_STATUS_TEST_URL')?.trim()
+    let testUrls = DEFAULT_TEST_URLS
+    const customTestUrl = env.get('INTERNET_STATUS_TEST_URL')?.trim()
 
-    // check that customTestUrl is a valid URL, if provided
+    // If a custom test URL is provided and valid, use it exclusively. This
+    // preserves the existing override behavior for operators who intentionally
+    // point connectivity checks at a specific endpoint.
     if (customTestUrl && customTestUrl !== '') {
       try {
         new URL(customTestUrl)
-        testUrl = customTestUrl
+        testUrls = [customTestUrl]
       } catch (error) {
         logger.warn(
-          `Invalid INTERNET_STATUS_TEST_URL: ${customTestUrl}. Falling back to default URL.`
+          `Invalid INTERNET_STATUS_TEST_URL: ${customTestUrl}. Falling back to default URLs.`
         )
       }
     }
 
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       try {
-        const res = await axios.get(testUrl, { timeout: 5000 })
-        return res.status === 200
+        // Probe all endpoints in parallel and resolve as soon as the first one
+        // responds. Any HTTP response (including non-2xx) means we reached the
+        // internet, so accept all status codes rather than requiring a strict 200.
+        await Promise.any(
+          testUrls.map((testUrl) =>
+            axios.get(testUrl, { timeout: 5000, validateStatus: () => true })
+          )
+        )
+        return true
       } catch (error) {
+        // Promise.any only rejects (with an AggregateError) when every endpoint failed.
         logger.warn(
           `Internet status check attempt ${attempt}/${MAX_ATTEMPTS} failed: ${error instanceof Error ? error.message : error}`
         )


### PR DESCRIPTION
Problem getInternetStatus() probed only https://1.1.1.1/cdn-cgi/trace and required a strict 200. On networks that block or hijack Cloudflare's 1.1.1.1 (common with ISPs, routers, DNS/firewall filters), the check failed even though downloads worked, so the UI showed "No internet connection" and disabled install/update actions.

Fix

Keep 1.1.1.1/cdn-cgi/trace as the primary endpoint; add fallbacks to hosts the app already contacts — the GitHub API (checkLatestVersion) and the Project N.O.M.A.D. API (subscribeToReleaseNotes). No new third parties.
Probe all endpoints in parallel via Promise.any, resolving as soon as one responds; online if any succeed.
Accept any HTTP response as "online" (validateStatus: () => true) instead of requiring 200.
Preserve the INTERNET_STATUS_TEST_URL override (used exclusively when valid) and the existing 3-attempt / 1s-backoff retry behavior.
Document the override in .env.example and the fallback behavior in README.md.
Latency Parallel probing keeps worst-case offline detection at ~17s (3 × 5s + 2 × 1s) — equal to the original single-endpoint baseline — rather than the ~47s a sequential multi-endpoint loop would cost.

Scope / non-goals

API contract unchanged (boolean response, same route).
No frontend/UI changes.
No change to retry count or per-endpoint timeout.
Testing

tsc --noEmit passes.
Recommended manual checks: normal connectivity (primary wins); 1.1.1.1 blocked at network layer (fallback → online); fully offline (→ false after retries, ~17s); valid override (only that URL probed); invalid override (warns, falls back); reachable host returning non-200 (→ online).
Privacy note No new external services. Fallback hosts are already contacted by the app, consistent with the "zero telemetry" stance.

Fixes #950