### PR TITLE
fix(content): narrow Wikipedia reconcile-skip to the managed selection file (closes #774)

### DIFF
--- a/admin/app/services/collection_manifest_service.ts
+++ b/admin/app/services/collection_manifest_service.ts
@@ -5,6 +5,7 @@ import { DateTime } from 'luxon'
 import { join } from 'path'
 import CollectionManifest from '#models/collection_manifest'
 import InstalledResource from '#models/installed_resource'
+import WikipediaSelection from '#models/wikipedia_selection'
 import { QueueService } from './queue_service.js'
 import { RunDownloadJob } from '#jobs/run_download_job'
 import { zimCategoriesSpecSchema, mapsSpecSchema, wikipediaSpecSchema } from '#validators/curated_collections'
@@ -284,10 +285,17 @@ export class CollectionManifestService {
 
       const seenZimIds = new Set<string>()
 
+      // Only skip the single Wikipedia file tracked by WikipediaSelection — not every file
+      // starting with `wikipedia_en_`. Curated category tiers (e.g. Medicine → Comprehensive)
+      // ship Wikipedia-themed ZIMs like `wikipedia_en_medicine_maxi` that must reconcile
+      // normally; otherwise their InstalledResource row gets wiped on every restart and the
+      // tier detection silently downgrades.
+      const wikipediaSelection = await WikipediaSelection.query().first()
+      const managedWikipediaFilename = wikipediaSelection?.filename ?? null
+
       for (const file of zimFiles) {
         console.log(`Processing ZIM file: ${file.name}`)
-        // Skip Wikipedia files (managed by WikipediaSelection model)
-        if (file.name.startsWith('wikipedia_en_')) continue
+        if (managedWikipediaFilename && file.name === managedWikipediaFilename) continue
 
         const parsed = CollectionManifestService.parseZimFilename(file.name)
         console.log(`Parsed ZIM filename:`, parsed)


### PR DESCRIPTION
## Problem

`reconcileFromFilesystem()` skipped every ZIM whose filename starts with `wikipedia_en_`, assuming all such files are managed by the `WikipediaSelection` model. But curated category tiers ship Wikipedia-themed ZIMs — e.g. **Medicine → Comprehensive** includes `wikipedia_en_medicine_maxi`. Those files were skipped during reconcile, so their `InstalledResource` rows got wiped on every restart and the detected tier silently downgraded.

## Fix

Skip only the single file actually tracked by `WikipediaSelection`, matched by exact filename instead of the `wikipedia_en_` prefix.

## Credit

Reimplemented in-house from @johno10661's #774, which was trapped on a stale base (35-file phantom diff). Full credit to them for the diagnosis and fix — this is their change on a clean branch off `dev`.

## Testing
- `tsc --noEmit` clean.

Closes #774