### PR TITLE
fix(AI): set OLLAMA_IGPU_ENABLE on AMD provisioning so iGPUs are used (#1056)

### DIFF
--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -807,6 +807,11 @@ export class DockerService {
           if (hsaOverride) {
             ollamaEnv.push(`HSA_OVERRIDE_GFX_VERSION=${hsaOverride}`)
           }
+          // Ollama's scheduler drops integrated GPUs unless this is set (issue #1056), so
+          // AMD APUs (780M/890M/8060S) fall back to CPU-only despite correct device
+          // passthrough. It's a no-op on discrete AMD cards, so it's safe to set whenever
+          // AMD acceleration is configured.
+          ollamaEnv.push('OLLAMA_IGPU_ENABLE=1')
         }
       }
 
@@ -1688,10 +1693,16 @@ export class DockerService {
       let finalEnv = baseEnv
       if (updatedAmdGpuConfigured) {
         const hsaOverride = await this._resolveAmdHsaOverride()
-        finalEnv = baseEnv.filter((e: string) => !e.startsWith('HSA_OVERRIDE_GFX_VERSION='))
+        finalEnv = baseEnv.filter(
+          (e: string) =>
+            !e.startsWith('HSA_OVERRIDE_GFX_VERSION=') && !e.startsWith('OLLAMA_IGPU_ENABLE=')
+        )
         if (hsaOverride) {
           finalEnv.push(`HSA_OVERRIDE_GFX_VERSION=${hsaOverride}`)
         }
+        // Re-assert the iGPU flag so updates from a container provisioned before the
+        // issue #1056 fix (which wouldn't have it in the captured env) pick it up.
+        finalEnv.push('OLLAMA_IGPU_ENABLE=1')
       }
 
       const newContainerConfig: any = {


### PR DESCRIPTION
## Problem

Ollama's scheduler drops integrated GPUs unless `OLLAMA_IGPU_ENABLE=1` is set. NOMAD sets `HSA_OVERRIDE_GFX_VERSION` for AMD but never this flag, so AMD APUs (780M / 890M / 8060S) silently fall back to CPU-only inference even when `/dev/kfd` and `/dev/dri` are passed through correctly.

Reported in #1056 with 4 independent reporters and confirmed root cause from the Ollama startup log:

```
msg="dropping integrated GPU; to enable, set OLLAMA_IGPU_ENABLE=1" library=ROCm compute=gfx1100 name=ROCm0 description="AMD Radeon 890M Graphics"
```

## Fix

Set `OLLAMA_IGPU_ENABLE=1` whenever AMD acceleration is configured, on both provisioning paths in `docker_service.ts`:

- **Install path** — pushed alongside the existing `HSA_OVERRIDE_GFX_VERSION` inside the `if (amdGpuConfigured)` block.
- **Update path** — re-asserted, and any prior value stripped first, so containers provisioned before this change pick up the flag on their next update (same pattern already used for the HSA override).

The flag is a no-op on discrete AMD cards, so it's safe to set unconditionally within the AMD branch.

## Testing

Verified on NOMAD2 (Ryzen AI 9 HX 370 / Radeon 890M) by hot-patching the compiled service and triggering a Force Reinstall of the AI Assistant:

**Before**
```
msg="dropping integrated GPU; to enable, set OLLAMA_IGPU_ENABLE=1" ... name=ROCm0 description="AMD Radeon 890M Graphics"
inference compute id=cpu library=cpu ...
```

**After**
```
OLLAMA_IGPU_ENABLE:1
inference compute id=0 library=ROCm compute=gfx1100 name=ROCm0 description="AMD Radeon 890M Graphics" type=iGPU total="30.2 GiB"
```

`ollama ps` after a generation:
```
NAME          SIZE     PROCESSOR    ...
llama3.2:1b   2.6 GB   100% GPU
```

Closes #1056

🤖 Generated with [Claude Code](https://claude.com/claude-code)