### PR TITLE
docs: point MeshCore Web to the official meshcore.io site

### DIFF
--- a/admin/docs/supply-depot-apps.md
+++ b/admin/docs/supply-depot-apps.md
@@ -265,9 +265,9 @@ A complete offline learning platform from Learning Equality. Kolibri pulls toget
 **Works offline:** Fully offline once content is imported, that's what Kolibri is for. The only step that uses the internet is importing channels from Kolibri Studio; everything after that, browsing lessons, doing exercises, tracking progress, runs entirely on your NOMAD.
 ## MeshCore Web {% #meshcore-web %}
 
-A browser-based client for [MeshCore](https://meshcore.co.uk) radios. MeshCore is another take on off-grid, long-range LoRa mesh messaging, a sibling to Meshtastic: small radios that form their own network and pass text and location for miles with no cell service, no internet, and no fees. This app is how you configure a MeshCore radio and read and send messages from a full-size screen. If you're not already running MeshCore gear, the Meshtastic client above is the more common starting point. This one is here for people who use MeshCore.
+A browser-based client for [MeshCore](https://meshcore.io) radios. MeshCore is another take on off-grid, long-range LoRa mesh messaging, a sibling to Meshtastic: small radios that form their own network and pass text and location for miles with no cell service, no internet, and no fees. This app is how you configure a MeshCore radio and read and send messages from a full-size screen. If you're not already running MeshCore gear, the Meshtastic client above is the more common starting point. This one is here for people who use MeshCore.
 
-**Official site:** [meshcore.co.uk](https://meshcore.co.uk) · **Source:** [github.com/aXistem-dev/meshcore-web](https://github.com/aXistem-dev/meshcore-web) (a packaged build of Liam Cottle's MeshCore client)
+**Official site:** [meshcore.io](https://meshcore.io) · **Source:** [github.com/aXistem-dev/meshcore-web](https://github.com/aXistem-dev/meshcore-web) (a packaged build of Liam Cottle's MeshCore client)
 
 **You need a MeshCore radio to use this.** Like the Meshtastic client, this is just the control panel. With no radio connected, there's nothing for it to talk to.
 


### PR DESCRIPTION
The MeshCore Web section of the Supply Depot apps doc listed **meshcore.co.uk** as the "Official site." The canonical MeshCore project — the firmware and protocol repo at [github.com/meshcore-dev/MeshCore](https://github.com/meshcore-dev/MeshCore) — declares its homepage as **meshcore.io** (set in both the repo homepage and the org profile).

This updates the two references in the MeshCore Web section (`admin/docs/supply-depot-apps.md`) to point at the official site.

- Reported by a community member in Discord.
- Docs-only, 2 lines. The `aXistem-dev/meshcore-web` image source and all internal identifiers are unchanged (they're correct).
- Verified `meshcore.co.uk` no longer appears anywhere in the repo.