### PR TITLE
docs: recommend Ubuntu 26.04 LTS as the default base

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -87,6 +87,7 @@ body:
       label: Operating System
       description: What OS are you running NOMAD on?
       options:
+        - Ubuntu 26.04 (Resolute Raccoon)
         - Ubuntu 24.04
         - Ubuntu 22.04
         - Ubuntu 20.04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ When opening an issue:
 
 ### Prerequisites
 
-- A Debian-based OS (Ubuntu recommended)
+- A Debian-based OS (Ubuntu 26.04 LTS recommended)
 - `sudo`/root privileges
 - Docker installed and running
 - A stable internet connection (required for dependency downloads)

--- a/FAQ.md
+++ b/FAQ.md
@@ -26,7 +26,7 @@ Long answer: Custom storage paths, mount points, and external drives (like iSCSI
 
 ## Why does NOMAD require a Debian-based OS?
 
-Project NOMAD is currently designed to run on Debian-based Linux distributions (with Ubuntu being the recommended distro) because our installation scripts and Docker configurations are optimized for this environment. While it's technically possible to run the Docker containers on other operating systems that support Docker, we have not tested or optimized the installation process for non-Debian-based systems, so we cannot guarantee a smooth experience on those platforms at this time.
+Project NOMAD is currently designed to run on Debian-based Linux distributions (with Ubuntu 26.04 LTS being the recommended version) because our installation scripts and Docker configurations are optimized for this environment. While it's technically possible to run the Docker containers on other operating systems that support Docker, we have not tested or optimized the installation process for non-Debian-based systems, so we cannot guarantee a smooth experience on those platforms at this time.
 
 Support for other operating systems will come in the future, but because our development resources are limited as a free and open-source project, we needed to prioritize our efforts and focus on a narrower set of supported platforms for the initial release. We chose Debian-based Linux as our starting point because it's widely used, easy to spin up, and provides a stable environment for running Docker containers.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 Project NOMAD is a self-contained, offline-first knowledge and education server packed with critical tools, knowledge, and AI to keep you informed and empowered — anytime, anywhere.
 
 ## Installation & Quickstart
-Project NOMAD can be installed on any Debian-based operating system (we recommend Ubuntu). Installation is completely terminal-based, and all tools and resources are designed to be accessed through the browser, so there's no need for a desktop environment if you'd rather setup NOMAD as a "server" and access it through other clients.
+Project NOMAD can be installed on any Debian-based operating system (we recommend Ubuntu 26.04 LTS; 24.04 LTS and Debian 12 are also supported). Installation is completely terminal-based, and all tools and resources are designed to be accessed through the browser, so there's no need for a desktop environment if you'd rather setup NOMAD as a "server" and access it through other clients.
 
 *Note: sudo/root privileges are required to run the install script*
 
@@ -77,7 +77,7 @@ At its core, however, NOMAD is still very lightweight. For a barebones installat
 - Processor: 2 GHz dual-core processor or better
 - RAM: 4GB system memory
 - Storage: At least 5 GB free disk space
-- OS: Debian-based (Ubuntu recommended)
+- OS: Debian-based (Ubuntu 26.04 LTS recommended)
 - Stable internet connection (required during install only)
 
 To run LLMs and other included AI tools:
@@ -87,7 +87,7 @@ To run LLMs and other included AI tools:
 - RAM: 32 GB system memory
 - Graphics: NVIDIA RTX 3060 or AMD equivalent or better (more VRAM = run larger models)
 - Storage: At least 250 GB free disk space (preferably on SSD)
-- OS: Debian-based (Ubuntu recommended)
+- OS: Debian-based (Ubuntu 26.04 LTS recommended)
 - Stable internet connection (required during install only)
 
 **For detailed build recommendations at three price points ($150–$1,000+), see the [Hardware Guide](https://www.projectnomad.us/hardware).**

--- a/admin/docs/getting-started.md
+++ b/admin/docs/getting-started.md
@@ -84,7 +84,7 @@ NOMAD includes a built-in AI chat interface powered by Ollama. It runs entirely 
 
 **Note:** The AI Assistant must be installed first. Enable it during Easy Setup or install it from the [Supply Depot](/supply-depot).
 
-**GPU Acceleration:** If your server has an NVIDIA GPU with the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed, NOMAD will automatically use it for AI — dramatically faster responses (10-20x improvement). If you add a GPU later, go to the [Supply Depot](/supply-depot) and **Force Reinstall** the AI Assistant to enable it.
+**GPU Acceleration:** If your server has an NVIDIA GPU, NOMAD's installer sets up GPU support for you (it installs the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) and configures Docker automatically). You only need the NVIDIA driver present on the host, which on Ubuntu you get by enabling "Install third-party drivers" during setup. With a GPU, AI responses are dramatically faster (10-20x improvement). If you add a GPU later, go to the [Supply Depot](/supply-depot) and **Force Reinstall** the AI Assistant to enable it.
 
 ---
 


### PR DESCRIPTION
## Summary

Project NOMAD is now validated on **Ubuntu 26.04 LTS** across two independent builds (an AMD/CPU-only box and an NVIDIA RTX 5060 box), both installing cleanly with the standard one-command install. This updates the docs to recommend 26.04 as the default base. **24.04 LTS and Debian 12 remain supported.**

## Changes

- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — add "Ubuntu 26.04 (Resolute Raccoon)" to the OS dropdown (above 24.04).
- **`README.md`** — intro + both min-spec OS lines name Ubuntu 26.04 LTS as recommended.
- **`CONTRIBUTING.md` / `FAQ.md`** — name Ubuntu 26.04 LTS as the recommended version.
- **`admin/docs/getting-started.md`** (in-app GUI doc) — correct the GPU-acceleration note: the installer sets up the NVIDIA Container Toolkit and Docker runtime **automatically**; the user only needs the NVIDIA driver present (via "Install third-party drivers" during Ubuntu setup). Previously it implied the user had to install the toolkit themselves.

## Notes

- The install script's OS gate (`check_is_debian_based`) already accepts 26.04, so no code change is needed.
- The WSL2 community guide is intentionally left on 24.04 (separate community-validated path).
- Website install-guide copy (the "download 24.04" step) is being updated separately on the site.