### PR TITLE
fix(AI): stream thinking from /v1 reasoning field + abort on client disconnect (#1065)

### DIFF
--- a/admin/app/controllers/ollama_controller.ts
+++ b/admin/app/controllers/ollama_controller.ts
@@ -164,14 +164,32 @@ export default class OllamaController {
 
       if (reqData.stream) {
         logger.debug(`[OllamaController] Initiating streaming response for model: "${reqData.model}" with think: ${think}`)
-        // Headers already flushed above
-        const stream = await this.ollamaService.chatStream({ ...ollamaRequest, think, numCtx })
+        // Headers already flushed above.
+        // Abort the upstream generation if the client disconnects — otherwise an abandoned
+        // request keeps decoding server-side and, with Ollama's default OLLAMA_NUM_PARALLEL=1,
+        // blocks every later chat/RAG request until the model is manually stopped (#1065).
+        const abortController = new AbortController()
+        response.response.on('close', () => abortController.abort())
+        const stream = await this.ollamaService.chatStream({
+          ...ollamaRequest,
+          think,
+          numCtx,
+          signal: abortController.signal,
+        })
         let fullContent = ''
-        for await (const chunk of stream) {
-          if (chunk.message?.content) {
-            fullContent += chunk.message.content
+        try {
+          for await (const chunk of stream) {
+            if (chunk.message?.content) {
+              fullContent += chunk.message.content
+            }
+            response.response.write(`data: ${JSON.stringify(chunk)}\n\n`)
           }
-          response.response.write(`data: ${JSON.stringify(chunk)}\n\n`)
+        } catch (err) {
+          if (abortController.signal.aborted) {
+            logger.debug('[OllamaController] Client disconnected; aborted upstream Ollama generation')
+            return
+          }
+          throw err
         }
         response.response.end()
 

--- a/admin/app/services/ollama_service.ts
+++ b/admin/app/services/ollama_service.ts
@@ -45,6 +45,9 @@ type ChatInput = {
   think?: boolean | 'medium'
   stream?: boolean
   numCtx?: number
+  // Aborts the upstream request when the client disconnects, so an abandoned generation
+  // doesn't keep decoding server-side and block Ollama's single parallel slot (#1065).
+  signal?: AbortSignal
 }
 
 @inject()
@@ -333,13 +336,15 @@ export class OllamaService {
       params.num_ctx = chatRequest.numCtx
     }
 
-    const response = await this.openai.chat.completions.create(params)
+    const response = await this.openai.chat.completions.create(params, { signal: chatRequest.signal })
     const choice = response.choices[0]
 
     return {
       message: {
         content: choice.message.content ?? '',
-        thinking: (choice.message as any).thinking ?? undefined,
+        // Ollama's OpenAI-compat endpoint (/v1) emits thinking as `reasoning`; its native
+        // shape uses `thinking`. Read both so thinking is never silently dropped (#1065).
+        thinking: (choice.message as any).thinking ?? (choice.message as any).reasoning ?? undefined,
       },
       done: true,
       model: response.model,
@@ -364,7 +369,9 @@ export class OllamaService {
       params.num_ctx = chatRequest.numCtx
     }
 
-    const stream = (await this.openai.chat.completions.create(params)) as unknown as Stream<ChatCompletionChunk>
+    const stream = (await this.openai.chat.completions.create(params, {
+      signal: chatRequest.signal,
+    })) as unknown as Stream<ChatCompletionChunk>
 
     // Returns how many trailing chars of `text` could be the start of `tag`
     function partialTagSuffix(tag: string, text: string): number {
@@ -383,7 +390,8 @@ export class OllamaService {
 
       for await (const chunk of stream) {
         const delta = chunk.choices[0]?.delta
-        const nativeThinking: string = (delta as any)?.thinking ?? ''
+        // /v1 emits thinking as `reasoning`; native Ollama uses `thinking`. Read both (#1065).
+        const nativeThinking: string = (delta as any)?.thinking ?? (delta as any)?.reasoning ?? ''
         const rawContent: string = delta?.content ?? ''
 
         // Parse <think> tags out of the content stream


### PR DESCRIPTION
## Problem

With a thinking-capable model (e.g. `qwen3`), chat hangs forever: the SSE stream emits nothing but empty `content`/`thinking` chunks and never reaches `done`. Reported in #1065 against a remote Ollama 0.31.x, but the cause is in NOMAD's Node service and affects the OpenAI-compat (`/v1`) path used for **both local and remote** Ollama.

Two defects:

1. **Field mismatch.** `chatStream()` and `chat()` read `delta.thinking` / `message.thinking`, but Ollama's `/v1` emits thinking tokens as **`reasoning`**. All thinking output was silently dropped.
2. **No abort on client disconnect.** When the user closed the chat, the upstream generation kept decoding server-side. With Ollama's default `OLLAMA_NUM_PARALLEL=1`, that abandoned request held the only slot, so every later chat/RAG request queued behind it and the assistant appeared dead until the model was manually stopped.

## Fix

1. Read `thinking ?? reasoning` in both the streaming and non-streaming paths (the inline `<think>`-tag parser for other backends is untouched).
2. Wire an `AbortController` to the response `close` event in the controller and thread the signal into the OpenAI SDK request, so a client disconnect aborts the upstream generation.

## Testing

Verified end-to-end on NOMAD2 with `qwen3:0.6b` (reports the `thinking` capability; emits `reasoning` on `/v1`, so the bug reproduces even on 0.30.10):

**Field fix**
- Before: `data: {"message":{"content":"","thinking":""},"done":false}` endlessly, never done.
- After: thinking streams visibly (`"thinking":"Okay"`, `" let"`, `"'s"` ...) and the stream reaches `"done":true`.

**Abort on disconnect**
- Started a long generation, disconnected the client at 3s.
- Ollama's `n_decoded` froze (100 → 100 over the next 4s) and the server logged `srv stop: cancel task` / `slot release`.
- A subsequent request completed normally, confirming the slot was freed.

## Follow-up

Thinking is still force-on for capable models here. A user-facing **per-model thinking toggle (default off)**, shown in the chat window only for models that report the `thinking` capability, is a planned follow-up PR.

Closes #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)
