### PR TITLE
content(collections): add CD3WD to Survival & Preparedness comprehensive tier

### DIFF
--- a/collections/kiwix-categories.json
+++ b/collections/kiwix-categories.json
@@ -156,7 +156,7 @@
         {
           "name": "Comprehensive",
           "slug": "survival-comprehensive",
-          "description": "Complete prepper library with food storage strategies and classic military strategy. Includes everything in Standard.",
+          "description": "Complete prepper library with food storage strategies, off-grid technical references, and classic military strategy. Includes everything in Standard.",
           "includesTier": "survival-standard",
           "resources": [
             {
@@ -174,6 +174,14 @@
               "description": "Classic military strategy, tactics, and field manuals",
               "url": "https://download.kiwix.org/zim/gutenberg/gutenberg_en_lcc-u_2026-03.zim",
               "size_mb": 1200
+            },
+            {
+              "id": "cd3wdproject.org_en_all",
+              "version": "2025-11",
+              "title": "CD3WD: Appropriate Technology Library",
+              "description": "Practical guides to food production, water and sanitation, construction, and village-scale manufacturing without industrial supply chains",
+              "url": "https://download.kiwix.org/zim/zimit/cd3wdproject.org_en_all_2025-11.zim",
+              "size_mb": 581
             }
           ]
         }


### PR DESCRIPTION
## Summary

Adds the CD3WD Project ZIM to the `survival-comprehensive` tier, and updates that tier's description to reflect it.

Requested in #1149.

## What CD3WD is

A compilation started in 2003 by Alex Weir, gathering appropriate-technology and development literature from NGO and UN-agency publishers. Content splits roughly into appropriate technology 22%, health 22%, agriculture 16%, construction 14%, with the rest across forestry, fisheries, food processing, engineering, water and sanitation, and education.

In practical terms it's the "how to do things without industrial supply chains" corpus: grain storage and preservation, well drilling and water purification, solar drying, small-scale construction, hand tools, animal husbandry, and clinic-level medicine.

## Why comprehensive tier

The survival category was until now almost entirely YouTube channel archives (Canadian Prepper, Urban Prepper), with Project Gutenberg military science as the only text reference. CD3WD is a substantial practical reference and fits the "complete library" framing of the comprehensive tier.

At 581 MB it's the smallest resource in the category by a wide margin, so the tier's storage footprint barely moves.

## Verification

- URL returns HTTP 206 on a range request, `Content-Range: bytes 0-0/581165229`
- `size_mb: 581` matches this file's decimal-MB convention, confirmed against three existing entries (urban-prepper 2,245,270,178 bytes → 2240; winterprepping 1,341,548,407 → 1340)
- JSON parses, all 6 categories intact
- Kiwix catalog reports 13,297 articles, 50,687 media items, `_ftindex:yes`, already tagged `preppers`

## Notes

**This targets `main` because collection manifests are fetched live from `main`, so it goes live to every install on merge.** That's fine here: it's a plain ZIM in an existing tier structure and needs no code support, unlike #1167.

Two things worth knowing, neither blocking:

- The 2025-11 in the filename is the scrape date, not the content date. The underlying material is decades old. For non-electric, non-industrial methods that's largely a feature, but the health portion shouldn't be read as current medical guidance.
- CD3WD states free access without a formal license. It's a compilation of other organizations' documents. We're linking to the Kiwix-hosted file rather than redistributing anything ourselves, so exposure is low, but it isn't a clean CC or Apache situation.

I did not audit overlap against existing survival or agriculture tiers in depth.

Refs #1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
