### PR TITLE
content(collections): rebalance Survival & Preparedness, add CD3WD, fix a broken URL

### DIFF
--- a/collections/kiwix-categories.json
+++ b/collections/kiwix-categories.json
@@ -156,7 +156,7 @@
         {
           "name": "Comprehensive",
           "slug": "survival-comprehensive",
-          "description": "Complete prepper library with food storage strategies and classic military strategy. Includes everything in Standard.",
+          "description": "Complete prepper library with food storage strategies, off-grid technical references, and classic military strategy. Includes everything in Standard.",
           "includesTier": "survival-standard",
           "resources": [
             {
@@ -174,6 +174,14 @@
               "description": "Classic military strategy, tactics, and field manuals",
               "url": "https://download.kiwix.org/zim/gutenberg/gutenberg_en_lcc-u_2026-03.zim",
               "size_mb": 1200
+            },
+            {
+              "id": "cd3wdproject.org_en_all",
+              "version": "2025-11",
+              "title": "CD3WD: Appropriate Technology Library",
+              "description": "Practical guides to food production, water and sanitation, construction, and village-scale manufacturing without industrial supply chains",
+              "url": "https://download.kiwix.org/zim/zimit/cd3wdproject.org_en_all_2025-11.zim",
+              "size_mb": 581
             }
           ]
         }

