### PR TITLE
fix(benchmark): don't submit unresolved PCI ids as the GPU model

### DIFF
--- a/admin/app/services/benchmark_service.ts
+++ b/admin/app/services/benchmark_service.ts
@@ -151,6 +151,26 @@ const MEMORY_BENCHMARK_THREADS = 4
 // AI is measured as the median of N runs (W7) to damp per-run inference jitter.
 const AI_BENCHMARK_RUNS = 3
 
+/**
+ * Is this GPU "model" a placeholder rather than a real name?
+ *
+ * systeminformation resolves PCI ids against the container's pci.ids database.
+ * When a card is newer than that file it reports the raw id verbatim — an RTX
+ * 5060 comes back as "Device 2d05". Vendor detection still succeeds, so these
+ * strings otherwise pass as legitimate model names and reach the leaderboard.
+ *
+ * Matches the "Device <hex>" shape plus the empty/unknown cases. Deliberately
+ * narrow: it must never reject a real product name, and no shipping GPU is
+ * called "Device" followed by four hex digits.
+ */
+function isUnresolvedGpuModel(model: string): boolean {
+  const s = model.trim()
+  if (s === '') return true
+  if (/^device\s+[0-9a-f]{4}$/i.test(s)) return true
+  if (/^unknown$/i.test(s)) return true
+  return false
+}
+
 // Minimum free disk required before pulling the AI model on first run. llama3.1:8b
 // (Q4) is ~4.9 GB; this covers the model plus headroom for the transient sysbench
 // disk-test file and normal slack. Only enforced when the model isn't already cached.
@@ -510,6 +530,24 @@ export class BenchmarkService {
         gpuModel = discreteGpu?.model || graphics.controllers[0]?.model || null
       }
 
+      // si.graphics() resolves PCI IDs against the container's pci.ids database,
+      // which ages out. A card newer than that file comes back as the literal
+      // "Device <pciid>" — an RTX 5060 reports vendor "NVIDIA Corporation",
+      // model "Device 2d05", vram 32. The vendor string still matches, so the
+      // discrete-GPU finder above accepts it and the authoritative nvidia-smi
+      // path below is skipped by its `if (!gpuModel)` guard.
+      //
+      // That put "Device 2d05" on the public leaderboard, and it is exactly the
+      // newest hardware — the results people most want to show off, and the ones
+      // that anchor the top of the board — that hits this. Treat a placeholder
+      // as no answer so the real detection runs.
+      if (gpuModel && isUnresolvedGpuModel(gpuModel)) {
+        logger.info(
+          `[BenchmarkService] si.graphics() returned an unresolved PCI id ("${gpuModel}"); falling through to authoritative GPU detection`
+        )
+        gpuModel = null
+      }
+
       // Fallback: Check Docker for nvidia runtime and query GPU model via nvidia-smi
       if (!gpuModel) {
         try {
@@ -559,7 +597,10 @@ export class BenchmarkService {
           const systemService = new (await import('./system_service.js')).SystemService(this.dockerService)
           const sysInfo = await systemService.getSystemInfo()
           const sysGpuModel = sysInfo?.graphics?.controllers?.[0]?.model
-          if (sysGpuModel) {
+          // Same si.graphics() source as above, so it can carry the same
+          // placeholder — don't launder an unresolved PCI id in through the
+          // back door.
+          if (sysGpuModel && !isUnresolvedGpuModel(sysGpuModel)) {
             gpuModel = sysGpuModel
           }
         } catch (sysError: any) {


### PR DESCRIPTION
Found during v1.34.0-rc.3 QA. An RTX 5060 reached the **public leaderboard** as `Device 2d05`.

## Cause

`systeminformation` resolves PCI ids against the container's `pci.ids` database, which ages out. A card newer than that file reports the raw id verbatim. Live on NOMAD3:

```json
{ "vendor": "NVIDIA Corporation", "model": "Device 2d05", "vram": 32 }
```

The vendor string still matches, so the discrete-GPU finder accepts `Device 2d05` as a legitimate model name — and the authoritative `nvidia-smi` path immediately below it is skipped, because it is guarded by `if (!gpuModel)`.

## Why it matters

- It targets **exactly the newest hardware** — the results people most want to show off, and the ones that anchor the top of the board.
- It breaks the hardware grouping and per-hardware stats on the leaderboard: the same card appears under two different names depending on how old the submitter's image is.
- The row is already live on the board today.

## Fix

Treat a placeholder as *no answer* so the existing detection chain runs, and apply the same filter to the AMD fallback further down, which reads from the same `si.graphics()` source and could otherwise launder the placeholder back in.

The predicate is deliberately narrow — it must never reject a real product name:

| Input | Verdict |
|---|---|
| `Device 2d05`, `device 2D05`, `Device 1234` | placeholder |
| `""`, `Unknown` | placeholder |
| `NVIDIA GeForce RTX 5060`, `Radeon RX 6800`, `Quadro P2000` | real name |
| `Intel Arc Graphics (Integrated)`, `Radeon 890M` | real name |
| `Device 12345`, `My Device 2d05` | real name |

## Verification

On NOMAD3 (rc.3), both preconditions for the fallback confirmed live:

```
$ docker info --format '{{json .Runtimes}}'   →  "nvidia":{"path":"nvidia-container-runtime"...
$ docker exec nomad_ollama nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits
NVIDIA GeForce RTX 5060, 8151
```

So the row would carry the real name and true VRAM (8151 MB) instead of the id and a bogus 32 MB.

`npx tsc --noEmit` clean for `benchmark_service.ts`.

## Targeting

Opened against `rc` because it affects data quality on the board from the moment 1.34.0 ships, and the change is confined to a fallback path that can only improve the name. Happy to retarget to `dev` if that's too late in the RC cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)