### PR TITLE
catalog: add The Modern Rogue creator pack

### DIFF
--- a/collections/creator-packs.json
+++ b/collections/creator-packs.json
@@ -22,6 +22,17 @@
       "video_count": 30,
       "size_mb": 2899,
       "license_id": "nomad-creator-pack-1.0"
+    },
+    {
+      "id": "modern-rogue",
+      "name": "The Modern Rogue",
+      "creator": "Brian Brushwood",
+      "description": "Discovering the function and design of whatever makes life more interesting.",
+      "version": "2026-07",
+      "resource_id": "modern-rogue",
+      "video_count": 37,
+      "size_mb": 5177,
+      "license_id": "nomad-creator-pack-1.0"
     }
   ]
 }


### PR DESCRIPTION
Adds **The Modern Rogue** (Brian Brushwood) as the third entry in the Creator Packs catalog (`collections/creator-packs.json`, served from `main`).

| Field | Value |
|---|---|
| id / resource_id | `modern-rogue` |
| version | `2026-07` |
| videos | 37 |
| size_mb | 5177 (5.18 GB) |
| license | `nomad-creator-pack-1.0` |

**Pipeline status:**
- ZIM `modern-rogue_2026-07.zim` built and uploaded to the private R2 bucket (`nomad-creator-packs`).
- Verified serveable via the entitlement Worker: `HTTP 200`, Content-Length matches, Range requests return `206` with valid ZIM magic.
- Metadata + branding (title, creator, illustration icon, 37/37 videos) verified in the ZIM.

Once merged, the pack appears in Content Explorer / Creator Packs and installs via the standard gated-download rail.

**Note (separate from this PR):** the Worker's `APP_KEY` secret was set to match the shipped `CREATOR_PACKS_APP_KEY` build value — without that, every pack download 401s. The CI build secret must carry the same value for GA.