### PR TITLE
fix(benchmark): remove stale progress setter

### DIFF
--- a/admin/inertia/pages/settings/benchmark.tsx
+++ b/admin/inertia/pages/settings/benchmark.tsx
@@ -93,14 +93,6 @@ export default function BenchmarkPage(props: {
       setErrorMsg(null)
       run.reset()
       setIsRunning(true)
-      setProgress({
-        status: 'starting',
-        progress: 5,
-        message: 'Starting benchmark... This takes 3-6 minutes.',
-        current_stage: 'Starting',
-        benchmark_id: '',
-        timestamp: new Date().toISOString(),
-      })
 
       // Use sync mode - runs inline without needing Redis/queue worker
       return await api.runBenchmark(type, true)


### PR DESCRIPTION
## Summary

- Remove the orphaned `setProgress(...)` call from the benchmark start mutation.
- Keep live progress state owned by `useBenchmarkRun`, as intended by the benchmark telemetry refactor.
- Allow Full, System Only, and AI Only runs to reach `api.runBenchmark(...)` instead of throwing in the browser first.

## Root cause

The live benchmark UI moved `progress` state into `useBenchmarkRun`, removing the page-local setter. A later stacked benchmark change reintroduced the old `setProgress(...)` call without restoring that setter, so every benchmark button failed with `ReferenceError: setProgress is not defined` before the API request was made.

The run view already handles a `null`/`starting` status while it waits for the first SSE update, so deleting the stale optimistic update restores the hook boundary without changing benchmark execution or progress handling.

Closes #1133

## Validation

- `npm run build` — production build completed successfully.
- `npx tsc -p inertia/tsconfig.json --noEmit` — the `benchmark.tsx` diagnostic is gone; the command still reports pre-existing diagnostics elsewhere in the client tree.
- Diff is limited to the stale eight-line progress update in `admin/inertia/pages/settings/benchmark.tsx`.

## Suggested release note

- **Benchmark:** Fixed Full, System Only, and AI Only runs failing immediately with `setProgress is not defined` (#1133).