### PR TITLE
fix(rag): stop re-creating payload indexes on every embedded document

### DIFF
--- a/admin/app/services/rag_service.ts
+++ b/admin/app/services/rag_service.ts
@@ -45,6 +45,10 @@ export class RagService {
   private qdrantInitPromise: Promise<void> | null = null
   private embeddingModelVerified = false
   private resolvedEmbeddingModel: string | null = null
+  // Collections already verified this session (created + payload indexes in place).
+  // Skips the getCollections/createPayloadIndex round-trips that otherwise run on
+  // every embed call — ~45% of per-document Qdrant time on large ingestions (#1129)
+  private ensuredCollections = new Set<string>()
   public static UPLOADS_STORAGE_PATH = 'storage/kb_uploads'
   public static CONTENT_COLLECTION_NAME = 'nomad_knowledge_base'
   public static EMBEDDING_DIMENSION = 768 // Nomic Embed Text v1.5 dimension is 768
@@ -94,6 +98,8 @@ export class RagService {
     } catch {
       this.qdrant = null
       this.qdrantInitPromise = null
+      // Qdrant may have restarted (or been recreated) — re-verify collections on reconnect
+      this.ensuredCollections.clear()
       return {
         online: false,
         message: 'Qdrant vector database is offline. Restart the AI Assistant service in Settings to restore the Knowledge Base.',
@@ -113,6 +119,11 @@ export class RagService {
   ) {
     try {
       await this._ensureDependencies()
+
+      if (this.ensuredCollections.has(collectionName)) {
+        return
+      }
+
       const collections = await this.qdrant!.getCollections()
       const collectionExists = collections.collections.some((col) => col.name === collectionName)
 
@@ -138,6 +149,9 @@ export class RagService {
         field_name: 'collection',
         field_schema: 'keyword',
       })
+
+      // Only memoize after every step succeeded, so a partial failure is retried
+      this.ensuredCollections.add(collectionName)
     } catch (error) {
       logger.error('Error ensuring Qdrant collection:', error)
       throw error
@@ -2103,6 +2117,10 @@ export class RagService {
         // Collection may not exist yet on a fresh install — log and continue.
         logger.warn(`[RAG] deleteCollection failed (may not exist): ${(err as Error).message}`)
       }
+
+      // The collection is gone — drop it from the ensured cache so the
+      // _ensureCollection call below actually recreates it
+      this.ensuredCollections.delete(RagService.CONTENT_COLLECTION_NAME)
 
       await this._ensureCollection(
         RagService.CONTENT_COLLECTION_NAME,


### PR DESCRIPTION
## Summary

Closes #1129 — RAG ingestion re-creates Qdrant payload indexes on every document.

`RagService._ensureCollection()` runs on every `embedAndStoreText()` call (once per document on the ingestion path), but only `createCollection` sits behind the `if (!collectionExists)` guard. The `getCollections` probe and the three `createPayloadIndex` calls ran unconditionally — about 21ms of redundant Qdrant work in every ~46ms document cycle (~45%), which makes large ZIM ingestions look stalled while they're actually progressing (see the access logs in the issue).

## What changed

- Added a private `ensuredCollections: Set<string>` to `RagService`, following the same session-memoization pattern as the existing `embeddingModelVerified` flag.
- `_ensureCollection()` returns early for collections already ensured by this instance. The name is recorded only after the existence check and all three `createPayloadIndex` calls succeed, so a partial failure is retried on the next call.
- `checkQdrantHealth()` clears the Set when it resets the client — if Qdrant went away it may have been restarted or recreated, so collections are re-verified on reconnect.
- `resetAndRebuild()` drops the collection from the Set right after `deleteCollection`, so the `_ensureCollection()` call that follows actually recreates it.

Memoizing (rather than moving the index calls inside the `!collectionExists` guard, the alternative floated in the issue) keeps the current self-healing behavior: missing payload indexes are still created on collections that predate the current schema — e.g. the `collection` keyword index added for #1062.

## After the change

Steady-state ingestion issues only `PUT /points` per document. The 4-request cycle from the issue (`PUT /points` → `GET /collections` → 2–3× `PUT /index`) collapses to a single upsert; the ensure round-trips happen once per collection per worker session (each `EmbedFileJob` constructs a fresh `RagService`, so in practice once per job — negligible next to per-document).

## Testing

- `npm run typecheck` — clean
- `npm run build` — clean (same check as the PR CI workflow)
- `npx eslint app/services/rag_service.ts` — no new findings vs. `dev` (the file's pre-existing prettier findings are untouched to keep this diff focused)
- Not manually tested against a live ingestion — I don't have a NOMAD install with a large ZIM handy. The reproduction in #1129 (`docker logs -f nomad_qdrant` during ingestion) is the easiest way to confirm: after the first document only `PUT /points` should appear, and Settings → Reset & Rebuild should still recreate the collection and its indexes.

## Suggested release note

- **Fixed:** Knowledge Base ingestion no longer re-creates Qdrant payload indexes for every document, removing up to ~45% of per-document overhead on large ingestions (#1129)
