### PR TITLE
Fix: update Wikipedia ZIM collection

### DIFF
--- a/collections/wikipedia.json
+++ b/collections/wikipedia.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "2026-03-23",
+  "spec_version": "2026-06-23",
   "options": [
     {
       "id": "none",
@@ -13,8 +13,8 @@
       "id": "top-mini",
       "name": "Quick Reference",
       "description": "Top 100,000 articles with minimal images. Great for quick lookups.",
-      "size_mb": 313,
-      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_top_mini_2025-12.zim",
+      "size_mb": 316,
+      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_top_mini_2026-06.zim",
       "version": "2025-12"
     },
     {
@@ -22,23 +22,23 @@
       "name": "Popular Articles",
       "description": "Top articles without images. Good balance of content and size.",
       "size_mb": 2100,
-      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_top_nopic_2025-12.zim",
+      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_top_nopic_2026-06.zim",
       "version": "2025-12"
     },
     {
       "id": "all-mini",
       "name": "Complete Wikipedia (Compact)",
       "description": "All 6+ million articles in condensed format.",
-      "size_mb": 11400,
-      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_mini_2025-12.zim",
+      "size_mb": 12000,
+      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_mini_2026-06.zim",
       "version": "2025-12"
     },
     {
       "id": "all-nopic",
       "name": "Complete Wikipedia (No Images)",
       "description": "All articles without images. Comprehensive offline reference.",
-      "size_mb": 49000,
-      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_nopic_2025-12.zim",
+      "size_mb": 48000,
+      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_nopic_2026-03.zim",
       "version": "2025-12"
     },
     {

--- a/collections/wikipedia.json
+++ b/collections/wikipedia.json
@@ -15,7 +15,7 @@
       "description": "Top 100,000 articles with minimal images. Great for quick lookups.",
       "size_mb": 316,
       "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_top_mini_2026-06.zim",
-      "version": "2025-12"
+      "version": "2026-06"
     },
     {
       "id": "top-nopic",
@@ -23,7 +23,7 @@
       "description": "Top articles without images. Good balance of content and size.",
       "size_mb": 2100,
       "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_top_nopic_2026-06.zim",
-      "version": "2025-12"
+      "version": "2026-06"
     },
     {
       "id": "all-mini",
@@ -31,7 +31,7 @@
       "description": "All 6+ million articles in condensed format.",
       "size_mb": 12000,
       "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_mini_2026-06.zim",
-      "version": "2025-12"
+      "version": "2026-06"
     },
     {
       "id": "all-nopic",
@@ -39,7 +39,7 @@
       "description": "All articles without images. Comprehensive offline reference.",
       "size_mb": 48000,
       "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_nopic_2026-03.zim",
-      "version": "2025-12"
+      "version": "2026-03"
     },
     {
       "id": "all-maxi",


### PR DESCRIPTION
The current collection in the repo is outdated, those versions of the ZIMs are no longer hosted.

Updated it to the latest available versions as of today.