### PR TITLE
catalog: add The Modern Rogue creator pack (dev)

### DIFF
--- a/collections/creator-packs.json
+++ b/collections/creator-packs.json
@@ -22,6 +22,17 @@
       "video_count": 30,
       "size_mb": 2899,
       "license_id": "nomad-creator-pack-1.0"
+    },
+    {
+      "id": "modern-rogue",
+      "name": "The Modern Rogue",
+      "creator": "Brian Brushwood",
+      "description": "Discovering the function and design of whatever makes life more interesting.",
+      "version": "2026-07",
+      "resource_id": "modern-rogue",
+      "video_count": 37,
+      "size_mb": 5177,
+      "license_id": "nomad-creator-pack-1.0"
     }
   ]
 }


### PR DESCRIPTION
Adds **The Modern Rogue** to `collections/creator-packs.json` on `dev`, mirroring #1145 (which targets `main` so the pack appears on live installs now).

Both are needed: `main` is the branch the app fetches the manifest from, but `dev` must also carry the entry or the next `dev`→`main` release merge would drop it. Same entry, both branches.

ZIM `modern-rogue_2026-07.zim` is uploaded to R2 and verified serveable via the Worker (200 + valid ZIM magic).