### PR TITLE
content(collections): fix four dead Wikipedia download URLs

### DIFF
--- a/collections/wikipedia.json
+++ b/collections/wikipedia.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "2026-03-23",
+  "spec_version": "2026-08-02",
   "options": [
     {
       "id": "none",
@@ -13,39 +13,39 @@
       "id": "top-mini",
       "name": "Quick Reference",
       "description": "Top 100,000 articles with minimal images. Great for quick lookups.",
-      "size_mb": 313,
-      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_top_mini_2025-12.zim",
-      "version": "2025-12"
+      "size_mb": 331,
+      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_top_mini_2026-06.zim",
+      "version": "2026-06"
     },
     {
       "id": "top-nopic",
       "name": "Popular Articles",
       "description": "Top articles without images. Good balance of content and size.",
-      "size_mb": 2100,
-      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_top_nopic_2025-12.zim",
-      "version": "2025-12"
+      "size_mb": 2239,
+      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_top_nopic_2026-06.zim",
+      "version": "2026-06"
     },
     {
       "id": "all-mini",
       "name": "Complete Wikipedia (Compact)",
       "description": "All 6+ million articles in condensed format.",
-      "size_mb": 11400,
-      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_mini_2025-12.zim",
-      "version": "2025-12"
+      "size_mb": 12531,
+      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_mini_2026-06.zim",
+      "version": "2026-06"
     },
     {
       "id": "all-nopic",
       "name": "Complete Wikipedia (No Images)",
       "description": "All articles without images. Comprehensive offline reference.",
-      "size_mb": 49000,
-      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_nopic_2025-12.zim",
-      "version": "2025-12"
+      "size_mb": 52690,
+      "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_nopic_2026-06.zim",
+      "version": "2026-06"
     },
     {
       "id": "all-maxi",
       "name": "Complete Wikipedia (Full)",
       "description": "The complete experience with all images and media.",
-      "size_mb": 118000,
+      "size_mb": 123980,
       "url": "https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_maxi_2026-02.zim",
       "version": "2026-02"
     }


### PR DESCRIPTION
## The problem

**Four of the five Wikipedia packages are 404.** They point at 2025-12 builds that openZIM has since rolled forward and deleted.

| Option | Shown size | URL | Status |
|---|---|---|---|
| Quick Reference | 313 MB | `wikipedia_en_top_mini_2025-12` | **404** |
| Popular Articles | 2.1 GB | `wikipedia_en_top_nopic_2025-12` | **404** |
| Complete Wikipedia (Compact) | 11.4 GB | `wikipedia_en_all_mini_2025-12` | **404** |
| Complete Wikipedia (No Images) | 49 GB | `wikipedia_en_all_nopic_2025-12` | **404** |
| Complete Wikipedia (Full) | 118 GB | `wikipedia_en_all_maxi_2026-02` | OK |

The only surviving option is the 124 GB full build, which is the one almost nobody picks. So in practice, **a user choosing any sensible Wikipedia size during Easy Setup gets a failed download** — and Wikipedia is close to the headline feature.

Reproduced on NOMAD3 (v1.34.0-rc.3): Content Explorer shows "Wikipedia download failed. Select a package and try again."

## The fix

Repointed all four at the current **2026-06** builds, and corrected every `size_mb` from the measured `Content-Length`. The old numbers were estimates and had drifted by up to 8%:

| Option | Was | Now (measured) |
|---|---|---|
| Quick Reference | 313 | **331** |
| Popular Articles | 2100 | **2239** |
| Complete (Compact) | 11400 | **12531** |
| Complete (No Images) | 49000 | **52690** |
| Complete (Full) | 118000 | **123980** |

Sizes are decimal MB, consistent with `kiwix-categories.json`.

## Verification

Every URL re-probed with a browser User-Agent and retry backoff:

```
200  wikipedia_en_top_mini_2026-06.zim
200  wikipedia_en_top_nopic_2026-06.zim
200  wikipedia_en_all_mini_2026-06.zim
200  wikipedia_en_all_nopic_2026-06.zim
200  wikipedia_en_all_maxi_2026-02.zim
```

## Why this went unnoticed, and why it won't self-heal

Two independent gaps:

1. **The URL validation CI has never actually run to completion.** It dies with curl exit 63 on the first URL alphabetically and checks nothing after it. Fix exists on `dev`, not on `main` — see #1188.

2. **Content auto-update can't repair this class of breakage.** `CollectionUpdateService.checkForUpdates()` only inspects `InstalledResource` rows, so it upgrades content you already have. It never re-validates catalog entries you *haven't* installed. A dead link in the catalog stays dead until a human notices. Related: #1171.

This targets `main` because manifests are fetched live from `main`. Merging publishes the fix to every install immediately, which is what we want here.

Refs #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)
