### PR TITLE
fix(seeder): skip catalog sync for installed apps on diverged host ports

### DIFF
--- a/admin/database/migrations/1778700000007_backfill_user_modified_for_diverged_ports.ts
+++ b/admin/database/migrations/1778700000007_backfill_user_modified_for_diverged_ports.ts
@@ -1,0 +1,90 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+/**
+ * Catalog default published host ports for curated services, as of the 1.33
+ * curated-catalog era (when the `is_user_modified` flag was introduced).
+ *
+ * A curated install whose live host port differs from its catalog default was
+ * deployed on an alternate port (commonly because the default was already taken
+ * on that host) before `is_user_modified` existed to record it. This is a
+ * point-in-time snapshot on purpose — it must not track later catalog changes.
+ */
+const CATALOG_DEFAULT_HOST_PORTS: Record<string, string[]> = {
+  nomad_kiwix_server: ['8090'],
+  nomad_ollama: ['11434'],
+  nomad_cyberchef: ['8100'],
+  nomad_flatnotes: ['8200'],
+  nomad_kolibri: ['8300'], // legacy (Gen 1)
+  nomad_kolibri_2: ['8310', '8311'],
+  nomad_stirling_pdf: ['8400'],
+  nomad_filebrowser: ['8410'],
+  nomad_calibreweb: ['8420'],
+  nomad_it_tools: ['8430'],
+  nomad_excalidraw: ['8440'],
+  nomad_meshtastic_web: ['8450'],
+  nomad_homebox: ['8470'],
+  nomad_vaultwarden: ['8480'],
+  nomad_jellyfin: ['8490'],
+  nomad_meshcore_web: ['8500'],
+}
+
+/** Sorted list of published host ports in a serialized container_config, or null. */
+function hostPortsOf(containerConfig: string | null): string[] | null {
+  if (!containerConfig) return null
+  try {
+    const bindings = JSON.parse(containerConfig)?.HostConfig?.PortBindings ?? {}
+    const ports = Object.values(bindings)
+      .flat()
+      .map((b: any) => b?.HostPort)
+      .filter(Boolean) as string[]
+    return ports.length ? ports.slice().sort() : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Backfill `is_user_modified` for curated installs whose host port diverged from
+ * the catalog default before that flag existed (pre-1.33).
+ *
+ * The catalog-sync loop in ServiceSeeder overwrites `container_config` and
+ * `ui_location` for every curated service that isn't `is_custom` or
+ * `is_user_modified`. For a pre-1.33 install on a non-default port that means
+ * its port is reset to the catalog default on the next boot, desyncing the row
+ * from the running container and breaking the app's Open link.
+ *
+ * Flagging these rows `is_user_modified` lets the existing sync loop skip them.
+ * This runs before `db:seed`, so the flag is set before the sync would clobber
+ * the port. Tradeoff: these installs stop receiving future catalog config
+ * changes — an acceptable price for keeping their working port.
+ */
+export default class extends BaseSchema {
+  protected tableName = 'services'
+
+  async up() {
+    this.defer(async (db) => {
+      const rows = await db
+        .from(this.tableName)
+        .where('installed', true)
+        .where('is_custom', false)
+        .where('is_user_modified', false)
+        .select('id', 'service_name', 'container_config')
+
+      for (const row of rows) {
+        const expected = CATALOG_DEFAULT_HOST_PORTS[row.service_name]
+        if (!expected) continue
+        const actual = hostPortsOf(row.container_config)
+        if (!actual) continue
+        if (actual.join(',') !== expected.slice().sort().join(',')) {
+          await db.from(this.tableName).where('id', row.id).update({ is_user_modified: true })
+        }
+      }
+    })
+  }
+
+  async down() {
+    // One-way data backfill: `is_user_modified` is not restored, since we can't
+    // distinguish rows flagged here from ones the user modified directly, and
+    // un-flagging would re-expose them to the port-clobbering sync.
+  }
+}


### PR DESCRIPTION
## Problem

The catalog sync in `ServiceSeeder.run()` (added with the supply depot work) overwrites `container_config` and `ui_location` for every curated service not flagged `is_user_modified`. That flag is new in 1.33.0, so it is `false` for all rows that predate it — including apps that were deliberately installed on an alternate host port because the catalog default was already taken on that host.

On the first boot after upgrading to 1.33.0, the seeder resets such a record back to the catalog port while the actual container keeps running on the alternate port. The record is now desynced from reality:

- the app's open link points at the wrong port (broken, or worse, at whatever unrelated service occupies the catalog port), and
- a later update/reinstall recreates the container on the catalog port, which fails or collides with the service that occupies it.

**Real-world case:** a host running Consul (server RPC on 8300) had Kolibri installed on 8310. After upgrading to 1.33.0-rc.1, the auto-seed reset Kolibri's `ui_location` to 8300, so the Supply Depot card linked to Consul's RPC port and the app appeared dead.

## Fix

Before syncing a row, compare the **published host ports** of the existing record against the catalog entry. If the app is installed and its host ports diverge, skip the sync for that row — the deployed container is the source of truth.

Only host ports are compared, deliberately, so the corrections this sync exists for still propagate:

- internal container-port fixes (e.g. Meshtastic Web 80 → 8080) still sync — host port unchanged
- `ui_location` scheme changes (e.g. Vaultwarden → `https:8480`) still sync — host port unchanged
- unparseable/absent configs on either side fall through to the existing sync behavior

Fresh installs, custom apps, and user-modified rows are unaffected.