### PR TITLE
fix(KB): stop ZIM ingestion progress freezing at 99% on multi-page archives

### DIFF
--- a/admin/app/jobs/embed_file_job.ts
+++ b/admin/app/jobs/embed_file_job.ts
@@ -168,9 +168,18 @@ export class EmbedFileJob {
           isFinalBatch: false, // Explicitly not final
         })
 
-        // Calculate progress based on articles processed
+        // Calculate progress based on articles processed.
+        //
+        // nextOffset counts entries passing our isArticleEntry() filter, but the
+        // denominator (totalArticles = archive.articleCount) uses libzim's
+        // narrower article definition. On ZIMs that pack one logical article as
+        // several sub-pages (e.g. iFixit), nextOffset outruns articleCount and a
+        // raw ratio overflows past 100%, which the UI pins at 99% for the entire
+        // tail so the file looks stuck (#903). Grow the denominator once we pass
+        // the reported count so the gauge keeps creeping forward monotonically,
+        // and never report 100% before the genuinely-final batch (handled below).
         const progress = totalArticles
-          ? Math.round((nextOffset / totalArticles) * 100)
+          ? Math.min(99, Math.round((nextOffset / Math.max(totalArticles, nextOffset + ZIM_BATCH_SIZE)) * 100))
           : 50
 
         await this.safeUpdateProgress(job, progress)


### PR DESCRIPTION
## Problem

Filed in #903. On ZIM archives that pack one logical article as several sub-pages (iFixit is the repro), the Processing Queue progress climbs past 100% internally and the UI pins the file at 99% for hours, making completing ingestion look hung.

## Root cause

The inter-batch progress was `nextOffset / totalArticles`. `nextOffset` counts entries passing our `isArticleEntry()` filter, but `totalArticles` is libzim's `archive.articleCount`, which uses a narrower definition. When `iterByPath()` yields more article-like sub-pages than `articleCount`, the numerator outruns the denominator, the ratio exceeds 100%, and the UI (clamped at 99%) freezes there for the rest of the run.

## Fix

Grow the denominator to `max(articleCount, nextOffset + ZIM_BATCH_SIZE)` once we pass the reported count, and clamp the inter-batch value to 99% (only the genuinely-final batch reports 100%). Progress now keeps creeping forward monotonically instead of freezing.

```
const progress = totalArticles
  ? Math.min(99, Math.round((nextOffset / Math.max(totalArticles, nextOffset + ZIM_BATCH_SIZE)) * 100))
  : 50
```

## Honest scope note

This is a graceful heuristic, not exact progress. True accuracy would require a pre-scan that counts `isArticleEntry()` matches before the first batch so the denominator is right from the start. That's a larger change (and a per-archive cost on huge ZIMs), so this PR just removes the user-visible "stuck at 99%" symptom with no change to batch offsets or resumption semantics. Filing the accurate-denominator pre-scan as a possible follow-up.

## Testing

- `npm run typecheck` clean.
- Logic change only; no batch-semantics change. (The visible behavior is best confirmed on a real multi-page ZIM like iFixit on a test server.)

Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)