### PR TITLE
chore: align package license with Apache-2.0 and fix README docs links/typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ available AI tools, we highly encourage the use of a beefy, GPU-backed device to
 
 At its core, however, N.O.M.A.D. is still very lightweight. For a barebones installation of the management application itself, the following minimal specs are required:
 
-*Note: Project N.O.M.A.D. is not sponsored by any hardware manufacturer and is designed to be as hardware-agnostic as possible. The harware listed below is for example/comparison use only*
+*Note: Project N.O.M.A.D. is not sponsored by any hardware manufacturer and is designed to be as hardware-agnostic as possible. The hardware listed below is for example/comparison use only*
 
 #### Minimum Specs
 - Processor: 2 GHz dual-core processor or better
@@ -79,7 +79,7 @@ At its core, however, N.O.M.A.D. is still very lightweight. For a barebones inst
 - OS: Debian-based (Ubuntu recommended)
 - Stable internet connection (required during install only)
 
-To run LLM's and other included AI tools:
+To run LLMs and other included AI tools:
 
 #### Optimal Specs
 - Processor: AMD Ryzen 7 or Intel Core i7 or better
@@ -94,7 +94,7 @@ To run LLM's and other included AI tools:
 Again, Project N.O.M.A.D. itself is quite lightweight — it's the tools and resources you choose to install with N.O.M.A.D. that will determine the specs required for your unique deployment
 
 #### Running AI models on a different host
-By default, N.O.M.A.D.'s installer will attempt to setup Ollama on the host when the AI Assistant is installed. However, if you would like to run the AI model on a different host, you can go to the settings of of the AI assistant and input a URL for either an ollama or OpenAI-compatible API server (such as LM Studio).  
+By default, N.O.M.A.D.'s installer will attempt to setup Ollama on the host when the AI Assistant is installed. However, if you would like to run the AI model on a different host, you can go to the settings of the AI assistant and input a URL for either an ollama or OpenAI-compatible API server (such as LM Studio).  
 Note that if you use Ollama on a different host, you must start the server with this option: `OLLAMA_HOST=0.0.0.0`.  
 Ollama is the preferred way to use the AI assistant, as it has features such as model download that OpenAI API does not support. So when using LM Studio, for example, you will have to use LM Studio to download models.
 You are responsible for the setup of Ollama/OpenAI server on the other host.
@@ -110,7 +110,7 @@ To test internet connectivity, N.O.M.A.D. attempts to make a request to Cloudfla
 ## About Security
 By design, Project N.O.M.A.D. is intended to be open and available without hurdles — it includes no authentication. If you decide to connect your device to a local network after install (e.g. for allowing other devices to access its resources), you can block/open ports to control which services are exposed.
 
-**Will authentication be added in the future?** Maybe. It's not currently a priority, but if there's enough demand for it, we may consider building in an optional authentication layer in a future release to support uses cases where multiple users need access to the same instance but with different permission levels (e.g. family use with parental controls, classroom use with teacher/admin accounts, etc.). We have a suggestion for this on our public roadmap, so if this is something you'd like to see, please upvote it here: https://roadmap.projectnomad.us/posts/1/user-authentication-please-build-in-user-auth-with-admin-user-roles
+**Will authentication be added in the future?** Maybe. It's not currently a priority, but if there's enough demand for it, we may consider building in an optional authentication layer in a future release to support use cases where multiple users need access to the same instance but with different permission levels (e.g. family use with parental controls, classroom use with teacher/admin accounts, etc.). We have a suggestion for this on our public roadmap, so if this is something you'd like to see, please upvote it here: https://roadmap.projectnomad.us/posts/1/user-authentication-please-build-in-user-auth-with-admin-user-roles
 
 For now, we recommend using network-level controls to manage access if you're planning to expose your N.O.M.A.D. instance to other devices on a local network. N.O.M.A.D. is not designed to be exposed directly to the internet, and we strongly advise against doing so unless you really know what you're doing, have taken appropriate security measures, and understand the risks involved.
 
@@ -122,7 +122,6 @@ Contributions are welcome and appreciated! Please see [CONTRIBUTING.md](CONTRIBU
 - **Website:** [www.projectnomad.us](https://www.projectnomad.us) - Learn more about the project
 - **Discord:** [Join the Community](https://discord.com/invite/crosstalksolutions) - Get help, share your builds, and connect with other NOMAD users
 - **Benchmark Leaderboard:** [benchmark.projectnomad.us](https://benchmark.projectnomad.us) - See how your hardware stacks up against other NOMAD builds
-- **Troubleshooting Guide:** [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - Find solutions to common issues
 - **FAQ:** [FAQ.md](FAQ.md) - Find answers to frequently asked questions
 - **Community Add-Ons:** [admin/docs/community-add-ons.md](admin/docs/community-add-ons.md) - Third-party content packs built by the community
 

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "project-nomad-admin",
       "version": "0.0.0",
-      "license": "ISC",
+      "license": "Apache-2.0",
       "dependencies": {
         "@adonisjs/auth": "9.6.0",
         "@adonisjs/core": "6.19.3",

--- a/admin/package.json
+++ b/admin/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "author": "Crosstalk Solutions, LLC",
   "scripts": {
     "start": "node bin/server.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "project-nomad",
       "version": "1.32.0-rc.6",
-      "license": "ISC"
+      "license": "Apache-2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "project-nomad",
   "version": "1.32.1",
-  "description": "\"",
+  "description": "Project N.O.M.A.D. (Node for Offline Media, Archives, and Data) - an offline-first knowledge and education server.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Crosstalk Solutions, LLC",
-  "license": "ISC"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
## Summary

Corrects package metadata and documentation accuracy. Carries forward the worthwhile fixes surfaced by @aqilaziz in #849, minus the lockfile version bump that conflicted with the current release line.

- **License metadata:** set to `Apache-2.0` in `package.json`, `admin/package.json`, and both lockfiles. The project has been Apache-2.0 since #197, but these still said `ISC`.
- **Root `description`:** replaced the placeholder (`"\""`) with a real project description.
- **Broken README link:** removed the dead **Troubleshooting Guide** link — `TROUBLESHOOTING.md` does not exist in the repo, and `FAQ.md` already has its own entry directly below it.
- **README typos:** `harware`→`hardware`, `LLM's`→`LLMs`, `of of`→`of`, `uses cases`→`use cases`.

## Verification

- All four JSON files parse cleanly.
- Confirmed `TROUBLESHOOTING.md` is absent on `dev` and `FAQ.md` is present.
- No version/dependency changes — license field only in the lockfiles.

Closes #849 (reimplemented in-house off current `dev`).