### PR TITLE
fix(docker): reject failed image pulls instead of treating them as success

### DIFF
--- a/admin/app/services/benchmark_service.ts
+++ b/admin/app/services/benchmark_service.ts
@@ -614,8 +614,7 @@ export class BenchmarkService {
       await this.dockerService.docker.getImage(SYSBENCH_IMAGE).inspect()
     } catch {
       this._updateStatus('starting', `Pulling sysbench image...`)
-      const pullStream = await this.dockerService.docker.pull(SYSBENCH_IMAGE)
-      await new Promise((resolve) => this.dockerService.docker.modem.followProgress(pullStream, resolve))
+      await this.dockerService.pullImage(SYSBENCH_IMAGE)
     }
   }
 

--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -58,6 +58,27 @@ export class DockerService {
     }
   }
 
+  /**
+   * Pull a Docker image and resolve only when the pull genuinely completes.
+   *
+   * dockerode's `followProgress(stream, onFinished)` reports failures via the
+   * first argument of onFinished. Every call site used to pass the Promise's
+   * `resolve` directly as that callback, so a failed pull (dropped/metered
+   * connection, bad manifest, registry error, disk full mid-pull) resolved as
+   * if it had succeeded — and the code then tried to create/start a container
+   * from a missing or partial image, surfacing a confusing downstream error.
+   * Rejecting on that error here lets callers fail fast with the real cause (#790).
+   */
+  async pullImage(imageName: string): Promise<void> {
+    const pullStream = await this.docker.pull(imageName)
+    await new Promise<void>((resolve, reject) => {
+      this.docker.modem.followProgress(pullStream, (error: Error | null) => {
+        if (error) reject(error)
+        else resolve()
+      })
+    })
+  }
+
   async affectContainer(
     serviceName: string,
     action: 'start' | 'stop' | 'restart'
@@ -632,13 +653,12 @@ export class DockerService {
         )
       } else {
         // Start pulling the Docker image and wait for it to complete
-        const pullStream = await this.docker.pull(service.container_image)
         this._broadcast(
           service.service_name,
           'pulling',
           `Pulling Docker image ${service.container_image}...`
         )
-        await new Promise((res) => this.docker.modem.followProgress(pullStream, res))
+        await this.pullImage(service.container_image)
       }
 
       if (service.service_name === SERVICE_NAMES.KIWIX) {
@@ -728,8 +748,7 @@ export class DockerService {
                 'pulling',
                 `Pulling Docker image ${finalImage}...`
               )
-              const rocmPullStream = await this.docker.pull(finalImage)
-              await new Promise((res) => this.docker.modem.followProgress(rocmPullStream, res))
+              await this.pullImage(finalImage)
             }
 
             const amdDevices = await this._discoverAMDDevices()
@@ -1523,8 +1542,7 @@ export class DockerService {
 
       // Step 1: Pull new image (runtimeImage diverges from newImage for AMD, see above)
       this._broadcast(serviceName, 'update-pulling', `Pulling image ${runtimeImage}...`)
-      const pullStream = await this.docker.pull(runtimeImage)
-      await new Promise((res) => this.docker.modem.followProgress(pullStream, res))
+      await this.pullImage(runtimeImage)
 
       // Step 2: Find and stop existing container
       this._broadcast(serviceName, 'update-stopping', `Stopping current container...`)
@@ -1996,8 +2014,7 @@ export class DockerService {
 
       // Pull the image if it's missing locally, or always when forcePull (e.g. :latest updates).
       if (opts.forcePull || !(await this._checkImageExists(service.container_image))) {
-        const pullStream = await this.docker.pull(service.container_image)
-        await new Promise((res) => this.docker.modem.followProgress(pullStream, res))
+        await this.pullImage(service.container_image)
       }
 
       const newContainer = await this.docker.createContainer({


### PR DESCRIPTION
## Problem

Filed in #790. Every Docker image pull used `followProgress(pullStream, resolve)`, passing the Promise's `resolve` directly as dockerode's `onFinished(err, output)` callback. The error argument was therefore ignored: a pull that fails partway (dropped/metered connection, bad manifest, registry error, disk full mid-pull) resolved as if it had succeeded, and the code then tried to create/start a container from a missing or partial image, surfacing a confusing downstream error instead of the real cause. For an offline-first audience on flaky/metered links this is a real failure mode.

## Fix

Add a `DockerService.pullImage(imageName)` helper that rejects when `followProgress` reports an error, and route **all five** pull sites through it:

- service install
- AMD ROCm image pull (`finalImage`)
- service update
- force-reinstall / recreate (`forcePull`)
- sysbench benchmark image pull (`benchmark_service`)

After this, no call site constructs a raw `followProgress` except the helper.

## Notes

This was independently reported in #790 (with a Codex draft PR that was closed stale) and later in community PR #837. #837 had the right idea but converted only 3 of the 5 sites — it missed the AMD ROCm pull and the force-reinstall path, and introduced a stray comment de-indent. This implements the complete fix cleanly off `dev`; closing #837 with thanks.

## Testing

- `npm run typecheck` clean.
- Confirmed `grep followProgress` now matches only the helper.

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)