### PR TITLE
fix(storage): derive child-app bind paths from the admin's actual storage mount

### DIFF
--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -30,6 +30,13 @@ export class DockerService {
   private activeInstallations: Set<string> = new Set()
   public static NOMAD_NETWORK = 'project-nomad_default'
   public static ADMIN_CONTAINER_NAME = 'nomad_admin'
+  // The admin's own storage mount destination inside its container (compose maps
+  // <hostPath>:/app/storage). Used to locate the backing host path (#938).
+  public static ADMIN_STORAGE_DEST = '/app/storage'
+  // Hardcoded production default host storage root. A seeded/frozen child bind can
+  // still carry this prefix even after NOMAD_STORAGE_PATH is set elsewhere, so it's
+  // matched alongside the env value when relocating binds (#938).
+  public static DEFAULT_HOST_STORAGE_ROOT = '/opt/project-nomad/storage'
 
   // Resolved once: the host filesystem path backing the admin's /app/storage mount.
   // Child-service binds are rewritten to live under this so relocating the admin
@@ -468,9 +475,9 @@ export class DockerService {
    */
   private async _resolveHostStorageRoot(): Promise<string> {
     if (this._hostStorageRoot) return this._hostStorageRoot
-    const fallback = env.get('NOMAD_STORAGE_PATH', '/opt/project-nomad/storage')
+    const fallback = env.get('NOMAD_STORAGE_PATH', DockerService.DEFAULT_HOST_STORAGE_ROOT)
     try {
-      const adminStorageDest = join(process.cwd(), '/storage') // e.g. /app/storage
+      const adminStorageDest = DockerService.ADMIN_STORAGE_DEST
       const containers = await this.docker.listContainers({ all: true })
       // Prefer the well-known admin container name; fall back to matching this
       // process's own container by hostname (Docker defaults it to the short id).
@@ -496,30 +503,49 @@ export class DockerService {
       logger.warn(
         `[DockerService] Could not resolve host storage root, using fallback ${fallback}: ${err.message}`
       )
+      // Deliberately NOT cached: a transient Docker error (e.g. socket not ready at
+      // early boot) shouldn't lock this process into the fallback for its lifetime —
+      // caching here could permanently re-hide #938 after Docker recovers. Retry next call.
       return fallback
     }
   }
 
   /**
    * Rewrite the host side of a service's storage bind mounts so they point at the
-   * resolved host storage root. The seeded binds use the default/env prefix; if the
-   * admin storage actually lives elsewhere on the host, swap that prefix so the
-   * child container mounts the same physical location (#938). No-op when the
-   * resolved root matches the seeded prefix (the common case).
+   * resolved host storage root. If the admin storage actually lives elsewhere on the
+   * host, swap a known storage-root prefix so the child container mounts the same
+   * physical location (#938).
+   *
+   * A bind's prefix may be the current NOMAD_STORAGE_PATH *or* the hardcoded default:
+   * curated services re-bake their config from the env every boot, but user-modified
+   * curated services and custom apps freeze their binds at edit time and can still
+   * carry the default prefix even after NOMAD_STORAGE_PATH is changed. Matching both
+   * (rather than only the current env, and short-circuiting when env == root) means
+   * the documented "set NOMAD_STORAGE_PATH and relocate the volume" path also fixes
+   * those frozen-prefix apps instead of leaving them mounting an empty directory.
+   * Idempotent: binds already under `root` match no other prefix and are left alone.
    */
   private async _applyHostStorageRoot(containerConfig: any): Promise<void> {
     const binds: string[] | undefined = containerConfig?.HostConfig?.Binds
     if (!binds?.length) return
-    const seededRoot = env.get('NOMAD_STORAGE_PATH', '/opt/project-nomad/storage')
     const root = await this._resolveHostStorageRoot()
-    if (root === seededRoot) return
+    // Known host-side prefixes a seeded/frozen bind might carry. Exclude `root` itself
+    // so binds already pointing at the resolved location are never rewritten.
+    const seededRoots = [
+      env.get('NOMAD_STORAGE_PATH', DockerService.DEFAULT_HOST_STORAGE_ROOT),
+      DockerService.DEFAULT_HOST_STORAGE_ROOT,
+    ].filter((r) => r !== root)
+    if (!seededRoots.length) return
     containerConfig.HostConfig.Binds = binds.map((b) => {
       // bind format: "<hostSrc>:<containerDest>[:opts]" — hostSrc is a Linux abs path.
       const firstColon = b.indexOf(':')
       if (firstColon < 0) return b
       const hostSrc = b.slice(0, firstColon)
       const rest = b.slice(firstColon) // includes leading ':'
-      if (hostSrc === seededRoot || hostSrc.startsWith(seededRoot + '/')) {
+      const seededRoot = seededRoots.find(
+        (r) => hostSrc === r || hostSrc.startsWith(r + '/')
+      )
+      if (seededRoot) {
         return `${root}${hostSrc.slice(seededRoot.length)}${rest}`
       }
       return b

--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -5,6 +5,8 @@ import { inject } from '@adonisjs/core'
 import transmit from '@adonisjs/transmit/services/main'
 import { doResumableDownloadWithRetry } from '../utils/downloads.js'
 import { join } from 'path'
+import os from 'node:os'
+import env from '#start/env'
 import {
   ZIM_STORAGE_PATH,
   BOOKS_STORAGE_PATH,
@@ -27,6 +29,12 @@ export class DockerService {
   public docker: Docker
   private activeInstallations: Set<string> = new Set()
   public static NOMAD_NETWORK = 'project-nomad_default'
+  public static ADMIN_CONTAINER_NAME = 'nomad_admin'
+
+  // Resolved once: the host filesystem path backing the admin's /app/storage mount.
+  // Child-service binds are rewritten to live under this so relocating the admin
+  // storage volume relocates every child app too (#938). null = not yet resolved.
+  private _hostStorageRoot: string | null = null
 
   private _servicesStatusCache: { data: { service_name: string; status: string }[]; expiresAt: number } | null = null
   private _servicesStatusInflight: Promise<{ service_name: string; status: string }[]> | null = null
@@ -447,12 +455,87 @@ export class DockerService {
    * @param serviceName
    * @returns
    */
+  /**
+   * Resolve the host filesystem path that backs the admin container's storage
+   * directory (`/app/storage`). Child services are created via the Docker socket,
+   * so their bind mounts need the path on the *host*, not inside the admin
+   * container. Deriving it from the admin's own mount means whatever host path
+   * the admin storage volume is mapped to in compose, child apps follow it
+   * automatically (#938).
+   *
+   * Falls back to NOMAD_STORAGE_PATH / the production default if the admin
+   * container or its storage mount can't be inspected.
+   */
+  private async _resolveHostStorageRoot(): Promise<string> {
+    if (this._hostStorageRoot) return this._hostStorageRoot
+    const fallback = env.get('NOMAD_STORAGE_PATH', '/opt/project-nomad/storage')
+    try {
+      const adminStorageDest = join(process.cwd(), '/storage') // e.g. /app/storage
+      const containers = await this.docker.listContainers({ all: true })
+      // Prefer the well-known admin container name; fall back to matching this
+      // process's own container by hostname (Docker defaults it to the short id).
+      let adminInfo = containers.find((c) =>
+        c.Names.includes(`/${DockerService.ADMIN_CONTAINER_NAME}`)
+      )
+      if (!adminInfo) {
+        const hn = os.hostname()
+        adminInfo = containers.find((c) => c.Id.startsWith(hn))
+      }
+      if (!adminInfo) return (this._hostStorageRoot = fallback)
+
+      const inspected = await this.docker.getContainer(adminInfo.Id).inspect()
+      const mount = (inspected.Mounts ?? []).find(
+        (m: any) => m.Type === 'bind' && m.Destination === adminStorageDest
+      )
+      if (mount?.Source) {
+        logger.info(`[DockerService] Resolved host storage root from admin mount: ${mount.Source}`)
+        return (this._hostStorageRoot = mount.Source)
+      }
+      return (this._hostStorageRoot = fallback)
+    } catch (err: any) {
+      logger.warn(
+        `[DockerService] Could not resolve host storage root, using fallback ${fallback}: ${err.message}`
+      )
+      return fallback
+    }
+  }
+
+  /**
+   * Rewrite the host side of a service's storage bind mounts so they point at the
+   * resolved host storage root. The seeded binds use the default/env prefix; if the
+   * admin storage actually lives elsewhere on the host, swap that prefix so the
+   * child container mounts the same physical location (#938). No-op when the
+   * resolved root matches the seeded prefix (the common case).
+   */
+  private async _applyHostStorageRoot(containerConfig: any): Promise<void> {
+    const binds: string[] | undefined = containerConfig?.HostConfig?.Binds
+    if (!binds?.length) return
+    const seededRoot = env.get('NOMAD_STORAGE_PATH', '/opt/project-nomad/storage')
+    const root = await this._resolveHostStorageRoot()
+    if (root === seededRoot) return
+    containerConfig.HostConfig.Binds = binds.map((b) => {
+      // bind format: "<hostSrc>:<containerDest>[:opts]" — hostSrc is a Linux abs path.
+      const firstColon = b.indexOf(':')
+      if (firstColon < 0) return b
+      const hostSrc = b.slice(0, firstColon)
+      const rest = b.slice(firstColon) // includes leading ':'
+      if (hostSrc === seededRoot || hostSrc.startsWith(seededRoot + '/')) {
+        return `${root}${hostSrc.slice(seededRoot.length)}${rest}`
+      }
+      return b
+    })
+  }
+
   async _createContainer(
     service: Service & { dependencies?: Service[] },
     containerConfig: any
   ): Promise<void> {
     try {
       this._broadcast(service.service_name, 'initializing', '')
+
+      // Point storage binds at wherever the admin's storage volume actually lives
+      // on the host (covers dependency installs too — they recurse through here).
+      await this._applyHostStorageRoot(containerConfig)
 
       let dependencies = []
       if (service.depends_on) {
@@ -1087,6 +1170,7 @@ export class DockerService {
       await service.save()
 
       const containerConfig = this._parseContainerConfig(service.container_config)
+      await this._applyHostStorageRoot(containerConfig)
 
       // Step 4: Recreate container directly (skipping _createContainer to avoid re-downloading
       // the bootstrap ZIM — ZIM files already exist on disk)

--- a/install/management_compose.yaml
+++ b/install/management_compose.yaml
@@ -18,11 +18,14 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - /opt/project-nomad/storage:/app/storage # If you change the default storage path (/opt/project-nomad/storage), make sure to update the disk-collector config as well!
+      # To store NOMAD's data somewhere other than /opt/project-nomad/storage, change the HOST side (left of the colon) here AND set NOMAD_STORAGE_PATH below to the same host path, then update the disk-collector volume at the bottom to match. The admin auto-detects this mount so child apps (Kiwix, Ollama, etc.) follow it, but setting NOMAD_STORAGE_PATH keeps everything explicit.
+      - /opt/project-nomad/storage:/app/storage
       - /var/run/docker.sock:/var/run/docker.sock # Allows the admin service to communicate with the Host's Docker daemon
       - nomad-update-shared:/app/update-shared # Shared volume for update communication
     environment:
       - NODE_ENV=production
+      # NOMAD_STORAGE_PATH is the HOST path where NOMAD stores all of its data (ZIMs, models, notes, etc.). It MUST match the host side of the /app/storage volume above and the disk-collector volume below. The admin also auto-detects its storage mount, so child apps follow it even if this is left at the default, but keep all three in sync to avoid surprises.
+      - NOMAD_STORAGE_PATH=/opt/project-nomad/storage
       # PORT is the port the admin server listens on *inside* the container and should not be changed. If you want to change which port the admin interface is accessible from on the host, you can change the port mapping in the "ports" section (e.g. "9090:8080" to access it on port 9090 from the host)
       - PORT=8080
       - LOG_LEVEL=info


### PR DESCRIPTION
## Problem

Reported in #938 (two reporters): deploying via `management_compose.yaml` and relocating the admin storage volume to another disk leaves Kiwix (and other child apps) unable to find their files.

## Root cause

Child services (Kiwix, Ollama, Qdrant, Flatnotes, Kolibri) aren't in the compose file — the admin spawns them through the Docker socket, so their bind mounts need a **host** path. That host path is baked into the `services` table at seed time from `NOMAD_STORAGE_PATH` (default `/opt/project-nomad/storage`)... and `NOMAD_STORAGE_PATH` wasn't even present in `management_compose.yaml`, so it always fell back to the default.

So changing the admin volume (`/opt/project-nomad/storage:/app/storage` → `/mnt/big/storage:/app/storage`) moves the admin's own data, but child apps keep mounting the old, now-empty `/opt/project-nomad/storage/...`. Kiwix comes up with no content. The existing compose comment warned about the disk-collector but never mentioned the child-app implication.

## Fix

Single source of truth: the admin's *actual* storage mount.

- **`_resolveHostStorageRoot()`** — inspect the admin's own container, find the bind whose destination is `/app/storage`, and use its host `Source`. Cached after first resolve. Falls back to `NOMAD_STORAGE_PATH` / the production default if the container or mount can't be inspected.
- **`_applyHostStorageRoot()`** — rewrite the host-side prefix of each storage bind to that root. **No-op when it already matches the seeded prefix**, so default installs are completely unaffected.
- Applied at the top of `_createContainer` (covers installs + dependency recursion) and in the Kiwix library-mode recreate path.
- **compose:** add an explicit `NOMAD_STORAGE_PATH` knob and rewrite the comments so the three places that must agree (admin volume, env var, disk-collector volume) are spelled out. Auto-derivation is primary; the env var is an explicit override.

Net effect: relocating the admin storage volume now makes every child app follow automatically, with an explicit override + clear docs for non-standard setups.

## Testing

- `npm run typecheck` clean.
- Verified live on a test server that the inspect shape the resolver depends on is exactly as expected: `nomad_admin` exposes a `bind` mount with `Destination=/app/storage` and a host `Source`, and the exact-match on `/app/storage` correctly ignores the nested `/app/storage/nomad-disk-info.json` mount. On a default-path box the resolved root equals the seeded root, so the rewrite is a no-op (confirmed Kiwix's live bind `/opt/project-nomad/storage/zim -> /data` matches the seeded value).
- The rewrite firing on a relocated-storage host is logic-verified (prefix swap) rather than run end-to-end on a moved box.

Closes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)