### PR TITLE
fix(benchmark): surface a clear reason when leaderboard submission fails

### DIFF
--- a/admin/app/controllers/benchmark_controller.ts
+++ b/admin/app/controllers/benchmark_controller.ts
@@ -184,9 +184,22 @@ export default class BenchmarkController {
       // Pass through the status code from the service if available, otherwise default to 400
       const statusCode = (error as any).statusCode || 400
       logger.error({ err: error }, '[BenchmarkController] Benchmark submit failed')
+
+      // Surface a clear, actionable reason to the UI instead of a generic failure.
+      // The rate limiter (429) is the most common cause, so name it explicitly;
+      // otherwise pass through the underlying detail (repository error or a service
+      // validation message) and fall back to a safe generic only when we have none.
+      let errorMessage: string
+      if (statusCode === 429) {
+        errorMessage = 'You can only submit one benchmark per hour. Please wait a bit and try again.'
+      } else {
+        errorMessage =
+          (error as any).detail || (error as any).message || 'Failed to submit benchmark results.'
+      }
+
       return response.status(statusCode).send({
         success: false,
-        error: 'Failed to submit benchmark results.',
+        error: errorMessage,
       })
     }
   }

--- a/admin/app/services/benchmark_service.ts
+++ b/admin/app/services/benchmark_service.ts
@@ -299,9 +299,11 @@ export class BenchmarkService {
       const statusCode = error.response?.status
       logger.error(`Failed to submit benchmark to repository: ${detail} (Status: ${statusCode})`)
       
-      // Create an error with the status code attached for proper handling upstream
+      // Create an error with the status code and raw detail attached for proper
+      // handling upstream (the controller surfaces `detail` as the user-facing reason).
       const err: any = new Error(`Failed to submit benchmark: ${detail}`)
       err.statusCode = statusCode
+      err.detail = detail
       throw err
     }
   }


### PR DESCRIPTION
## Summary

The benchmark submit flow discarded the real failure reason and always returned a generic `Failed to submit benchmark results.` to the UI. The most common cause is the leaderboard's one-per-hour rate limit (HTTP 429), so users were left with no idea why the submission failed, or that retrying immediately would fail too.

- **`benchmark_controller.ts`** — return a clear, actionable message. Name the rate limit explicitly on 429 ("You can only submit one benchmark per hour. Please wait a bit and try again."); otherwise pass through the underlying detail (repository error, or a service-side validation message such as "already submitted"), falling back to the generic string only when we have nothing.
- **`benchmark_service.ts`** — attach the raw upstream `detail` to the thrown error so the controller can surface it.

The frontend already renders the server `error` string (`api.ts` rethrows `response.data.error`; the page shows it in the "Submission Failed" alert), so no client change is needed.

## Testing

- `admin` typecheck passes (pre-push hook).
- Verified live on a rc.2 box: with a fresh unsubmitted result and a submission already made in the same hour, clicking **Share with Community** now shows "You can only submit one benchmark per hour. Please wait a bit and try again." instead of the generic failure.

## Before

> Submission Failed
> Failed to submit benchmark results.

## After

> Submission Failed
> You can only submit one benchmark per hour. Please wait a bit and try again.