### PR TITLE
fix(content): refresh stale Wikipedia ZIM catalog URLs

### DIFF
--- a/.github/workflows/validate-collection-urls.yml
+++ b/.github/workflows/validate-collection-urls.yml
@@ -30,13 +30,19 @@ jobs:
 
             # Use Range: bytes=0-0 to avoid downloading the full file.
             # --max-filesize 1 aborts early if the server ignores the Range header
-            # and returns 200 with the full body. The HTTP status is still captured.
+            # and returns 200 with the full body. download.kiwix.org redirects to
+            # mirrors, some of which ignore Range and stream the body, making curl
+            # exit 63 (CURLE_FILESIZE_EXCEEDED). That just means the file EXISTS, so
+            # it must not fail the step: `|| true` keeps the step's `set -e` from
+            # aborting on that exit code, while curl still writes the real
+            # %{http_code} (200/206) for the check below. A genuine 404 still
+            # returns 404 with exit 0 and is still caught.
             HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
               --range 0-0 \
               --max-filesize 1 \
               --max-time 30 \
               --location \
-              "$url")
+              "$url" || true)
 
             if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "206" ]; then
               echo "OK ($HTTP_CODE)"

--- a/.github/workflows/validate-collection-urls.yml
+++ b/.github/workflows/validate-collection-urls.yml
@@ -28,18 +28,18 @@ jobs:
             CHECKED=$((CHECKED + 1))
             printf "Checking: %s ... " "$url"
 
-            # Use Range: bytes=0-0 to avoid downloading the full file.
-            # --max-filesize 1 aborts early if the server ignores the Range header
-            # and returns 200 with the full body. download.kiwix.org redirects to
-            # mirrors, some of which ignore Range and stream the body, making curl
-            # exit 63 (CURLE_FILESIZE_EXCEEDED). That just means the file EXISTS, so
-            # it must not fail the step: `|| true` keeps the step's `set -e` from
-            # aborting on that exit code, while curl still writes the real
-            # %{http_code} (200/206) for the check below. A genuine 404 still
-            # returns 404 with exit 0 and is still caught.
+            # Range: bytes=0-0 GET, following redirects, with the response body
+            # discarded. download.kiwix.org 301-redirects BOTH valid and dead files
+            # to a mirror, so we must follow to the mirror to learn the real status
+            # (206/200 = exists, 404 = gone). The previous --max-filesize 1 aborted
+            # on the 301 redirect page's own body BEFORE following it, reporting 301
+            # for every URL; it is removed. Range-honoring mirrors return 206 after
+            # one byte; --max-time bounds the rare mirror that ignores Range.
+            # `|| true` keeps the step's `set -e` from aborting on a curl-level
+            # error (e.g. transient network failure); those surface as a non-200
+            # code below.
             HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
               --range 0-0 \
-              --max-filesize 1 \
               --max-time 30 \
               --location \
               "$url" || true)

--- a/collections/wikipedia.json
+++ b/collections/wikipedia.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "2026-03-23",
+  "spec_version": "2026-06-24",
   "options": [
     {
       "id": "none",
@@ -13,33 +13,33 @@
       "id": "top-mini",
       "name": "Quick Reference",
       "description": "Top 100,000 articles with minimal images. Great for quick lookups.",
-      "size_mb": 313,
-      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_top_mini_2025-12.zim",
-      "version": "2025-12"
+      "size_mb": 316,
+      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_top_mini_2026-06.zim",
+      "version": "2026-06"
     },
     {
       "id": "top-nopic",
       "name": "Popular Articles",
       "description": "Top articles without images. Good balance of content and size.",
-      "size_mb": 2100,
-      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_top_nopic_2025-12.zim",
-      "version": "2025-12"
+      "size_mb": 2136,
+      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_top_nopic_2026-06.zim",
+      "version": "2026-06"
     },
     {
       "id": "all-mini",
       "name": "Complete Wikipedia (Compact)",
       "description": "All 6+ million articles in condensed format.",
-      "size_mb": 11400,
-      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_mini_2025-12.zim",
-      "version": "2025-12"
+      "size_mb": 11951,
+      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_mini_2026-06.zim",
+      "version": "2026-06"
     },
     {
       "id": "all-nopic",
       "name": "Complete Wikipedia (No Images)",
       "description": "All articles without images. Comprehensive offline reference.",
-      "size_mb": 49000,
-      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_nopic_2025-12.zim",
-      "version": "2025-12"
+      "size_mb": 49521,
+      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_nopic_2026-03.zim",
+      "version": "2026-03"
     },
     {
       "id": "all-maxi",


### PR DESCRIPTION
## Problem
The Wikipedia download catalog pinned dated Kiwix filenames from `2025-12`. Kiwix rotates ZIMs by date and removes the old files, so `wikipedia_en_all_mini_2025-12.zim` now **404s on download** (reported in #1015 — the 11GB "Complete Wikipedia (Compact)" option).

## Change
Refreshed every Wikipedia variant to the newest file Kiwix currently serves, with corrected sizes:

| id | was | now | size_mb |
|---|---|---|---|
| top-mini | 2025-12 | 2026-06 | 313 → 316 |
| top-nopic | 2025-12 | 2026-06 | 2100 → 2136 |
| all-mini | 2025-12 | **2026-06** | 11400 → 11951 |
| all-nopic | 2025-12 | 2026-03 | 49000 → 49521 |
| all-maxi | 2026-02 | 2026-02 (current) | 118000 |

All five URLs verified live (HTTP 200).

## Note
This is a **manual refresh**. The underlying issue is that the download catalog uses static dated URLs that age out, while the installed-content auto-updater already resolves live URLs from the Kiwix catalog. The durable fix (resolve download URLs from the live catalog at download time) is tracked in #1045.