### PR TITLE
ci: bring the collection URL validation fix to main

### DIFF
--- a/.github/workflows/validate-collection-urls.yml
+++ b/.github/workflows/validate-collection-urls.yml
@@ -28,22 +28,46 @@ jobs:
             CHECKED=$((CHECKED + 1))
             printf "Checking: %s ... " "$url"
 
-            # Use Range: bytes=0-0 to avoid downloading the full file.
-            # --max-filesize 1 aborts early if the server ignores the Range header
-            # and returns 200 with the full body. The HTTP status is still captured.
+            # HEAD transfers no body at all, so nothing is downloaded even when a
+            # server ignores Range headers. curl can still exit non-zero (DNS,
+            # TLS, timeout), so capture the status without letting `set -e`
+            # (bash -e) kill the whole step mid-loop.
+            METHOD="HEAD"
+            CURL_EXIT=0
             HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-              --range 0-0 \
-              --max-filesize 1 \
+              --head \
               --max-time 30 \
+              --retry 2 \
+              --retry-delay 2 \
               --location \
-              "$url")
+              "$url") || CURL_EXIT=$?
+
+            # Some servers refuse HEAD outright. Fall back to a single-byte
+            # ranged GET for those. --max-filesize caps the damage if the server
+            # ignores the Range header, but has to stay comfortably above a
+            # redirect body: --location applies the limit to the 3xx body too,
+            # and a cap below that aborts on the redirect itself.
+            case "$HTTP_CODE" in
+              403|405|501)
+                METHOD="GET"
+                CURL_EXIT=0
+                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+                  --range 0-0 \
+                  --max-filesize 8192 \
+                  --max-time 30 \
+                  --retry 2 \
+                  --retry-delay 2 \
+                  --location \
+                  "$url") || CURL_EXIT=$?
+                ;;
+            esac
 
             if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "206" ]; then
-              echo "OK ($HTTP_CODE)"
+              echo "OK ($HTTP_CODE via $METHOD)"
             else
-              echo "FAILED ($HTTP_CODE)"
+              echo "FAILED (HTTP $HTTP_CODE via $METHOD, curl exit $CURL_EXIT)"
               FAILED=$((FAILED + 1))
-              FAILED_URLS="$FAILED_URLS\n  - $url (HTTP $HTTP_CODE)"
+              FAILED_URLS="$FAILED_URLS\n  - $url (HTTP $HTTP_CODE via $METHOD, curl exit $CURL_EXIT)"
             fi
           done <<< "$URLS"
 


### PR DESCRIPTION
## Summary

Cherry-picks `13ce691` ("ci: fix collection url validation") from `dev` onto `main`. No new code, authorship preserved.

## Why this matters

The fix has been on `dev` since 2026-07-24 but **never reached `main`**, and `main` is where it's actually needed: collection manifests are fetched live from `main`, so every catalog PR targets `main` and therefore runs `main`'s stale copy of the workflow.

The stale version fails like this:

```
Checking: https://download.kiwix.org/zim/devdocs/devdocs_en_bash_2026-01.zim ...
##[error]Process completed with exit code 63
```

From GitHub's runners, `download.kiwix.org` redirects to a mirror that ignores the `Range` header and returns the full body. `curl` blows past `--max-filesize 1` and exits **63**. The step runs under `bash -e`, so the failing command substitution in `HTTP_CODE=$(curl ...)` kills the script before the `if` can evaluate the code it just captured.

It dies on the **first URL alphabetically** and checks nothing else. Deterministic from GH egress, not flaky, so re-running never helps.

## The consequence

This check exists to catch broken collection URLs. Because it dies at `zim/devdocs/...` and never reaches `zim/videos/...`, **it never caught that `canadian_prepper_preppingfood_en_2025-09.zim` went 404** — a broken download that is live in the Survival Comprehensive tier on `main` right now (#1171, fixed separately in #1187).

So the check has been giving false assurance while a real breakage sat in production, and training everyone to wave through a red X. The next genuinely broken URL would look identical to the noise.

## Verification

Ran the fixed script's logic against the URL that has been killing the old one:

```
HEAD https://download.kiwix.org/zim/devdocs/devdocs_en_bash_2026-01.zim
  -> http=200  curl_exit=0
```

HEAD transfers no body, so a Range-ignoring mirror can't trip a filesize cap. `|| CURL_EXIT=$?` keeps a non-zero curl from killing the step, and the ranged-GET fallback covers servers that refuse HEAD.

And confirming it would catch the real bug:

```
404  canadian_prepper_preppingfood_en_2025-09.zim   (current entry on main)
200  canadian-prepper_en_preppingfood_2026-07.zim   (replacement, in #1187)
```

## Note

#1187 will keep showing the red X until this merges and that branch is rebased onto `main`. Its 12 URLs were each verified by hand at 206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
