### PR TITLE
fix(queue): share one ioredis connection across BullMQ queues and workers

### DIFF
--- a/admin/app/services/queue_service.ts
+++ b/admin/app/services/queue_service.ts
@@ -1,11 +1,11 @@
 import { Queue } from 'bullmq'
 import queueConfig from '#config/queue'
 
-// Process-wide singleton. Each `Queue` opens two ioredis connections (one for
-// commands, one blocking). Instantiating a fresh QueueService per dispatch /
-// status lookup leaks both, and under sustained job churn (e.g. multi-batch ZIM
-// ingestion enqueueing a continuation every few seconds) it saturates Redis's
-// maxclients within hours.
+// Process-wide singleton. Instantiating a fresh QueueService per dispatch /
+// status lookup leaks connections, and under sustained job churn (e.g.
+// multi-batch ZIM ingestion enqueueing a continuation every few seconds) it
+// saturates Redis's maxclients within hours. All queues additionally reuse the
+// single shared ioredis instance exported from #config/queue (#885).
 export class QueueService {
   private queues: Map<string, Queue> = new Map()
 

--- a/admin/config/queue.ts
+++ b/admin/config/queue.ts
@@ -1,11 +1,23 @@
 import env from '#start/env'
+import { Redis } from 'ioredis'
+
+// BullMQ treats a plain `{host, port}` connection object as a recipe: every
+// Queue / Worker instantiates its own ioredis client from it, and script
+// commands executed against those clients can spawn further short-lived
+// connections. Under sustained ZIM ingestion this leaked ~1 client/sec until
+// Redis maxclients was exhausted (#885). Passing a single shared ioredis
+// instance instead gives BullMQ a pool to reuse — Workers still duplicate it
+// once for their blocking client, which is expected and bounded.
+// `maxRetriesPerRequest: null` is mandatory for connections shared with BullMQ.
+const sharedConnection = new Redis({
+  host: env.get('REDIS_HOST'),
+  port: env.get('REDIS_PORT') ?? 6379,
+  db: env.get('REDIS_DB') ?? 0,
+  maxRetriesPerRequest: null,
+})
 
 const queueConfig = {
-  connection: {
-    host: env.get('REDIS_HOST'),
-    port: env.get('REDIS_PORT') ?? 6379,
-    db: env.get('REDIS_DB') ?? 0,
-  },
+  connection: sharedConnection,
 }
 
 export default queueConfig

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -47,6 +47,7 @@
         "edge.js": "6.4.0",
         "fast-xml-parser": "5.7.0",
         "fuse.js": "7.1.0",
+        "ioredis": "5.10.1",
         "ipaddr.js": "2.4.0",
         "jszip": "3.10.1",
         "luxon": "3.7.2",

--- a/admin/package.json
+++ b/admin/package.json
@@ -100,6 +100,7 @@
     "edge.js": "6.4.0",
     "fast-xml-parser": "5.7.0",
     "fuse.js": "7.1.0",
+    "ioredis": "5.10.1",
     "ipaddr.js": "2.4.0",
     "jszip": "3.10.1",
     "luxon": "3.7.2",


### PR DESCRIPTION
## Summary

Closes #885

`config/queue.ts` hands BullMQ a plain `{host, port}` connection object. BullMQ treats that as a recipe: every `Queue` and `Worker` instantiates its own ioredis client from it, and script commands executed against those clients can spawn further short-lived connections. As documented in #885, under sustained ZIM ingestion this leaks ~1 client/sec on the admin process until Redis `maxclients` (10k) is exhausted in ~2–3 hours, forcing periodic admin restarts.

This PR implements the fix direction suggested in the issue — the [BullMQ-documented production pattern](https://docs.bullmq.io/guide/connections) of passing a single shared ioredis instance so all Queues and Workers reuse one client pool:

- **`admin/config/queue.ts`** — construct one shared `Redis` instance (preserving the `REDIS_DB` support from #939) and export it as `queueConfig.connection`. `maxRetriesPerRequest: null` is set, as BullMQ requires for shared connections.
- **`admin/package.json` / lockfile** — add `ioredis@5.10.1` as a direct dependency (previously only transitive via bullmq; pinned to the version already in the lockfile).
- **`admin/app/services/queue_service.ts`** — comment-only update: the singleton rationale from #877 still applies, but the per-Queue connection-count claim is no longer accurate with a shared instance.

No call sites change: `QueueService` and `commands/queue/work.ts` already read `queueConfig.connection`, so both the web process and the worker process pick up the shared instance automatically. Workers duplicate the connection once for their blocking client, which is expected and bounded (1 per worker).

## Testing

- `npm run typecheck` and `eslint` pass clean.
- Synthetic steady-state test against a throwaway `redis:7-alpine`, simulating NOMAD's topology (7 queues + 7 workers at the same concurrency settings, sustained `add` + `getJobCounts` + `getJobs` dispatch for 45 s, sampling `CLIENT LIST` every 5 s):

  | connection style | clients at t=0 | clients at t=45s |
  |---|---|---|
  | `{host, port}` object (current) | 15 | 22 (one per Queue + two per Worker) |
  | shared ioredis instance (this PR) | 9 | 9 (flat — 1 shared + 1 blocking dup per worker) |

  The post-fix steady state matches the ~20–30 client expectation from the issue once scaled to the full app. Caveat, in the interest of full transparency: the synthetic run did **not** reproduce the unbounded ~1 client/sec growth — that appears to need the real embed pipeline's dispatch pattern — so verification on a NOMAD instance under sustained multi-batch ZIM ingestion (the #885 repro: watch `docker exec nomad_redis redis-cli CLIENT LIST | wc -l` over ~10 min of embedding) would be a valuable confirmation before merge.

## Suggested release note

> Fixed a Redis connection leak during sustained Knowledge Base ingestion that could make the admin UI unresponsive after a few hours (#885).