### PR TITLE
fix(system): roll back service update when the new container fails to start

### DIFF
--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -1195,7 +1195,35 @@ export class DockerService {
 
       // Step 3: Rename old container as safety net
       const oldName = `${serviceName}_old`
+
+      // Clear any stale rollback container left behind by a previously failed update.
+      // Otherwise the rename below collides with the existing `<name>_old` and throws,
+      // which wedges every subsequent retry on the same error.
+      const staleOld = (await this.docker.listContainers({ all: true })).find((c) =>
+        c.Names.includes(`/${oldName}`)
+      )
+      if (staleOld) {
+        try {
+          await this.docker.getContainer(staleOld.Id).remove({ force: true })
+        } catch {
+          // Best effort — if it can't be removed the rename below will surface the error.
+        }
+      }
+
       await oldContainer.rename({ name: oldName })
+
+      // Restore the previous container after a failed update: rename the renamed-aside
+      // old container back into place and start it, so a failure anywhere between here
+      // and the health check never leaves the service down.
+      const rollbackToOld = async () => {
+        const containers = await this.docker.listContainers({ all: true })
+        const oldRef = containers.find((c) => c.Names.includes(`/${oldName}`))
+        if (oldRef) {
+          const rollbackContainer = this.docker.getContainer(oldRef.Id)
+          await rollbackContainer.rename({ name: serviceName }).catch(() => {})
+          await rollbackContainer.start().catch(() => {})
+        }
+      }
 
       // Step 4: Create new container with inspected config + new image
       this._broadcast(serviceName, 'update-creating', `Creating updated container...`)
@@ -1252,16 +1280,35 @@ export class DockerService {
       } catch (createError: any) {
         // Rollback: rename old container back
         this._broadcast(serviceName, 'update-rollback', `Failed to create new container: ${createError.message}. Rolling back...`)
-        const rollbackContainer = this.docker.getContainer((await this.docker.listContainers({ all: true })).find((c) => c.Names.includes(`/${oldName}`))!.Id)
-        await rollbackContainer.rename({ name: serviceName })
-        await rollbackContainer.start()
+        await rollbackToOld()
         this.activeInstallations.delete(serviceName)
         return { success: false, message: `Failed to create updated container: ${createError.message}` }
       }
 
-      // Step 5: Start new container
+      // Step 5: Start new container. If the start itself throws (bad device/GPU config,
+      // a host port already bound, image incompatibility), roll back to the previous
+      // container instead of leaving the service stopped with no replacement running.
       this._broadcast(serviceName, 'update-starting', `Starting updated container...`)
-      await newContainer.start()
+      try {
+        await newContainer.start()
+      } catch (startError: any) {
+        this._broadcast(
+          serviceName,
+          'update-rollback',
+          `Updated container failed to start: ${startError.message}. Rolling back to previous version...`
+        )
+        try {
+          await newContainer.remove({ force: true })
+        } catch {
+          // Best effort — leave the half-created container for manual cleanup if needed.
+        }
+        await rollbackToOld()
+        this.activeInstallations.delete(serviceName)
+        return {
+          success: false,
+          message: `Update failed: new container did not start (${startError.message}). Rolled back to previous version.`,
+        }
+      }
 
       // Step 6: Health check — verify container stays running for 5 seconds
       await new Promise((resolve) => setTimeout(resolve, 5000))
@@ -1307,14 +1354,7 @@ export class DockerService {
           // Best effort cleanup
         }
 
-        // Restore old container
-        const oldContainers = await this.docker.listContainers({ all: true })
-        const oldRef = oldContainers.find((c) => c.Names.includes(`/${oldName}`))
-        if (oldRef) {
-          const rollbackContainer = this.docker.getContainer(oldRef.Id)
-          await rollbackContainer.rename({ name: serviceName })
-          await rollbackContainer.start()
-        }
+        await rollbackToOld()
 
         this.activeInstallations.delete(serviceName)
         return {


### PR DESCRIPTION
## Problem

Reported in #949: updating a service (commonly `nomad_ollama`) from Command Center returns a 400, and the logs show the new image pulled and the old container stopped, then nothing. The service is left down, and **retrying fails identically every time**.

## Root cause

`updateContainer()` stops and renames the old container aside (`<name>_old`) *before* the new one is confirmed running, but rollback was only wired up in two places: if `createContainer()` throws, and if the new container fails the 5s health check.

A throw from **`newContainer.start()` itself** (bad device/GPU config, a host port already bound, image incompatibility) was outside any rollback try/catch. It bubbled to the outer `catch`, which returned a generic "Update failed" 400 and **never restored the old container** — leaving the service stopped with no replacement.

The wedged-retry is a second-order effect: the failed new container still holds the service name, so the next attempt's rename to `<name>_old` collides with the leftover from the first attempt and throws the same error indefinitely.

## Fix

- Wrap `newContainer.start()` so a start failure removes the half-created container and rolls back to the previous one (service stays up on the old version).
- Clear any stale `<name>_old` before the rename so a prior failed attempt can't wedge retries.
- Dedupe the three rollback sites into a single `rollbackToOld()` helper. This also removes a non-null assertion (`.find(...)!.Id`) in the create-failure path that could itself throw when no `_old` existed.

## Testing

- `npm run typecheck` clean.
- Verified the happy path live: ran a real AI Assistant update (0.18→0.24, AMD/ROCm path) on a test server — clean swap, no `_old` leftover, service healthy.
- The failure paths are best-effort and non-throwing, so a rollback can't itself take down the service.

Refs #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)