--- a/collections/kiwix-categories.json
+++ b/collections/kiwix-categories.json
@@ -108,9 +108,33 @@
         {
           "name": "Essential",
           "slug": "survival-essential",
-          "description": "Core survival concepts and winter preparedness videos. Start here for emergency basics.",
+          "description": "Water, food, and knot references plus core survival videos. Start here for emergency basics.",
           "recommended": true,
           "resources": [
+            {
+              "id": "zimgit-water_en",
+              "version": "2024-08",
+              "title": "Water Treatment Library",
+              "description": "Collecting, filtering, and purifying drinking water",
+              "url": "https://download.kiwix.org/zim/other/zimgit-water_en_2024-08.zim",
+              "size_mb": 20
+            },
+            {
+              "id": "zimgit-food-preparation_en",
+              "version": "2025-04",
+              "title": "Food for Preppers",
+              "description": "Recipes and techniques for preparing and preserving food",
+              "url": "https://download.kiwix.org/zim/other/zimgit-food-preparation_en_2025-04.zim",
+              "size_mb": 97
+            },
+            {
+              "id": "zimgit-knots_en",
+              "version": "2024-08",
+              "title": "A Library of Knots",
+              "description": "Illustrated guides to knots, lashings, ladders, and sutures",
+              "url": "https://download.kiwix.org/zim/other/zimgit-knots_en_2024-08.zim",
+              "size_mb": 27
+            },
             {
               "id": "canadian_prepper_winterprepping_en",
               "version": "2026-02",
@@ -132,9 +156,33 @@
         {
           "name": "Standard",
           "slug": "survival-standard",
-          "description": "Bug-out strategies and urban survival techniques. Includes everything in Essential.",
+          "description": "Official disaster planning, field skills, and radio communications, plus bug-out and urban survival techniques. Includes everything in Essential.",
           "includesTier": "survival-essential",
           "resources": [
+            {
+              "id": "www.ready.gov_en",
+              "version": "2024-12",
+              "title": "Ready.gov",
+              "description": "Official US disaster planning guidance - weather, fire, evacuation plans, and emergency kits",
+              "url": "https://download.kiwix.org/zim/zimit/www.ready.gov_en_2024-12.zim",
+              "size_mb": 2429
+            },
+            {
+              "id": "outdoors.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "The Great Outdoors Q&A",
+              "description": "Answered questions on hiking, camping, navigation, and wilderness skills",
+              "url": "https://download.kiwix.org/zim/stack_exchange/outdoors.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 142
+            },
+            {
+              "id": "ham.stackexchange.com_en_all",
+              "version": "2026-02",
+              "title": "Amateur Radio Q&A",
+              "description": "Answered questions on radio equipment, antennas, licensing, and emergency communications",
+              "url": "https://download.kiwix.org/zim/stack_exchange/ham.stackexchange.com_en_all_2026-02.zim",
+              "size_mb": 75
+            },
             {
               "id": "canadian_prepper_bugoutconcepts_en",
               "version": "2026-02",
@@ -156,16 +204,32 @@
         {
           "name": "Comprehensive",
           "slug": "survival-comprehensive",
-          "description": "Complete prepper library with food storage strategies, off-grid technical references, and classic military strategy. Includes everything in Standard.",
+          "description": "Complete prepper library - post-disaster recovery, growing and storing food, off-grid technical references, and classic military strategy. Includes everything in Standard.",
           "includesTier": "survival-standard",
           "resources": [
             {
-              "id": "canadian_prepper_preppingfood_en",
-              "version": "2025-09",
+              "id": "canadian-prepper_en_preppingfood",
+              "version": "2026-07",
               "title": "Canadian Prepper: Prepping Food",
               "description": "Long-term food storage and survival meal preparation",
-              "url": "https://download.kiwix.org/zim/videos/canadian_prepper_preppingfood_en_2025-09.zim",
+              "url": "https://download.kiwix.org/zim/videos/canadian-prepper_en_preppingfood_2026-07.zim",
               "size_mb": 2160
+            },
+            {
+              "id": "zimgit-post-disaster_en",
+              "version": "2024-05",
+              "title": "Post Disaster Resource Library",
+              "description": "Shelter, sanitation, salvage, and recovery guidance for the aftermath of a disaster",
+              "url": "https://download.kiwix.org/zim/other/zimgit-post-disaster_en_2024-05.zim",
+              "size_mb": 644
+            },
+            {
+              "id": "100r.co_en_all",
+              "version": "2026-06",
+              "title": "Hundred Rabbits",
+              "description": "Field notes on low-tech living - solar power, water, food, and repair from a decade off-grid",
+              "url": "https://download.kiwix.org/zim/zimit/100r.co_en_all_2026-06.zim",
+              "size_mb": 172
             },
             {
               "id": "gutenberg_en_lcc-u",


### PR DESCRIPTION
**Supersedes #1183** (the CD3WD entry is included here as the first commit, so the two don't conflict on the same file).

## Why

Survival & Preparedness was **10.8 GB, 89% of it YouTube channel archives**. Nothing in Essential or Standard could be read without watching a video, which is the wrong shape for the situations this content exists for: low power, low bandwidth, or just wanting to look something up.

It also has a **live 404**.

## The broken URL

`canadian_prepper_preppingfood_en_2025-09.zim` no longer exists upstream, so **anyone installing the Comprehensive tier today hits a failed download** (#1171). openZIM renamed it to `canadian-prepper_en_preppingfood_2026-07`.

Note the `id` changes too, and that's required rather than cosmetic: `CollectionManifestService.parseZimFilename()` derives `resource_id` from the on-disk filename and looks it up in a map keyed on `res.id`. If the id doesn't equal the filename base, an installed file never matches its catalog entry and the tier shows as incomplete forever. Every id in this PR was checked against its filename.

## What's added

| Tier | Added | Size |
|---|---|---|
| **Essential** | Water Treatment Library, Food for Preppers, A Library of Knots | **144 MB** |
| **Standard** | Ready.gov, The Great Outdoors Q&A, Amateur Radio Q&A | 2,646 MB |
| **Comprehensive** | Post Disaster Resource Library, Hundred Rabbits, CD3WD | 1,397 MB |

Reasoning per tier:

- **Essential** gains the three smallest, most-reached-for references for **144 MB, a 6% increase**. Someone who installs only Essential currently gets two videos and nothing else; now they can look up how to purify water without watching anything.
- **Standard** gains official planning (Ready.gov, FEMA, public domain), field skills (12,951 answered outdoors questions), and **communications**, which was a genuine hole. Comms is a core preparedness topic and the category had nothing on it. 9,205 answered questions for 75 MB.
- **Comprehensive** gains post-disaster recovery, a decade of documented off-grid living from Hundred Rabbits, and CD3WD's appropriate-technology library (requested in #1149).

Text share goes from **11% to 36%**. Category total goes from 10.8 GB to 15.0 GB, all of it opt-in by tier.

## Deliberately not included

- **`gardening.stackexchange`** and **`gutenberg_en_lcc-s`** (Agriculture) are already curated under Agriculture & Food. Cross-listing them would have added 5.4 GB of redundancy.
- **`survivorlibrary.com_en_all`** is arguably the most on-mission corpus in the entire Kiwix library, 14,940 scanned pre-industrial technology books, but it is **252 GB**. Flagging it as worth knowing about, not as curatable.
- **`energypedia_en_all`** overlaps CD3WD, and the available flavour is `nopic`.

## One thing to sanity-check

`zimgit-food-preparation_en` is **cross-listed**: it already appears in `agriculture-standard`. The unique constraint is on `(curated_collection_slug, url)` so this is legal, and it's the same file on disk either way, but there's no existing precedent for cross-listing in this catalog. Rationale: food is core survival, it's only 97 MB, and reaching it via Agriculture would otherwise mean pulling that whole tier. Easy to drop if you'd rather keep one-resource-one-category. (Minor: `agriculture-standard` lists it as 98 MB, actual is 97 MB. Left alone as out of scope.)

## Verification

All 12 URLs range-requested: every one returns **206**, and every `id` matches its filename base. JSON parses, all 6 categories intact, no duplicate ids within any collection.

This targets `main` because collection manifests are fetched live from `main`, so it reaches every install on merge. Every entry is a plain ZIM in the existing tier structure and needs no code support.

Refs #1171, #1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
