### PR TITLE
docs: update in-app docs + README for v1.33 (Supply Depot + auto-updates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ N.O.M.A.D. is a management UI ("Command Center") and API that orchestrates a col
 - **Data Tools** — encryption, encoding, and analysis via [CyberChef](https://gchq.github.io/CyberChef/)
 - **Notes** — local note-taking via [FlatNotes](https://github.com/dullage/flatnotes)
 - **System Benchmark** — hardware scoring with a [community leaderboard](https://benchmark.projectnomad.us)
+- **Supply Depot** — a one-click app catalog (PDF tools, file browser, e-book library, password manager, and more) plus the ability to run your own custom Docker containers
+- **Automatic Updates** — opt-in, hands-off updates for the core software, installed apps, and offline content, on a schedule you control
 - **Easy Setup Wizard** — guided first-time configuration with curated content collections
 
 N.O.M.A.D. also includes built-in tools like a Wikipedia content selector, ZIM library manager, and content explorer.
@@ -59,10 +61,11 @@ N.O.M.A.D. also includes built-in tools like a Wikipedia content selector, ZIM l
 | Information Library | Kiwix | Offline Wikipedia, medical references, survival guides, ebooks |
 | AI Assistant | Ollama + Qdrant | Built-in chat with document upload and semantic search |
 | Education Platform | Kolibri | Khan Academy courses, progress tracking, multi-user support |
-| Offline Maps | ProtoMaps | Downloadable regional maps with search and navigation |
+| Offline Maps | ProtoMaps | Downloadable regional maps for offline viewing and search |
 | Data Tools | CyberChef | Encryption, encoding, hashing, and data analysis |
 | Notes | FlatNotes | Local note-taking with markdown support |
 | System Benchmark | Built-in | Hardware scoring, Builder Tags, and community leaderboard |
+| Supply Depot | Built-in | One-click app catalog + bring-your-own custom Docker containers |
 
 ## Device Requirements
 While many similar offline survival computers are designed to be run on bare-minimum, lightweight hardware, Project N.O.M.A.D. is quite the opposite. To install and run the

--- a/admin/app/services/docs_service.ts
+++ b/admin/app/services/docs_service.ts
@@ -14,9 +14,10 @@ export class DocsService {
     'use-cases': 3,
     'supply-depot-apps': 4,
     'community-add-ons': 5,
-    'faq': 6,
-    'about': 7,
-    'release-notes': 8,
+    'updates': 6,
+    'faq': 7,
+    'about': 8,
+    'release-notes': 9,
   }
 
   async getDocs() {

--- a/admin/docs/faq.md
+++ b/admin/docs/faq.md
@@ -73,7 +73,7 @@ This helps you balance content coverage against storage usage.
 2. Type your question or request
 3. The AI responds in conversational style
 
-The AI must be installed first — enable it during Easy Setup or install it from the [Apps](/settings/apps) page.
+The AI must be installed first — enable it during Easy Setup or install it from the [Supply Depot](/supply-depot) page.
 
 ### How do I upload documents to the Knowledge Base?
 1. Go to **[Knowledge Base →](/knowledge-base)**
@@ -104,7 +104,7 @@ The Early Access Channel lets you opt in to receive release candidate builds wit
 2. Refresh the page (Ctrl+R or Cmd+R)
 3. Go back to the Command Center and try again
 4. Check Settings → System to see if the service is running
-5. Try restarting the service (Stop, then Start in Apps manager)
+5. Try restarting the service (Stop, then Start in the Supply Depot)
 
 ### Maps show a gray/blank area
 
@@ -119,7 +119,7 @@ The Maps feature requires downloaded map data. If you see a blank area:
 This usually means the Information Library service started before its Kiwix library index was fully initialized.
 
 Try this recovery flow:
-1. Go to **[Apps](/settings/apps)**
+1. Go to **[Supply Depot](/supply-depot)**
 2. Stop **Information Library (Kiwix)**
 3. Wait 10-15 seconds, then start it again
 4. If the error persists, run **Force Reinstall** for Information Library from the same page
@@ -140,7 +140,7 @@ N.O.M.A.D. automatically detects NVIDIA GPUs when the NVIDIA Container Toolkit i
 
 1. **Install an NVIDIA GPU** in your server (if not already present)
 2. **Install the NVIDIA Container Toolkit** on the host — follow the [official installation guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
-3. **Reinstall the AI Assistant** — Go to [Apps](/settings/apps), find AI Assistant, and click **Force Reinstall**
+3. **Reinstall the AI Assistant** — Go to [Supply Depot](/supply-depot), find AI Assistant, and click **Force Reinstall**
 
 N.O.M.A.D. will detect the GPU during installation and configure the AI to use it automatically. You'll see "NVIDIA container runtime detected" in the installation progress.
 
@@ -151,7 +151,7 @@ N.O.M.A.D. will detect the GPU during installation and configure the AI to use i
 When you add or swap a GPU, N.O.M.A.D. needs to reconfigure the AI container to use it:
 
 1. Make sure the **NVIDIA Container Toolkit** is installed on the host
-2. Go to **[Apps](/settings/apps)**
+2. Go to **[Supply Depot](/supply-depot)**
 3. Find the **AI Assistant** and click **Force Reinstall**
 
 Force Reinstall recreates the AI container with GPU support enabled. Without this step, the AI continues to run on CPU only.
@@ -163,7 +163,7 @@ N.O.M.A.D. checks whether your GPU is actually accessible inside the AI containe
 ### AI Chat not available
 
 The AI Chat page requires the AI Assistant to be installed first:
-1. Go to **[Apps](/settings/apps)**
+1. Go to **[Supply Depot](/supply-depot)**
 2. Install the **AI Assistant**
 3. Wait for the installation to complete
 4. The AI Chat will then be accessible from the home screen or [Chat](/chat)
@@ -171,7 +171,7 @@ The AI Chat page requires the AI Assistant to be installed first:
 ### Knowledge Base upload stuck
 
 If a document upload appears stuck in the Knowledge Base:
-1. Check that the AI Assistant is running in **Settings → Apps**
+1. Check that the AI Assistant is running in **Settings → Supply Depot**
 2. Large documents take time to process — wait a few minutes
 3. Try uploading a smaller document to verify the system is working
 4. Check **Settings → System** for any error messages
@@ -190,7 +190,7 @@ If submission fails, check the error message for details.
 The service might still be starting up. Wait 1-2 minutes and try again.
 
 If the problem persists:
-1. Go to **Settings → Apps**
+1. Go to **Settings → Supply Depot**
 2. Find the problematic service
 3. Click **Restart**
 4. Wait 30 seconds, then try again
@@ -233,11 +233,16 @@ Yes, while you have internet access. Updates include:
 - Security improvements
 - Performance enhancements
 
+### Can N.O.M.A.D. update itself automatically?
+Yes. N.O.M.A.D. can keep its software, its installed apps, and its content current on its own. Automatic updates are **opt-in and off by default** — you turn on what you want from **Settings → Updates** (and, for apps, a per-app toggle in the Supply Depot). They only run inside a time window you choose, after safety checks, and never apply major version jumps automatically. See the **[Updates guide](/docs/updates)** for a full walkthrough.
+
 ### How do I update content (Wikipedia, etc.)?
 Content updates are separate from software updates:
 1. Go to **Settings → Content Manager** or **Content Explorer**
 2. Check for newer versions of your installed content
 3. Download updated versions as needed
+
+You can also turn on **automatic content updates** so installed Wikipedia/ZIM libraries and map regions refresh on their own overnight — see the [Updates guide](/docs/updates).
 
 Tip: New Wikipedia snapshots are released approximately monthly.
 

--- a/admin/docs/getting-started.md
+++ b/admin/docs/getting-started.md
@@ -37,7 +37,7 @@ The Information Library stores compressed versions of websites and references th
 - Classic books from Project Gutenberg
 
 **How to use it:**
-1. Click **Information Library** from the Command Center home screen or [Apps](/settings/apps) page
+1. Click **Information Library** from the Command Center home screen or the [Supply Depot](/supply-depot)
 2. Choose a collection (like Wikipedia)
 3. Search or browse just like the regular website
 
@@ -54,7 +54,7 @@ The Education Platform provides complete educational courses that work offline.
 - Works for all ages
 
 **How to use it:**
-1. Click **Education Platform** from the Command Center home screen or [Apps](/settings/apps) page
+1. Click **Education Platform** from the Command Center home screen or the [Supply Depot](/supply-depot)
 2. Sign in or create a learner account
 3. Browse courses and start learning
 
@@ -82,9 +82,9 @@ N.O.M.A.D. includes a built-in AI chat interface powered by Ollama. It runs enti
 
 **Tip:** Be specific in your questions. Instead of "tell me about plants," try "what vegetables grow well in shade?"
 
-**Note:** The AI Assistant must be installed first. Enable it during Easy Setup or install it from the [Apps](/settings/apps) page.
+**Note:** The AI Assistant must be installed first. Enable it during Easy Setup or install it from the [Supply Depot](/supply-depot).
 
-**GPU Acceleration:** If your server has an NVIDIA GPU with the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed, N.O.M.A.D. will automatically use it for AI — dramatically faster responses (10-20x improvement). If you add a GPU later, go to [Apps](/settings/apps) and **Force Reinstall** the AI Assistant to enable it.
+**GPU Acceleration:** If your server has an NVIDIA GPU with the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed, N.O.M.A.D. will automatically use it for AI — dramatically faster responses (10-20x improvement). If you add a GPU later, go to the [Supply Depot](/supply-depot) and **Force Reinstall** the AI Assistant to enable it.
 
 ---
 
@@ -141,7 +141,7 @@ View maps without internet. Download the regions you need before going offline.
 
 As your needs change, you can add more content anytime:
 
-- **More apps:** Settings → Apps
+- **More apps:** Settings → Supply Depot
 - **More references:** Settings → Content Explorer or Content Manager
 - **More map regions:** Settings → Maps Manager
 - **More educational content:** Through Kolibri's built-in content browser
@@ -183,6 +183,8 @@ While you have internet, periodically check for updates:
 3. Wait for the update to complete (your server will restart)
 
 Content updates (Wikipedia, maps, etc.) can be managed separately from software updates.
+
+**Automatic updates:** N.O.M.A.D. can also keep itself current without you having to check. Software, installed apps, and content can each be set to update automatically on an opt-in basis, with safety checks and a time window you control. See the **[Updates guide](/docs/updates)** for the full picture.
 
 **Early Access Channel:** Want the latest features before they hit stable? Enable the Early Access Channel from the Check for Updates page to receive release candidate builds. You can switch back to stable anytime.
 

--- a/admin/docs/home.md
+++ b/admin/docs/home.md
@@ -15,12 +15,12 @@ Think of it as having Wikipedia, Khan Academy, an AI assistant, and offline maps
 ### Browse Offline Knowledge
 Access millions of Wikipedia articles, medical references, how-to guides, and ebooks — all stored locally on your server. No internet required.
 
-*Launch the Information Library from the home screen or the [Apps](/settings/apps) page.*
+*Launch the Information Library from the home screen or the [Supply Depot](/supply-depot).*
 
 ### Learn Something New
 Khan Academy courses covering math, science, economics, and more. Complete with videos and exercises, all available offline.
 
-*Launch the Education Platform from the home screen or the [Apps](/settings/apps) page.*
+*Launch the Education Platform from the home screen or the [Supply Depot](/supply-depot).*
 
 ### Chat with AI
 Ask questions, get explanations, brainstorm ideas, or get help with writing. Your local AI assistant works completely offline — and you can upload documents to the Knowledge Base for document-aware responses.
@@ -60,7 +60,7 @@ Or explore the **[Getting Started Guide](/docs/getting-started)** for a walkthro
 |--------------|---------|
 | Chat with the AI | [AI Chat →](/chat) |
 | Upload documents for AI | [Knowledge Base →](/knowledge-base) |
-| Download more content | [Install Apps →](/settings/apps) |
+| Install more apps | [Supply Depot →](/supply-depot) |
 | Add Wikipedia/reference content | [Content Explorer →](/settings/zim/remote-explorer) |
 | Manage installed content | [Content Manager →](/settings/zim) |
 | Download map regions | [Maps Manager →](/settings/maps) |
@@ -79,5 +79,7 @@ N.O.M.A.D. works best when kept up to date while you have internet access. This 
 - AI model improvements
 
 When you go offline, you'll have everything you need — the last synced versions of all your content.
+
+You can update on demand, or turn on **automatic updates** so N.O.M.A.D. keeps its software, apps, and content current on its own while you have internet. See the **[Updates guide](/docs/updates)** for how it works.
 
 **[Check for Updates →](/settings/update)**

--- a/admin/docs/supply-depot-apps.md
+++ b/admin/docs/supply-depot-apps.md
@@ -8,6 +8,38 @@ A quick note on logins: some of these apps have their own accounts, separate fro
 
 ---
 
+## Managing your apps
+
+Every app you install gets a **Manage** menu on its card. From there you can:
+
+- **Docs** — jump straight to the NOMAD getting-started notes for that app (the same per-app sections you'll find below).
+- **Edit** — change an app's settings: port mappings, volume binds, environment variables, and memory/CPU limits. This works for curated apps too, not just custom ones. Your edits are merged into the app's existing setup, so advanced settings (like GPU access on the AI Assistant) are preserved, and an edited app stops getting overwritten by catalog updates.
+- **Logs** and **Stats** — open a live view of an app's log output or its current memory and CPU use, handy when something isn't behaving.
+- **Update** and **Remove** — pull the latest version of an app, or remove it (optionally deleting its image too). If an update's new container fails to start, NOMAD automatically rolls back to the version that was working.
+
+**Seeing what version you're running:** Each app card shows the installed version right next to the app name (for example, `Kiwix · 3.7.0`). When a newer version is available, an orange **Update available** pill appears on the card so it's easy to spot at a glance.
+
+**Custom "Open" links:** By default the **Open** button points at the app on your NOMAD's own address. If you run a reverse proxy or local DNS and would rather open an app at a friendlier address (for example `https://jellyfin.myhomelab.net`), use **Manage › Edit** to set a custom launch URL. NOMAD keeps your original link safely on file, so you can always switch back, and the override sticks across upgrades.
+
+**Keeping apps updated automatically:** Installed apps can update themselves hands-off. This is opt-in at two levels — a master switch in **Settings → Updates** and a per-app toggle in the Supply Depot — and only minor and patch updates are ever applied automatically (major versions always stay manual). See the [Updates guide](/docs/updates) for the full story.
+
+---
+
+## Bringing your own app
+
+Beyond the curated catalog, the Supply Depot can run **your own Docker container** as a managed app alongside everything else. Click **Add a custom app** and tell NOMAD:
+
+- the **image** to pull (for example `ghcr.io/owner/app:1.2.3`),
+- any **port mappings**, **volume binds**, **environment variables**, and **memory/CPU limits** it needs.
+
+As you fill it in, NOMAD runs a live pre-flight check and warns you about things like port conflicts or risky settings. Some warnings (an untrusted registry, or a `:latest` tag that can't be version-tracked) are advisory and you can choose **Install anyway**; genuinely unsafe configurations are blocked outright.
+
+Once installed, a custom app behaves like any other: it gets the same **Manage** menu (Edit, Logs, Stats, Update, Remove), shows its version on the card, and can opt in to automatic updates. NOMAD hardens host-path binds and scopes logs and stats to its own managed containers, so a custom app can't reach outside what you give it.
+
+> A custom app is exactly that — yours. NOMAD runs it and gets out of the way; it doesn't provide setup docs or support for software outside the curated catalog. Check the project's own documentation for how to use it.
+
+---
+
 ## Stirling PDF {% #stirling-pdf %}
 
 A full toolbox for working with PDFs, all on your own hardware. Merge and split files, convert to and from PDF, compress, rotate, add or remove passwords, OCR scanned documents so they're searchable, sign, stamp, and redact. There are over 50 tools in here, and because it runs locally, none of your documents ever leave your NOMAD.

--- a/admin/docs/updates.md
+++ b/admin/docs/updates.md
@@ -1,0 +1,67 @@
+# Keeping N.O.M.A.D. Updated
+
+N.O.M.A.D. works best when it's kept current while you have internet, so it's ready with the latest software and content the next time you go offline. This page explains what can be updated, how to do it on demand, and how to let N.O.M.A.D. handle it for you automatically.
+
+---
+
+## The three kinds of updates
+
+There are three separate things that can be updated, and you control each one independently:
+
+1. **Software (the core)** — N.O.M.A.D. itself: the Command Center, new features, bug fixes, and security improvements.
+2. **Apps** — the installable apps from the [Supply Depot](/supply-depot) (Kiwix, the AI Assistant, and any others you've added).
+3. **Content** — your offline material: Wikipedia and other Kiwix libraries, and downloaded map regions.
+
+You can update any of these on demand, or set any of them to update automatically.
+
+---
+
+## Updating on demand
+
+To check for and install updates yourself:
+
+1. Go to **[Settings → Check for Updates](/settings/update)**.
+2. If a software update is available, click to install it. N.O.M.A.D. downloads the update and restarts (usually 2–5 minutes).
+3. Apps can be updated from their card in the [Supply Depot](/supply-depot) using **Manage › Update**.
+4. Content is managed from **Settings → Content Manager** and **Content Explorer**, where you can download newer versions of installed libraries and maps.
+
+If a software or app update ever fails, N.O.M.A.D. is designed to recover gracefully — the previous working version keeps running, so your server stays up.
+
+---
+
+## Automatic updates
+
+N.O.M.A.D. can keep itself current without you having to remember to check. **Automatic updates are opt-in and off by default** — nothing updates on its own until you turn it on. You manage all of it from **Settings → Updates**.
+
+A few things are true across all three:
+
+- **You choose a time window.** Automatic updates only run during the hours you set, so they never interrupt you mid-use.
+- **Major versions are never automatic.** Only minor and patch updates apply on their own; a big version jump always waits for you to do it manually, on purpose.
+- **Safety checks come first.** Before applying anything, N.O.M.A.D. confirms there's enough disk space and that no other update, download, or install is already in progress.
+- **Being offline is harmless.** If N.O.M.A.D. can't reach the internet to check, it simply skips that round and tries again later.
+
+### Automatic software (core) updates
+
+Turn this on from **Settings → Updates**. When enabled, N.O.M.A.D. updates its own core to newer releases within the same major version, during your chosen window, after a configurable **cool-off** period (so a brand-new release has time to prove itself before your server takes it). The same page shows the toggle, the window, the cool-off setting, and live status. If updates fail repeatedly for a real reason, N.O.M.A.D. turns the feature back off and lets you know rather than retrying forever.
+
+### Automatic app updates
+
+App auto-updates are opt-in at **two levels**: a master switch in **Settings → Updates**, *and* a per-app toggle on each app's card in the [Supply Depot](/supply-depot). Both have to be on for an app to update itself. App updates share the same update window and cool-off as the core, apply only minor and patch versions, and back off automatically for any individual app that keeps failing.
+
+### Automatic content updates
+
+Installed Wikipedia/ZIM libraries and map regions can refresh themselves too. Because content downloads are large (often many gigabytes), content updates run on their **own dedicated overnight window** with a **bandwidth cap**, separate from the software and app schedule. N.O.M.A.D. checks the upstream Kiwix and map catalogs directly, and when a Wikipedia library is replaced with a newer version, it keeps the AI Knowledge Base in sync automatically.
+
+---
+
+## Early Access Channel
+
+Want new features before they reach the stable release? Enable the **Early Access Channel** from the [Check for Updates](/settings/update) page to receive release-candidate builds. Early-access builds may contain rough edges — you can switch back to stable at any time.
+
+---
+
+## Before you go offline
+
+Whatever you choose, the habit that matters most is simple: **update while you still have internet.** Whether you do it by hand or let automatic updates handle it, make sure your software and content are current before you head somewhere without a connection. When you're offline, you'll have the last synced versions of everything ready to go.
+
+**[Check for Updates →](/settings/update)** · **[See what's new in each version →](/docs/release-notes)**


### PR DESCRIPTION
Brings both the in-app documentation and the GitHub-facing README in line with the v1.33 feature set (Supply Depot custom apps, curated app onboarding, and the auto-update trilogy).

## In-app docs (Markdoc)
- Repoint dead `/settings/apps` links to the Supply Depot (`/supply-depot`) across home, getting-started, and faq; reword "Apps page" / "Settings → Apps" to "Supply Depot" (the old `/apps` route now redirects there).
- Expand `supply-depot-apps.md` with a **Managing your apps** section (Docs/Edit/Logs/Stats/Update/Remove, installed version + update-available visibility, custom launch URLs, per-app auto-update toggle) and a **Bringing your own app** section for custom Docker containers.
- Add a new **Updates** doc (`updates.md`) covering the auto-update trilogy (core/apps/content), manual updates, and the Early Access channel; wire it into `DOC_ORDER` and cross-link from home, getting-started, faq.

## README
- Add **Supply Depot** and **Automatic Updates** to the "Built-in capabilities" list and the "What's Included" table.
- Fix the Offline Maps row, which claimed "navigation" — NOMAD maps are download/view only, with no routing. Reworded to "offline viewing and search."

Docs-only; no behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)