### PR TITLE
fix(chat): open full chat in place instead of a new window

### DIFF
--- a/admin/inertia/components/chat/ChatSidebar.tsx
+++ b/admin/inertia/components/chat/ChatSidebar.tsx
@@ -117,18 +117,17 @@ export default function ChatSidebar({
         <img src="/project_nomad_logo.webp" alt="Project NOMAD Logo" className="h-28 w-28 mb-6" />
         <StyledButton
           onClick={() => {
-            if (isInModal) {
-              window.open('/chat', '_blank')
-            } else {
-              router.visit('/home')
-            }
+            // /chat is served by the admin app itself, so navigate in place rather than
+            // spawning a window. Popping out broke anyone running NOMAD as an installed
+            // web app or in kiosk mode, who then had a stray window to get back out of.
+            router.visit(isInModal ? '/chat' : '/home')
           }}
-          icon={isInModal ? 'IconExternalLink' : 'IconHome'}
+          icon={isInModal ? 'IconArrowRight' : 'IconHome'}
           variant="outline"
           size="sm"
           fullWidth
         >
-          {isInModal ? 'Open in New Tab' : 'Back to Home'}
+          {isInModal ? 'Open Full Chat' : 'Back to Home'}
         </StyledButton>
         <StyledButton
           onClick={() => {


### PR DESCRIPTION
## Summary

The pop-out button at the bottom of the chat modal's sidebar called `window.open('/chat', '_blank')`. `/chat` is served by the admin app itself, so this spawned a whole second browser window for a same-origin internal route.

For anyone running NOMAD as an installed web app or in kiosk mode, that leaves a stray window they then have to find their way back out of. That's the complaint in #1123.

## Changes

- Navigate with `router.visit` instead of `window.open`, so the modal expands to the full chat page in place
- Relabel the button from "Open in New Tab" to "Open Full Chat", since it no longer opens a tab
- Swap the external-link icon for `IconArrowRight`. `IconMessage` would have read better but isn't in the `DynamicIcon` registry, which is deliberately curated for tree-shaking, and adding to it for one button didn't seem worth the bundle churn

Six lines, one file, no behavior change outside the modal.

## Scope note

#1123 also asks for app launches (Kiwix, Kolibri) to stay in one window. That part is **not** addressed here and isn't really addressable: those run on separate ports, so they're different origins, and browsers pull an installed web app out to a normal window on cross-origin navigation regardless of the `target` attribute. Only the same-origin `/chat` case is fixed.

## Testing

Built and deployed to NOMAD3 (v1.34.0-rc.3), verified in Chrome:

- Chat modal button now reads "Open Full Chat" with the arrow icon
- Clicking it navigates to `/chat` **in the same tab**, no new window, modal unmounts cleanly
- On the full page the button correctly flips back to "Back to Home" with the home icon, and returns to `/home` in place
- Both branches of the ternary exercised

Also: `tsc -p inertia/tsconfig.json` clean for this file (that config isn't in the pre-push hook and has pre-existing errors elsewhere on `dev`). Prettier reports this file as unformatted both before and after the change, so I left the formatting alone rather than reformat an unrelated 130 lines into the diff.

Refs #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)
