### PR TITLE
chore(catalog): sunset orphaned Meshtastic Daemon card

### DIFF
--- a/admin/database/migrations/1776400000001_sunset_meshtastic_daemon.ts
+++ b/admin/database/migrations/1776400000001_sunset_meshtastic_daemon.ts
@@ -1,0 +1,37 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+import { SERVICE_NAMES } from '../../constants/service_names.js'
+
+export default class extends BaseSchema {
+  protected tableName = 'services'
+
+  async up() {
+    // Sunset the Meshtastic Daemon catalog entry. It was removed from the seeder's DEFAULT_SERVICES
+    // because it can't work without hands-on setup (the user's radio MAC address, etc.), so leaving
+    // the card in the catalog only offers a broken install. The seeder is additive + sync-existing
+    // and never deletes, so every deployment seeded while it was in the catalog (all early-access
+    // boxes) keeps an orphaned `nomad_meshtasticd` row and still shows the non-functional card.
+    // Mirror the legacy-Kolibri sunset; the `is_deprecated` column already exists from that migration.
+    this.defer(async (db) => {
+      // Never installed → just an orphaned catalog row; drop it outright so the card disappears.
+      await db
+        .from(this.tableName)
+        .where('service_name', SERVICE_NAMES.MESHTASTICD)
+        .where('installed', false)
+        .delete()
+
+      // Currently installed (rare) → keep the row so it stays Nomad's handle to stop/uninstall the
+      // container, but flag it deprecated: it drops out of the catalog (see SystemService.getServices)
+      // and shows a "Legacy" badge. Honors the "we don't remove pre-installed apps" policy.
+      await db
+        .from(this.tableName)
+        .where('service_name', SERVICE_NAMES.MESHTASTICD)
+        .where('installed', true)
+        .update({ is_deprecated: true })
+    })
+  }
+
+  async down() {
+    // The orphaned-row deletion is a one-way data change and is not restored here. The is_deprecated
+    // column is owned by the legacy-Kolibri migration, so there is nothing schema-level to revert.
+  }
+}


### PR DESCRIPTION
## Problem

Meshtastic Daemon was removed from the seeder's `DEFAULT_SERVICES` (it can't work without hands-on setup — the user's radio MAC address, etc.), but the seeder is additive + sync-existing and **never deletes rows**. So every deployment that was seeded while it was in the catalog — all early-access boxes — keeps an orphaned `nomad_meshtasticd` row and still shows the non-functional card in Supply Depot.

## Fix

A data migration modeled exactly on `1776300000001_deprecate_legacy_kolibri`:

- **`installed = false`** (the common case — nobody really set it up) → delete the orphaned row outright, so the card disappears.
- **`installed = true`** (rare) → keep the row so it stays Nomad's handle to stop/uninstall the container, but set `is_deprecated = true`. That hides it from the catalog (`SystemService.getServices()`: `is_deprecated=false OR installed=true`) and shows a "Legacy" badge. Honors the "we don't remove pre-installed apps" policy.

Runs automatically on each box's next update via `migration:run --force`. The `is_deprecated` column already exists (added by the Kolibri migration), so this is a data-only change. On fresh installs there's no row to touch, so it's a no-op there.

## Testing

- Typecheck passes (pre-push hook).
- Verified on NOMAD3 by hand (orphaned row deleted, card gone, MESH-API custom app untouched).
- Plan: deploy + verify on NOMAD6 (also an EA box with the orphaned row).