### PR TITLE
fix(KB): persist accumulated chunk count across batched ZIM dispatches

### DIFF
--- a/admin/app/jobs/embed_file_job.ts
+++ b/admin/app/jobs/embed_file_job.ts
@@ -18,6 +18,11 @@ export interface EmbedFileJobParams {
   batchOffset?: number  // Current batch offset (for ZIM files)
   totalArticles?: number // Total articles in ZIM (for progress tracking)
   isFinalBatch?: boolean // Whether this is the last batch (prevents premature deletion)
+  // Running total of chunks embedded across prior batches in this dispatch chain.
+  // Carried forward so the final batch can persist an accurate `chunks_embedded`
+  // count via KbIngestState.markIndexed (see #933 — without this, only the last
+  // batch's chunk count was stored while Qdrant held the full set).
+  chunksSoFar?: number
 }
 
 export class EmbedFileJob {
@@ -159,13 +164,16 @@ export class EmbedFileJob {
           await new Promise((resolve) => setTimeout(resolve, EmbedFileJob.CPU_BATCH_DELAY_MS))
         }
 
-        // Dispatch next batch (not final yet)
+        // Dispatch next batch (not final yet). Carry forward the running
+        // chunk count so the final batch can persist an accurate total (#933).
+        const chunksSoFarNext = (job.data.chunksSoFar || 0) + (result.chunks || 0)
         await EmbedFileJob.dispatch({
           filePath,
           fileName,
           batchOffset: nextOffset,
           totalArticles: totalArticles || result.totalArticles,
           isFinalBatch: false, // Explicitly not final
+          chunksSoFar: chunksSoFarNext,
         })
 
         // Calculate progress based on articles processed
@@ -178,7 +186,7 @@ export class EmbedFileJob {
           ...job.data,
           status: 'batch_completed',
           lastBatchAt: Date.now(),
-          chunks: (job.data.chunks || 0) + (result.chunks || 0),
+          chunks: chunksSoFarNext,
         })
 
         return {
@@ -192,8 +200,11 @@ export class EmbedFileJob {
         }
       }
 
-      // Final batch or non-batched file - mark as complete
-      const totalChunks = (job.data.chunks || 0) + (result.chunks || 0)
+      // Final batch or non-batched file - mark as complete.
+      // chunksSoFar carries the accumulated count from prior dispatched batches
+      // (each continuation passes it forward — see EmbedFileJobParams). For a
+      // non-batched file it is undefined and we just count this single result.
+      const totalChunks = (job.data.chunksSoFar || 0) + (result.chunks || 0)
       await this.safeUpdateProgress(job, 100)
       await job.updateData({
         ...job.data,


### PR DESCRIPTION
Closes #933

## Problem

For batched ZIM ingest, `kb_ingest_state.chunks_embedded` ends up far lower than the vector count actually stored in Qdrant. Reporter saw `chunks_embedded = 4` in MySQL vs `1403` points in Qdrant for the same source file.

## Cause

In `embed_file_job.ts`, when a ZIM file needs continuation batches, the dispatched next-batch job inherits `filePath` / `fileName` / `batchOffset` / `totalArticles` / `isFinalBatch` but not the running chunk total. `job.data.chunks` is only updated on the *current* job via `job.updateData(...)` and dies with it.

So on the final batch:

```
totalChunks = (job.data.chunks || 0) + (result.chunks || 0)
            = 0 + (last batch's chunks)
```

That value is what `KbIngestState.markIndexed(filePath, totalChunks)` persists, even though Qdrant has been receiving vectors from every batch the whole time.

## Fix

Add `chunksSoFar?: number` to `EmbedFileJobParams` and thread it through the continuation dispatch chain. Each batch computes the new running total and passes it to the next, so the final batch's `markIndexed` call reflects the true count.

Non-batched files are unaffected: `chunksSoFar` is undefined, falls back to 0, totalChunks is just `result.chunks` as before.

## Testing

Manual trace through the dispatch chain confirms the accumulator now survives across continuation jobs. I did not add an automated test: the existing `admin/tests/unit/` suite covers pure utility functions only, and there's no BullMQ harness in the repo for in-process job-chain tests. Happy to add one if you'd like to point me at the preferred shape.
