### PR TITLE
fix(content): refresh installed ZIMs when a download completes to prune ghost entries

### DIFF
--- a/admin/inertia/pages/settings/zim/remote-explorer.tsx
+++ b/admin/inertia/pages/settings/zim/remote-explorer.tsx
@@ -175,6 +175,26 @@ export default function ZimRemoteExplorer() {
   }, [data, downloads, localFiles])
   const hasMore = useMemo(() => data?.pages[data.pages.length - 1]?.has_more || false, [data])
 
+  // When a ZIM download drops off the polled downloads list it has completed (or been
+  // cancelled). The installed-files query (refetchOnWindowFocus is off) won't otherwise
+  // refresh, so a just-installed ZIM stays absent from `localFiles` and reappears in the
+  // accumulated remote pages as a ghost entry. Refresh it so the item is pruned.
+  const prevDownloadKeysRef = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    const currentKeys = new Set((downloads ?? []).map((d) => d.jobId))
+    let anyRemoved = false
+    for (const key of prevDownloadKeysRef.current) {
+      if (!currentKeys.has(key)) {
+        anyRemoved = true
+        break
+      }
+    }
+    prevDownloadKeysRef.current = currentKeys
+    if (anyRemoved) {
+      queryClient.invalidateQueries({ queryKey: [ZIM_FILES_KEY] })
+    }
+  }, [downloads, queryClient])
+
   const fetchOnBottomReached = useCallback(
     (parentRef?: HTMLDivElement | null) => {
       if (parentRef) {


### PR DESCRIPTION
## Problem
In the Content Explorer remote list (`/settings/zim/remote-explorer`), a ZIM that just finished downloading can reappear in the browse list as a "ghost entry" until the page remounts.

The client-side `flatData` filter already excludes installed ZIMs (`isPresent` against `localFiles`). But the installed-files query has `refetchOnWindowFocus` disabled and was never invalidated when a download completes. So when a ZIM finishes, it drops off the active-downloads list (`isDownloading` -> false) while `localFiles` stays stale (`isPresent` -> false), and the item slips back into the accumulated pages.

## Fix
Add an effect that invalidates the `['zim-files']` query whenever a job drops off the polled downloads list, so the just-completed install is picked up and pruned on the next render.

This is a focused reimplementation of @johno10661's diagnosis in #771, adapted onto current `dev` -- the accumulated-page/filter groundwork that PR also touched already landed separately (via #731), so only this last piece remained.

## Verification
- Inertia `tsc` clean for this file (pre-existing unrelated errors in other files remain)
- Needs a browser test on a NOMAD box: start a ZIM download, let it complete, and confirm it does not reappear in the remote list while scrolling.