### PR TITLE
fix(benchmark): name the fix in the remote-host block, log warm-up failures

### DIFF
--- a/admin/app/services/benchmark_service.ts
+++ b/admin/app/services/benchmark_service.ts
@@ -292,9 +292,14 @@ export class BenchmarkService {
     const remoteOllamaUrl = await KVStore.getValue('ai.remoteOllamaUrl')
     if (remoteOllamaUrl) {
       throw new Error(
-        'This NOMAD is configured to use a remote AI host, so its AI results measure that machine rather than this one. ' +
-          'Leaderboard results must be measured entirely on the submitting hardware. ' +
-          'To share a result, install the local AI Assistant and run a Full Benchmark.'
+        // Name the setting and where it lives. The previous wording told the
+        // user to install the AI Assistant, but configuring a remote host
+        // already marks it installed — so it sent them looking for something
+        // they believe they have, and never mentioned the one thing that fixes
+        // it.
+        'This NOMAD is set to use a remote AI host, so the AI portion of this benchmark measured that machine, not this one. ' +
+          'Leaderboard results have to be measured entirely on the hardware being submitted. ' +
+          'To share a result, clear the remote host under Settings → Models so AI runs locally, then run a Full Benchmark.'
       )
     }
 
@@ -947,8 +952,17 @@ export class BenchmarkService {
       // load the model and warm the context here, then time the median-of-N below.
       // Best-effort — a warm-up hiccup must not fail the run (the timed loop will
       // surface any real inference error). See issue #1139.
+      // Log the swallowed failure. Silently discarding it makes a run whose
+      // reproducibility guarantee did not actually apply indistinguishable from
+      // a clean one after the fact. Matches _unloadResidentModels, the sibling
+      // best-effort helper, which already warns on every swallowed error.
       this._updateStatus('running_ai', 'Warming up AI model...')
-      await this._runSingleAIInference(ollamaAPIURL).catch(() => null)
+      await this._runSingleAIInference(ollamaAPIURL).catch((error) => {
+        logger.warn(
+          `[BenchmarkService] AI warm-up failed (${error?.message ?? error}); the first timed run may be cold.`
+        )
+        return null
+      })
 
       // Run inference AI_BENCHMARK_RUNS times and take the median run by tok/s (W7).
       // A single inference is noisy (scheduler, thermal, cache); the median damps


### PR DESCRIPTION
Two small follow-ups from v1.34.0-rc.3 QA. Both one-liners in `benchmark_service.ts`; no behaviour change to the benchmark itself.

## 1. The remote-host block pointed the wrong way (#1157)

The gate works correctly — it fires exactly when the AI channel was measured through the remote path, since it mirrors the predicate `_runAIBenchmark` uses to pick its endpoint. The **message** was the problem:

> To share a result, install the local AI Assistant and run a Full Benchmark.

But `configureRemote` sets `installed = true`. So a user hitting this already believes the AI Assistant *is* installed, and the message sends them looking for something they think they have — while never naming the one action that resolves it.

```diff
-'This NOMAD is configured to use a remote AI host, so its AI results measure that machine rather than this one. '
-'Leaderboard results must be measured entirely on the submitting hardware. '
-'To share a result, install the local AI Assistant and run a Full Benchmark.'
+'This NOMAD is set to use a remote AI host, so the AI portion of this benchmark measured that machine, not this one. '
+'Leaderboard results have to be measured entirely on the hardware being submitted. '
+'To share a result, clear the remote host under Settings → Models so AI runs locally, then run a Full Benchmark.'
```

## 2. Warm-up failures were silent (#1140)

The warm-up before the timed runs is deliberately best-effort — a hiccup there must not fail the run, and the timed loop surfaces any real inference error. But `.catch(() => null)` logged nothing, so a run whose reproducibility guarantee silently did not apply was indistinguishable from a clean one afterwards.

Now warns, matching `_unloadResidentModels` — the sibling best-effort helper in the same file, which already warns on every swallowed failure. The benchmark still proceeds exactly as before.

This matters more than it looks on slow cold-starts: the PR that added the warm-up cites an observed 173s cold first inference against a 120s client timeout, so the warm-up genuinely can time out and be swallowed on real hardware.

## Known, not addressed here

The gate has no loopback exemption, so someone running Ollama natively on the host and pointing NOMAD at `localhost`/`127.0.0.1`/`host.docker.internal` is measuring *this* machine yet is blocked from submitting. That's a separate behavioural change rather than a copy fix, and it matters most once native-Ollama hosts are in play (the Mac in the ARM plan), so it's worth its own issue post-GA.

Likewise, `canShareBenchmark` has no awareness of the remote setting, so the Share button renders enabled and the user only learns it's blocked after clicking. Pre-emptively disabling it with inline explanation would be the consistent treatment.

## Verification

`npx tsc --noEmit` clean for `benchmark_service.ts`; `logger` was already imported at line 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)