### PR TITLE
fix(benchmark): warm the AI model before timed runs for reproducible scores

### DIFF
--- a/admin/app/services/benchmark_service.ts
+++ b/admin/app/services/benchmark_service.ts
@@ -883,10 +883,25 @@ export class BenchmarkService {
       // model the whole GPU. Best-effort: never fail the run on an eviction hiccup.
       await this._unloadResidentModels(ollamaAPIURL)
 
+      // Warm-up pass (result discarded). The eviction above forces the benchmark
+      // model cold, so without this the first *timed* inference would pay the full
+      // model-load + GPU spin-up cost. On a cold box that lands as a huge outlier
+      // (observed: 173s TTFT / 5.83 tok/s on a run whose warm steady-state was
+      // ~80 tok/s), and since the AI channel is uncapped and ~30% of the composite
+      // it swings the whole NOMAD Score ~2x between a cold first run and a warm
+      // re-run of the same machine. Measure warm, steady-state throughput instead:
+      // load the model and warm the context here, then time the median-of-N below.
+      // Best-effort — a warm-up hiccup must not fail the run (the timed loop will
+      // surface any real inference error). See issue #1139.
+      this._updateStatus('running_ai', 'Warming up AI model...')
+      await this._runSingleAIInference(ollamaAPIURL).catch(() => null)
+
       // Run inference AI_BENCHMARK_RUNS times and take the median run by tok/s (W7).
       // A single inference is noisy (scheduler, thermal, cache); the median damps
-      // outliers without a warmup-run bias. TTFT is reported from the same run that
-      // is the tok/s median, so the two figures always describe one real inference.
+      // outliers. The model is already warm (see the warm-up pass above), so every
+      // timed run measures steady-state throughput. TTFT is reported from the same
+      // run that is the tok/s median, so the two figures always describe one real
+      // inference.
       const runs: { tps: number; ttft: number }[] = []
       for (let i = 0; i < AI_BENCHMARK_RUNS; i++) {
         this._updateStatus('running_ai', `Running AI benchmark (${i + 1}/${AI_BENCHMARK_RUNS})...`)


### PR DESCRIPTION
Draft fix for #1139.

## Problem

`_runAIBenchmark()` evicts resident models (forcing the benchmark model cold), then runs the timed median-of-3 loop with no warm-up. The model-load + GPU spin-up cost lands inside the timed runs, so:

- A cold first run undershoots badly (observed **173s TTFT / 5.83 tok/s** where warm steady-state was **~80 tok/s**).
- Consecutive runs aren't isolated — a prior run leaves the model warm, so the second run of a session scores much higher.

Because the AI channel is uncapped and ~30% of the composite, this swung the NOMAD Score **888 → 1958** between two back-to-back Full Benchmarks on the same RTX 5060 box (CPU/mem/disk were all within a few percent). Full data in #1139.

## Fix

Add one discarded warm-up inference after the eviction and before the timed loop, so every timed run measures warm, steady-state throughput. Cold and warm invocations converge on the same score. Best-effort: a warm-up hiccup never fails the run.

```
evict resident models   (unchanged)
run one throwaway inference   <-- new: loads model to GPU, warms context
time the median-of-N   (unchanged)
```

Cost: one extra inference per Full Benchmark (the cold-load time that today pollutes run 1).

## Validation

- `admin` typecheck passes.
- Still to do before marking ready: a cold-start convergence run on real hardware (restart Ollama to force cold, then confirm the first post-fix Full Benchmark scores like a warm run rather than ~2x lower).

## Follow-up

Once the harness is warm-stable, spot-check whether the Reference Build AI constant (`REFERENCE_SCORES_V2.ai_tokens_per_second = 13.2`) still holds under the warmed method.