### PR TITLE
docs: document Ubuntu 26.04 LTS as the recommended OS in the in-app docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ Because NOMAD relies heavily on Docker, we actually recommend against installing
 
 ## UI Consistency
 
-N.O.M.A.D.'s guiding principle is that **user-friendliness is paramount**: a control that looks or behaves differently from the rest of the app reads as broken to a non-technical user. New frontend (inertia/React) work should be visually and behaviorally uniform with what is already there. Before adding a UI element, look at its neighbors and reuse the shared building blocks rather than hand-rolling a one-off.
+NOMAD's guiding principle is that **user-friendliness is paramount**: a control that looks or behaves differently from the rest of the app reads as broken to a non-technical user. New frontend (inertia/React) work should be visually and behaviorally uniform with what is already there. Before adding a UI element, look at its neighbors and reuse the shared building blocks rather than hand-rolling a one-off.
 
 **Reuse the shared components** in `admin/inertia/components/` (and `.../components/inputs/`):
 

--- a/admin/docs/faq.md
+++ b/admin/docs/faq.md
@@ -11,6 +11,15 @@ No — that's the whole point. Once your content is downloaded, everything works
 - Update the software
 - Sync the latest versions of Wikipedia, maps, etc.
 
+### What operating system does NOMAD need?
+Debian-based Linux. **Ubuntu 26.04 LTS is what we recommend and test on** for new installs.
+
+Ubuntu 24.04 LTS and Debian 12 are also supported, so there is no need to reinstall if you are already on one of those. Windows users can follow the [WSL2 guide](https://www.projectnomad.us/install/wsl2), which is community-supported.
+
+macOS and non-Debian distributions like Fedora or Arch are not officially supported. NOMAD does not need a desktop environment, so Ubuntu Server is a fine choice if you are comfortable at the terminal.
+
+For a full walkthrough including the Ubuntu install itself, see the [Installation Guide](https://www.projectnomad.us/install).
+
 ### What hardware do I need?
 NOMAD is designed for capable hardware, especially if you want to use the AI features. Recommended:
 - Modern multi-core CPU (AMD Ryzen 7 with Radeon graphics is the community sweet spot)

--- a/admin/docs/getting-started.md
+++ b/admin/docs/getting-started.md
@@ -4,6 +4,55 @@ This guide will help you get the most out of your NOMAD server.
 
 ---
 
+## System Requirements
+
+If you already have NOMAD running, you can skip this section. It is here for when you are planning a second server, moving to different hardware, or helping someone else get set up.
+
+### Operating System
+
+NOMAD runs on Debian-based Linux.
+
+| Support level | Operating system |
+|---|---|
+| **Recommended** | Ubuntu 26.04 LTS |
+| **Also supported** | Ubuntu 24.04 LTS, Debian 12 |
+| **Community-supported** | Windows via WSL2, other Debian derivatives |
+
+Ubuntu 26.04 LTS is the version we test on and the one we recommend for new installs. If you are already running 24.04 LTS or Debian 12, there is no need to reinstall, both are still supported.
+
+Ubuntu Desktop is the friendlier choice if you are coming from Windows or macOS. Ubuntu Server works just as well if you are comfortable at the terminal, and NOMAD does not need a desktop environment either way since everything is accessed through a browser.
+
+macOS and non-Debian distributions like Fedora or Arch are not officially supported.
+
+### Hardware
+
+NOMAD itself is lightweight. What drives your requirements is the content and tools you choose to install, and whether you want to run AI locally.
+
+**Minimum, without local AI:**
+
+- 2 GHz dual-core processor
+- 4 GB RAM
+- 5 GB free disk space, plus room for whatever content you download
+
+**Recommended, with local AI:**
+
+- AMD Ryzen 7 or Intel Core i7 or better
+- 32 GB RAM
+- NVIDIA RTX 3060 or AMD equivalent, more VRAM lets you run larger models
+- 250 GB or more of free disk space, preferably an SSD
+
+A stable internet connection is required during installation only. After that, NOMAD is designed to run fully offline.
+
+### A note on GPU drivers
+
+The installer sets up Docker and the NVIDIA Container Toolkit for you, but it does **not** install the GPU driver itself. You need that on the host beforehand.
+
+On Ubuntu, the easiest way is to check **"Install third-party drivers for graphics and Wi-Fi hardware"** during setup. If you skipped that, or you added the GPU later, install the driver first and then use **Force Reinstall** on the AI Assistant in the [Supply Depot](/supply-depot) to pick it up.
+
+Without a GPU, the AI Assistant still works. It just runs on the CPU, which is considerably slower.
+
+---
+
 ## Easy Setup Wizard
 
 If this is your first time using NOMAD, the Easy Setup wizard will help you get everything configured.

--- a/install/update_nomad.sh
+++ b/install/update_nomad.sh
@@ -139,7 +139,7 @@ get_local_ip() {
 }
 
 success_message() {
-  echo -e "${GREEN}#${RESET} Project N.O.M.A.D update completed successfully!\\n"
+  echo -e "${GREEN}#${RESET} Project NOMAD update completed successfully!\\n"
   echo -e "${GREEN}#${RESET} Installation files are located at /opt/project-nomad\\n\n"
   echo -e "${GREEN}#${RESET} Project NOMAD's Command Center should automatically start whenever your device reboots. However, if you need to start it manually, you can always do so by running: ${WHITE_R}${nomad_dir}/start_nomad.sh${RESET}\\n"
   echo -e "${GREEN}#${RESET} You can now access the management interface at http://localhost:8080 or http://${local_ip_address}:8080\\n"


### PR DESCRIPTION
## What

Adds system requirements to the in-app documentation, where there was previously no OS or hardware guidance at all. A user reading the docs inside NOMAD had no way to find out which operating system is recommended.

- **`admin/docs/getting-started.md`** — new **System Requirements** section covering supported operating systems, minimum and recommended hardware, and GPU driver expectations.
- **`admin/docs/faq.md`** — new "What operating system does NOMAD need?" entry, placed above the existing hardware question.

Ubuntu 26.04 LTS is documented as recommended, with 24.04 LTS and Debian 12 listed as still supported so existing users aren't pushed toward an unnecessary reinstall.

This brings the in-app docs in line with the README, FAQ, and CONTRIBUTING guidance already on this branch, and with the projectnomad.us install guide.

## Also included

Two remaining `N.O.M.A.D.` references, which are the last ones left in the repo:

- `CONTRIBUTING.md` — UI Consistency section
- `install/update_nomad.sh` — update success message

## Notes

- **Documentation only.** No code paths, no migrations, no behaviour changes.
- The GPU note states explicitly that the installer sets up Docker and the NVIDIA Container Toolkit but **does not** install the GPU driver itself. That has caught people out during setup.
- The table follows the headered-table convention already used in `admin/docs/home.md`.
- Targeting `rc` rather than `dev` so the guidance ships with 1.34.0 GA alongside the branding cleanup, rather than a release behind it.

## Deliberately not changed

- **The WSL2 install guide stays at 24.04.** It carries benchmark comparisons measured on 24.04, so changing the version would misrepresent what was tested. It should be re-benchmarked before that page moves.
- **The `/guides` blurb stays generic.** It describes the install video, which shows an older Ubuntu release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
