### PR TITLE
fix(updates): resolve relative registry pagination URL so tag listing doesn't crash (#945)

### DIFF
--- a/admin/app/services/container_registry_service.ts
+++ b/admin/app/services/container_registry_service.ts
@@ -139,11 +139,17 @@ export class ContainerRegistryService {
         allTags.push(...data.tags)
       }
 
-      // Handle pagination via Link header
+      // Handle pagination via Link header. Per the OCI/Docker registry spec the next-page
+      // URL is relative (e.g. "/v2/<repo>/tags/list?last=<tag>&n=1000"), so it must be
+      // resolved against the registry origin before re-fetching — assigning the raw relative
+      // path to `url` makes fetch() throw "Failed to parse URL". This silently broke update
+      // checks for any repo with >1000 tags (e.g. ollama/ollama, filebrowser/filebrowser),
+      // which is the root cause of #945. new URL(relative, base) also passes absolute
+      // next-URLs through unchanged, so it's safe for registries that return those.
       const linkHeader = response.headers.get('link')
       if (linkHeader) {
         const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/)
-        url = match ? match[1] : ''
+        url = match ? new URL(match[1], `https://${parsed.registry}`).toString() : ''
       } else {
         url = ''
       }


### PR DESCRIPTION
## Problem

`ContainerRegistryService.listTags()` follows the registry's `Link`-header pagination, but the next-page URL is **relative** per the OCI/Docker registry spec (e.g. `/v2/ollama/ollama/tags/list?last=0.9.3-rc5&n=1000`). The code assigned that raw relative path straight back to `url` and re-fetched it, so `fetch('/v2/...')` throws **"Failed to parse URL from /v2/..."**.

Any image repo with **more than 1000 tags** paginates, so the whole tag list — and therefore the update check — fails silently. Observed live on NOMAD1 when clicking **Check for Updates**:

```
[CheckServiceUpdatesJob] Failed to check updates for nomad_ollama: Failed to parse URL from /v2/ollama/ollama/tags/list?last=0.9.3-rc5&n=1000
[CheckServiceUpdatesJob] Failed to check updates for nomad_filebrowser: Failed to parse URL from /v2/filebrowser/filebrowser/tags/list?last=v2.63.5-armv7&n=1000
```

## Why this is #945

#945 reported Ollama "won't update past 0.24.0." Root cause: `ollama/ollama` has >1000 tags, so its tag list paginates and the check crashes before any newer version is ever evaluated. No update is offered, so it appears pinned. This affects every install, not just the original reporter, and any other high-tag-count image (filebrowser too).

## Fix

Resolve the next-page URL against the registry origin:

```ts
url = match ? new URL(match[1], `https://${parsed.registry}`).toString() : ''
```

`new URL(relative, base)` resolves the relative path (query string intact) and passes absolute next-URLs through unchanged, so it's safe for registries that return either form.

## Testing
- `tsc --noEmit` clean.
- Verified resolution of the two real failing URLs (relative → absolute with query preserved; absolute → unchanged).
- Live re-test on NOMAD1 to follow (rebuild + Check for Updates → Ollama returns versions instead of erroring).

Closes #945