### PR TITLE
fix(benchmark): block leaderboard submission when AI runs on a remote host

### DIFF
--- a/admin/app/services/benchmark_service.ts
+++ b/admin/app/services/benchmark_service.ts
@@ -260,6 +260,25 @@ export class BenchmarkService {
       throw new Error('Benchmark result has already been submitted')
     }
 
+    // Remote inference cannot be attributed to this machine.
+    //
+    // DockerService.getServiceURL() resolves ai.remoteOllamaUrl ahead of the
+    // local container, so when a remote host is configured the AI channel
+    // measures THAT machine while every other channel measures this one. The
+    // submission would report someone else's tok/s under this hardware, and AI
+    // carries 0.30 of an uncapped v2 score, so the distortion is large.
+    //
+    // Blocks submission only — running the benchmark locally is still useful to
+    // the operator, it just isn't a result about this box.
+    const remoteOllamaUrl = await KVStore.getValue('ai.remoteOllamaUrl')
+    if (remoteOllamaUrl) {
+      throw new Error(
+        'This NOMAD is configured to use a remote AI host, so its AI results measure that machine rather than this one. ' +
+          'Leaderboard results must be measured entirely on the submitting hardware. ' +
+          'To share a result, install the local AI Assistant and run a Full Benchmark.'
+      )
+    }
+
     // Build the v2 payload (raw channels; server recomputes the score). Throws a
     // user-facing error if the row predates v2 and lacks the raw channels.
     const submission = this._buildV2Submission(result, anonymous ?? false)


### PR DESCRIPTION
Refs #1151. Targeting `rc` for 1.34.0-rc.3.

## The problem

`DockerService.getServiceURL()` resolves `ai.remoteOllamaUrl` ahead of the local container:

```ts
if (serviceName === SERVICE_NAMES.OLLAMA) {
  const remoteUrl = await KVStore.getValue('ai.remoteOllamaUrl')
  if (remoteUrl) return remoteUrl
}
```

So when a remote AI host is configured, the AI channel measures **that** machine while every other channel measures this one. The submission reports someone else's tok/s under this hardware's CPU, RAM and disk.

Under v2 this matters more than it did under v1: `ai_tokens_per_second` carries **0.30** of the weight and the score is **uncapped**, so a remote GPU's throughput is no longer limited by a clamp.

## The change

19 lines, one file — a guard alongside the existing submit-time checks.

**It uses the same truthiness predicate as `getServiceURL`**, so it fires exactly when the remote routing it guards against would occur. The two can't disagree about what "remote" means.

Verified against the KV semantics: `clearValue()` sets the value to `null` and `getValue()` returns `null` for that, so a cleared key correctly does **not** trip the guard. (The known KV string-vs-boolean gotcha doesn't apply — this key is string-typed, so `getValue` returns the raw string.)

**Blocks submission only.** Running the benchmark locally is still useful to the operator; it just isn't a result about this box, so it shouldn't go on a board that ranks hardware.

## Known limitation, stated deliberately

The check reads the KV at **submit** time, not at **measurement** time. Benchmarking with a remote host, then clearing the setting, then submitting would still get through.

That's a deliberate workaround rather than an accident, and closing it properly needs a column on `benchmark_results` recording how inference was reached. Worth doing if it ever shows up in practice — not worth a migration on the evidence available.

## Why `Refs` and not `Closes`

#1151 also carries a second item (reporting the sysbench digest actually resolved, rather than the compiled-in constant). That one touches the same constants as #1156's image swap, so it'll ship with that PR to avoid two changes fighting over the same lines. Leaving #1151 open until both land.

## Server side

Already deployed. The leaderboard can't detect this on its own — a remote-inference submission is indistinguishable from a local one once it arrives, which is why the fix has to be client-side. This is the one integrity problem in the current set where prevention is actually available rather than just detection.