### PR TITLE
fix(downloads): don't 500 the jobs endpoint on an orphaned BullMQ job

### DIFF
--- a/admin/app/services/download_service.ts
+++ b/admin/app/services/download_service.ts
@@ -47,7 +47,12 @@ export class DownloadService {
       ...active.map((j) => ({ job: j, state: 'active' as const })),
       ...delayed.map((j) => ({ job: j, state: 'delayed' as const })),
       ...failed.map((j) => ({ job: j, state: 'failed' as const })),
-    ]
+      // A job id can outlive its payload hash — BullMQ still returns an entry for
+      // it, with `data` empty. One of those in the failed set used to throw on
+      // every poll of this endpoint (normalize(undefined)), and because failed
+      // jobs are never evicted the endpoint stayed broken until Redis was cleared
+      // by hand. Drop them: with no payload there is nothing to show anyway.
+    ].filter(({ job }) => job?.id != null && job.data != null)
   }
 
   async listDownloadJobs(filetype?: string): Promise<DownloadJobWithProgress[]> {
@@ -65,7 +70,7 @@ export class DownloadService {
         jobId: job.id!.toString(),
         url: job.data.url,
         progress: parsed.percent,
-        filepath: normalize(job.data.filepath),
+        filepath: job.data.filepath ? normalize(job.data.filepath) : '',
         filetype: job.data.filetype,
         title: job.data.title || undefined,
         downloadedBytes: parsed.downloadedBytes,
@@ -82,7 +87,7 @@ export class DownloadService {
         jobId: job.id!.toString(),
         url: job.data.sourceUrl,
         progress: parsed.percent,
-        filepath: normalize(job.data.outputFilepath),
+        filepath: job.data.outputFilepath ? normalize(job.data.outputFilepath) : '',
         filetype: job.data.filetype || 'map',
         title: job.data.title || undefined,
         downloadedBytes: parsed.downloadedBytes,


### PR DESCRIPTION
**Targeting `rc` for 1.34.0 GA.** Small, contained, and the failure mode is a permanently broken Content Explorer on a user's box.

## The bug

A job id can outlive its payload hash. BullMQ still returns an entry for it with empty `data`, so this threw:

```ts
filepath: normalize(job.data.filepath),
```

`fetchJobsWithStates()` includes **failed** jobs, and failed jobs are retained deliberately. So one orphan makes `GET /api/downloads/jobs` throw on **every** call, forever. It survives restarts. The only cure was editing Redis by hand.

Content Explorer polls that endpoint every ~3s, so the symptom is `Request failed with status code 500` on repeat and a page that never loads.

## Found in the wild

Hit on NOMAD3 running v1.34.0-rc.3 — **93 occurrences in 15 minutes**, one per poll. `bull:downloads:failed` held two ids: one legitimate failed download, one with no payload hash at all.

This was not a synthetic edge case; it happened on a normal test box during ordinary use, and it took the whole Content Explorer page down with it.

## The fix

Drop entries with no usable payload at the source in `fetchJobsWithStates()`, and guard both `normalize()` calls — the pmtiles-extract map a few lines below had the identical pattern. With no payload there is nothing to render anyway, so filtering loses nothing.

## Testing

Reproduced the exact condition against a patched build on NOMAD3 by injecting an orphan:

```bash
docker exec nomad_redis redis-cli ZADD bull:downloads:failed 1 "orphan-repro-test"
```

| | unpatched | patched |
|---|---|---|
| `/api/downloads/jobs` | 500, every call | **200, every call** |
| `ERR_INVALID_ARG_TYPE` in 30s | 10+ | **0** |
| legitimate failed job still listed | n/a (500) | **yes** |

The real failed download in the queue still renders correctly with the orphan present, so the filter isn't over-broad.

`npm run typecheck` clean. NOMAD3 restored to stock afterwards.

Closes #1190

🤖 Generated with [Claude Code](https://claude.com/claude-code)
