### PR TITLE
chore(collections): surface FDA Drug Reference in Medicine > Standard

### DIFF
--- a/collections/kiwix-categories.json
+++ b/collections/kiwix-categories.json
@@ -61,6 +61,15 @@
               "description": "NIH's consumer health encyclopedia - diseases, conditions, drugs, supplements",
               "url": "https://download.kiwix.org/zim/zimit/medlineplus.gov_en_all_2025-01.zim",
               "size_mb": 1800
+            },
+            {
+              "id": "openfda-drug-labels",
+              "type": "dataset",
+              "version": "2025-01",
+              "title": "FDA Drug Reference",
+              "description": "Offline FDA drug labels - search by drug name",
+              "url": "https://api.fda.gov/download.json",
+              "size_mb": 1700
             }
           ]
         },


### PR DESCRIPTION
> **⛔ DO NOT MERGE UNTIL v1.34.0 GA IS PUBLISHED.** Draft deliberately. Merging early breaks v1.33.0 installs — see below.

## What

Adds the `openfda-drug-labels` entry to the **Medicine → Standard** tier. The entry is byte-identical to the one already on `rc`.

```json
{
  "id": "openfda-drug-labels",
  "type": "dataset",
  "version": "2025-01",
  "title": "FDA Drug Reference",
  "description": "Offline FDA drug labels - search by drug name",
  "url": "https://api.fda.gov/download.json",
  "size_mb": 1700
}
```

## Why it must wait for GA

The category manifest is fetched **live from `main`**, not baked into the image:

```ts
// admin/app/services/collection_manifest_service.ts
zim_categories: 'https://raw.githubusercontent.com/.../refs/heads/main/collections/kiwix-categories.json'
```

So this reaches **every install on every version the moment it merges** — not on their next upgrade.

`type: "dataset"` does not exist in v1.33.0. A grep across `admin/app`, `admin/inertia` and `admin/types` at tag `v1.33.0` returns **zero hits**; it is new in 1.34.0. On a v1.33.0 box the entry would render as an installable resource with no code that understands its type and a URL (`https://api.fda.gov/download.json`) that is not a ZIM.

## Why it must not be forgotten either

This is the discovery path for the Drug Reference. Without it, 1.34.0 ships a working, fully documented feature that cannot be found from Content Explorer — which is how QA found the gap in the first place.

A draft PR rather than a reminder or an issue, deliberately: it cannot be merged by accident, it is visible in the PR queue, and at release it is one click rather than a task someone has to remember and reconstruct.

## Verification

- JSON parses
- The resulting `medicine-standard` resource list is identical to `origin/rc`'s, confirmed by structural comparison rather than eyeballing
- No other tier or category touched

## Release checklist

1. Publish v1.34.0 GA
2. Un-draft and merge this
3. Confirm `GET /api/easy-setup/curated-categories` on a 1.34.0 box lists **FDA Drug Reference** under Medicine → Standard

🤖 Generated with [Claude Code](https://claude.com/claude-code)