### PR TITLE
Fix admin axios header typecheck

### DIFF
--- a/admin/app/services/map_service.ts
+++ b/admin/app/services/map_service.ts
@@ -300,7 +300,7 @@ export class MapService implements IMapService {
         throw new Error(`Failed to fetch file info: ${response.status} ${response.statusText}`)
       }
 
-      const contentLength = response.headers['content-length']
+      const contentLength = String(response.headers['content-length'] ?? '')
       const size = contentLength ? parseInt(contentLength, 10) : 0
 
       return { filename, size }

--- a/admin/app/utils/downloads.ts
+++ b/admin/app/utils/downloads.ts
@@ -53,9 +53,8 @@ export async function doResumableDownload({
   // already in every binary-content allowlist we use (ZIM, PMTILES, base assets).
   // Without this default, the validator below throws `MIME type  is not allowed`
   // and breaks all downloads from kiwix's primary host (#848).
-  const contentType =
-    headResponse.headers['content-type'] || 'application/octet-stream'
-  const totalBytes = parseInt(headResponse.headers['content-length'] || '0')
+  const contentType = String(headResponse.headers['content-type'] ?? 'application/octet-stream')
+  const totalBytes = parseInt(String(headResponse.headers['content-length'] ?? '0'))
   const supportsRangeRequests = headResponse.headers['accept-ranges'] === 'bytes'
 
   // If allowedMimeTypes is provided, check content type


### PR DESCRIPTION
## Summary
- coerce Axios response header values to strings before using parseInt/includes
- preserve the existing octet-stream fallback for missing content-type headers

## Validation
- npm run typecheck

Fixes #987