### PR TITLE
feat: Expandable rows in Kiwix Library browser

### DIFF
--- a/admin/app/services/zim_service.ts
+++ b/admin/app/services/zim_service.ts
@@ -164,6 +164,13 @@ export class ZimService {
           download_url,
           author: entry.author.name,
           file_name,
+          language: entry.language,
+          category: entry.category,
+          tags: entry.tags,
+          article_count: entry.articleCount,
+          media_count: entry.mediaCount,
+          publisher: entry.publisher?.name,
+          issued: entry['dc:issued'],
         })
       }
 

--- a/admin/inertia/pages/settings/zim/remote-explorer.tsx
+++ b/admin/inertia/pages/settings/zim/remote-explorer.tsx
@@ -7,7 +7,6 @@ import {
 } from '@tanstack/react-query'
 import api from '~/lib/api'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useVirtualizer } from '@tanstack/react-virtual'
 import StyledTable from '~/components/StyledTable'
 import SettingsLayout from '~/layouts/SettingsLayout'
 import { Head } from '@inertiajs/react'
@@ -190,13 +189,6 @@ export default function ZimRemoteExplorer() {
     },
     [fetchNextPage, isFetching, hasMore]
   )
-
-  const virtualizer = useVirtualizer({
-    count: flatData.length,
-    estimateSize: () => 48, // Estimate row height
-    getScrollElement: () => tableParentRef.current,
-    overscan: 5, // Number of items to render outside the visible area
-  })
 
   //a check on mount and after a fetch to see if the table is already scrolled to the bottom and immediately needs to fetch more data
   useEffect(() => {
@@ -591,14 +583,7 @@ export default function ZimRemoteExplorer() {
                 />
               </div>
               <StyledTable<RemoteZimFileEntry & { actions?: any }>
-                data={flatData.map((i, idx) => {
-                  const row = virtualizer.getVirtualItems().find((v) => v.index === idx)
-                  return {
-                    ...i,
-                    height: `${row?.size || 48}px`,
-                    translateY: row?.start || 0,
-                  }
-                })}
+                data={flatData}
                 ref={tableParentRef}
                 loading={isLoading}
                 columns={[
@@ -610,6 +595,13 @@ export default function ZimRemoteExplorer() {
                   },
                   {
                     accessor: 'summary',
+                    render(record) {
+                      return (
+                        <span className="block max-w-md truncate text-text-muted" title={record.summary}>
+                          {record.summary}
+                        </span>
+                      )
+                    },
                   },
                   {
                     accessor: 'updated',
@@ -644,11 +636,95 @@ export default function ZimRemoteExplorer() {
                     },
                   },
                 ]}
-                className="relative overflow-x-auto overflow-y-auto h-[600px] w-full mt-4"
-                tableBodyStyle={{
-                  position: 'relative',
-                  height: `${virtualizer.getTotalSize()}px`,
+                expandable={{
+                  expandedRowRender(record) {
+                    return (
+                      <div className="py-4 px-6">
+                        <p className="text-sm text-text-primary mb-4">{record.summary}</p>
+                        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 text-sm">
+                          {record.author && (
+                            <div>
+                              <span className="text-text-muted">Author: </span>
+                              <span className="text-text-primary">{record.author}</span>
+                            </div>
+                          )}
+                          {record.publisher && (
+                            <div>
+                              <span className="text-text-muted">Publisher: </span>
+                              <span className="text-text-primary">{record.publisher}</span>
+                            </div>
+                          )}
+                          {record.language && (
+                            <div>
+                              <span className="text-text-muted">Language: </span>
+                              <span className="text-text-primary">{record.language}</span>
+                            </div>
+                          )}
+                          {record.category && (
+                            <div>
+                              <span className="text-text-muted">Category: </span>
+                              <span className="text-text-primary">{record.category}</span>
+                            </div>
+                          )}
+                          {record.article_count != null && record.article_count > 0 && (
+                            <div>
+                              <span className="text-text-muted">Articles: </span>
+                              <span className="text-text-primary">
+                                {record.article_count.toLocaleString()}
+                              </span>
+                            </div>
+                          )}
+                          {record.media_count != null && record.media_count > 0 && (
+                            <div>
+                              <span className="text-text-muted">Media: </span>
+                              <span className="text-text-primary">
+                                {record.media_count.toLocaleString()}
+                              </span>
+                            </div>
+                          )}
+                          {record.issued && (
+                            <div>
+                              <span className="text-text-muted">Issued: </span>
+                              <span className="text-text-primary">
+                                {new Intl.DateTimeFormat('en-US', {
+                                  dateStyle: 'medium',
+                                }).format(new Date(record.issued))}
+                              </span>
+                            </div>
+                          )}
+                          {record.size_bytes > 0 && (
+                            <div>
+                              <span className="text-text-muted">Size: </span>
+                              <span className="text-text-primary">{formatBytes(record.size_bytes)}</span>
+                            </div>
+                          )}
+                        </div>
+                        {record.tags && (
+                          <div className="mt-4 flex flex-wrap gap-2">
+                            {record.tags
+                              .split(';')
+                              .filter(Boolean)
+                              .map((tag, i) => (
+                                <span
+                                  key={i}
+                                  className="inline-flex items-center rounded-full bg-surface-elevated px-2.5 py-0.5 text-xs font-medium text-text-muted"
+                                >
+                                  {tag.trim()}
+                                </span>
+                              ))}
+                          </div>
+                        )}
+                        {record.file_name && (
+                          <div className="mt-4">
+                            <span className="text-text-muted text-sm">File: </span>
+                            <code className="text-xs text-text-muted">{record.file_name}</code>
+                          </div>
+                        )}
+                      </div>
+                    )
+                  },
                 }}
+                className="overflow-y-auto h-[600px] w-full mt-4"
                 containerProps={{
                   onScroll: (e) => fetchOnBottomReached(e.currentTarget as HTMLDivElement),
                 }}
@@ -760,7 +836,6 @@ export default function ZimRemoteExplorer() {
               )}
             </div>
           )}
-
           <ActiveDownloads filetype="zim" withHeader />
 
           {/* Manage Custom Libraries Modal */}

--- a/admin/inertia/pages/settings/zim/remote-explorer.tsx
+++ b/admin/inertia/pages/settings/zim/remote-explorer.tsx
@@ -638,6 +638,8 @@ export default function ZimRemoteExplorer() {
                 ]}
                 expandable={{
                   expandedRowRender(record) {
+                    const issuedDate = record.issued ? new Date(record.issued) : null
+                    const hasValidIssuedDate = issuedDate && !Number.isNaN(issuedDate.getTime())
                     return (
                       <div className="py-4 px-6">
                         <p className="text-sm text-text-primary mb-4">{record.summary}</p>
@@ -682,13 +684,13 @@ export default function ZimRemoteExplorer() {
                               </span>
                             </div>
                           )}
-                          {record.issued && (
+                          {hasValidIssuedDate && (
                             <div>
                               <span className="text-text-muted">Issued: </span>
                               <span className="text-text-primary">
                                 {new Intl.DateTimeFormat('en-US', {
                                   dateStyle: 'medium',
-                                }).format(new Date(record.issued))}
+                                }).format(issuedDate!)}
                               </span>
                             </div>
                           )}

--- a/admin/types/zim.ts
+++ b/admin/types/zim.ts
@@ -64,6 +64,13 @@ export type RemoteZimFileEntry = {
   download_url: string
   author: string
   file_name: string
+  language?: string
+  category?: string
+  tags?: string
+  article_count?: number
+  media_count?: number
+  publisher?: string
+  issued?: string
 }
 
 export type ExtractZIMContentOptions = {
@@ -71,8 +78,8 @@ export type ExtractZIMContentOptions = {
   maxArticles?: number
   onProgress?: (processedArticles: number, totalArticles: number) => void
   // Batch processing options to avoid lock timeouts
-  startOffset?: number  // Article index to start from for resuming
-  batchSize?: number    // Max articles to process in this batch
+  startOffset?: number // Article index to start from for resuming
+  batchSize?: number // Max articles to process in this batch
 }
 
 export type ExtractZIMChunkingStrategy = 'structured' | 'simple'


### PR DESCRIPTION
## Summary

The "Browse the Kiwix Library" table in Content Explorer previously showed each ZIM file's description truncated to a single line, making it difficult to assess content before downloading. This PR adds click-to-expand functionality so each row reveals the full description and additional metadata.

## Changes

- **`admin/types/zim.ts`** — Extended `RemoteZimFileEntry` with optional metadata fields: `language`, `publisher`, `category`, `tags`, `article_count`, `media_count`, `issued`
- **`admin/app/services/zim_service.ts`** — Updated `listRemote()` to map these additional fields from the raw Kiwix API response (previously discarded)
- **`admin/inertia/pages/settings/zim/remote-explorer.tsx`** — Removed `@tanstack/react-virtual` virtualization (12 items/page — not needed and incompatible with variable-height expanded rows) and added `expandable` prop to `StyledTable` with a rich `expandedRowRender` showing full description, metadata grid, tags, and file name

## Before / After

**Before** — descriptions truncated to a single line, no expandable detail:

![Before](https://files.catbox.moe/ez1tb6.png)

**After** — click a row to expand and see full description + metadata:

![After](https://files.catbox.moe/8xp240.png)

## Test plan

- [ ] Navigate to Settings → Content Explorer → Browse the Kiwix Library
- [ ] Verify rows render as before (collapsed state)
- [ ] Click a row — verify it expands to show full description and metadata
- [ ] Click again — verify it collapses
- [ ] Verify multiple rows can be expanded simultaneously
- [ ] Verify download button still works from both collapsed and expanded states
- [ ] Verify infinite scroll still loads more items
