### PR TITLE
feat(supply-depot): show installed version on cards + make Update pill stand out

### DIFF
--- a/admin/inertia/pages/supply-depot.tsx
+++ b/admin/inertia/pages/supply-depot.tsx
@@ -790,9 +790,20 @@ function AppCard({
             <p className="font-semibold text-text-primary text-sm leading-tight truncate">
               {service.friendly_name ?? service.service_name}
             </p>
-            {service.powered_by && (
-              <p className="text-xs text-text-muted truncate">{service.powered_by}</p>
-            )}
+            {(() => {
+              // Show the installed image tag next to the powered-by name (e.g. "Kiwix · 3.7.0").
+              // Only for installed apps — a not-yet-installed catalog entry has no meaningful
+              // running version. Falls back to just the version if powered_by is unset.
+              const version = service.installed ? extractTag(service.container_image) : ''
+              if (!service.powered_by && !version) return null
+              return (
+                <p className="text-xs text-text-muted truncate">
+                  {service.powered_by}
+                  {service.powered_by && version ? ' · ' : ''}
+                  {version ? <span className="font-mono">{version}</span> : null}
+                </p>
+              )
+            })()}
           </div>
         </div>
 
@@ -854,7 +865,7 @@ function AppCard({
             type="button"
             onClick={onUpdateVersion}
             title={`Update to ${service.available_update_version}`}
-            className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium border border-desert-green-light bg-desert-green-lighter text-desert-green-dark cursor-pointer transition-colors hover:bg-desert-green-light"
+            className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-semibold bg-desert-orange text-white shadow-sm cursor-pointer transition-colors hover:bg-desert-orange-dark"
           >
             <IconArrowUp className="h-3 w-3" />
             Update available

--- a/admin/inertia/pages/supply-depot.tsx
+++ b/admin/inertia/pages/supply-depot.tsx
@@ -757,6 +757,19 @@ function AppCard({
   // without a doc section (custom apps, undocumented catalog apps) so the Docs item is hidden.
   const docLink = getSupplyDepotDocLink(service.service_name)
 
+  // Subtitle under the app name: the powered-by name plus the installed image tag
+  // (e.g. "Kiwix · 3.7.0"). Only installed apps have a meaningful running version; a
+  // not-yet-installed catalog entry shows just the powered-by name. Null when neither exists.
+  const version = service.installed ? extractTag(service.container_image) : ''
+  const subtitle =
+    !service.powered_by && !version ? null : (
+      <p className="text-xs text-text-muted truncate">
+        {service.powered_by}
+        {service.powered_by && version ? ' · ' : ''}
+        {version ? <span className="font-mono">{version}</span> : null}
+      </p>
+    )
+
   function toggleDropdown(e: React.MouseEvent) {
     e.stopPropagation()
     onOpenDropdown(isDropdownOpen ? null : service.service_name)
@@ -790,20 +803,7 @@ function AppCard({
             <p className="font-semibold text-text-primary text-sm leading-tight truncate">
               {service.friendly_name ?? service.service_name}
             </p>
-            {(() => {
-              // Show the installed image tag next to the powered-by name (e.g. "Kiwix · 3.7.0").
-              // Only for installed apps — a not-yet-installed catalog entry has no meaningful
-              // running version. Falls back to just the version if powered_by is unset.
-              const version = service.installed ? extractTag(service.container_image) : ''
-              if (!service.powered_by && !version) return null
-              return (
-                <p className="text-xs text-text-muted truncate">
-                  {service.powered_by}
-                  {service.powered_by && version ? ' · ' : ''}
-                  {version ? <span className="font-mono">{version}</span> : null}
-                </p>
-              )
-            })()}
+            {subtitle}
           </div>
         </div>
 


### PR DESCRIPTION
## What

Two small Supply Depot card tweaks that came out of the update-detection work:

1. **Installed version on the card** — shows the running image tag next to the powered-by name, e.g. `Kiwix · 3.7.0`. Only for installed apps (a not-yet-installed catalog entry has no running version); falls back to just the version if `powered_by` is unset. Sourced from `extractTag(service.container_image)`, same as the Apps page.

2. **"Update available" pill now stands out** — was a muted light-green tint that blended into the card. Now a solid `desert-orange` fill with white text, so an available update actually draws the eye.

## Why

With Check-for-Updates working again (#999), the card never showed the **current** version, so there was no way to see what you're on or what you'd be moving from. And the old update pill was too subtle to notice.

## Testing
- `tsc --noEmit` clean.
- Live on NOMAD1 to follow (rebuild → cards show versions; AI Assistant / Filebrowser show the orange pill since their updates are detected post-#999).