### PR TITLE
fix(kb): respect ingest policy when a ZIM is uploaded locally

### DIFF
--- a/admin/app/services/zim_service.ts
+++ b/admin/app/services/zim_service.ts
@@ -597,14 +597,40 @@ export class ZimService {
 
     const ollamaUrl = await this.dockerService.getServiceURL('nomad_ollama')
     if (ollamaUrl) {
+      // Respect the global ingest policy, same as the post-download path (PR #919).
+      // This used to dispatch unconditionally, so a user who deliberately chose
+      // Manual still got sideloaded ZIMs embedded behind their back.
+      //
+      // Reuses decideScanAction rather than re-inlining the Always/Manual check,
+      // so an existing browse_only or pending_decision row is honored too instead
+      // of being overridden by the act of re-uploading the file.
+      const filePath = join(process.cwd(), ZIM_STORAGE_PATH, filename)
       try {
-        const { EmbedFileJob } = await import('#jobs/embed_file_job')
-        await EmbedFileJob.dispatch({
-          fileName: filename,
-          filePath: join(process.cwd(), ZIM_STORAGE_PATH, filename),
-        })
+        const { default: KVStore } = await import('#models/kv_store')
+        const { default: KbIngestState } = await import('#models/kb_ingest_state')
+        const { decideScanAction } = await import('../utils/kb_ingest_decision.js')
+
+        // Unset is treated as Always, preserving legacy behavior — mirrors
+        // rag_service.ts and run_download_job.ts.
+        const policyRaw = await KVStore.getValue('rag.defaultIngestPolicy')
+        const policy = policyRaw === 'Manual' ? 'Manual' : 'Always'
+
+        const existing = await KbIngestState.findBy('file_path', filePath)
+        const action = decideScanAction(existing, false, policy)
+
+        if (action.kind === 'dispatch') {
+          const { EmbedFileJob } = await import('#jobs/embed_file_job')
+          await EmbedFileJob.dispatch({ fileName: filename, filePath })
+        } else if (action.kind === 'create_pending') {
+          // firstOrCreate so the KB panel surfaces the per-file Index affordance
+          // without demoting a row that already exists.
+          await KbIngestState.getOrCreate(filePath)
+        }
+        // 'skip' and 'backfill_indexed' need no action here: the file was just
+        // written to disk, so there is nothing to backfill and a settled state
+        // row means the user has already decided about this file.
       } catch (error) {
-        logger.error(`[ZimService] EmbedFileJob dispatch failed after local upload:`, error)
+        logger.error(`[ZimService] KB ingest decision failed after local upload:`, error)
       }
     }
 


### PR DESCRIPTION
## Summary

`ZimService.registerLocalUpload()` dispatched `EmbedFileJob` unconditionally, gated only on whether Ollama was reachable. It never read `rag.defaultIngestPolicy`:

```ts
const ollamaUrl = await this.dockerService.getServiceURL('nomad_ollama')
if (ollamaUrl) {
  const { EmbedFileJob } = await import('#jobs/embed_file_job')
  await EmbedFileJob.dispatch({ fileName: filename, ... })
}
```

So a user who deliberately set **Manual** and then sideloaded a ZIM got it embedded into the knowledge base anyway.

**PR #919 fixed exactly this for the post-download path. The local-upload path was missed.**

## Approach

Rather than inline a third copy of the Always/Manual conditional, this reuses `decideScanAction`, the same helper `scanAndSyncStorage` uses.

That's not just tidier, it fixes a second case: an existing `browse_only` or `pending_decision` row is now honored, instead of being overridden by the act of re-uploading the file. The inline version in `run_download_job.ts` doesn't do that.

Unset policy is still treated as `Always`, so existing installs keep current behavior.

## Testing

Verified live on NOMAD3 (v1.34.0-rc.3) by uploading the same ZIM through `POST /api/zim/upload` under each policy, then counting the resulting vectors in Qdrant:

| policy | `kb_ingest_state` row | `EmbedFileJob` | points in `nomad_knowledge_base` |
|---|---|---|---|
| **Manual** | `pending_decision`, chunks=0 | not dispatched, no log lines | **0** |
| **Always** | dispatched and processed | `[EmbedFileJob] Dispatched...` | **1076** |

Same file, same code path, difference is entirely the policy. Under Manual the file lands as `pending_decision`, which is what surfaces the per-file Index affordance in the KB panel (PR #909), so the user can still opt it in deliberately.

All test artifacts removed afterward and the box restored to its prior state (11 indexed / 8 pending, policy back to Manual, test vectors deleted).

`npm run typecheck` clean.

Decision logic itself is already covered exhaustively by `tests/unit/kb_ingest_decision.spec.ts`, including every case this call site depends on: no-row + Manual → `create_pending`, no-row + Always → `dispatch`, `browse_only` → `skip`, `pending_decision` + Manual → `skip`.

## Scope

Reported by @just-jbc on #1119, which also proposed disabling ZIM auto-discovery entirely. **That larger change is deliberately not included here.** Turning discovery off by default would mean someone who downloads Wikipedia through our own curated flow gets no AI answers from it and no explanation why. This PR fixes only the part where we ignore a setting the user already chose.

Refs #1119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
