### PR TITLE
feat(dashboard): round out the v1.34 What's new highlights

### DIFF
--- a/admin/inertia/components/WhatsNewBanner.tsx
+++ b/admin/inertia/components/WhatsNewBanner.tsx
@@ -18,8 +18,11 @@ const WHATS_NEW = {
   version: '1.34',
   title: "What's new in v1.34",
   highlights: [
-    'Creator Packs — install curated video packs from your favorite creators and watch them fully offline.',
-    'Medication Reference — offline FDA drug-label lookup for quick, reliable medication information.',
+    'Creator Packs - install curated video packs from your favorite creators and watch them fully offline.',
+    'Medication Reference - offline FDA drug-label lookup for quick, reliable medication information.',
+    'Benchmark Score v2 - a rebuilt scoring model, with live telemetry while the test runs and your score revealed at the end.',
+    'NOMAD.md - give your AI assistant standing instructions it follows in every conversation.',
+    'Knowledge Base collections - group what the assistant searches by subject, so answers stay on topic.',
   ],
 }
 


### PR DESCRIPTION
## What

Expands the dashboard "What's new in v1.34" banner from two highlights to five, and drops the em dashes.

```
  Creator Packs - install curated video packs from your favorite creators and watch them fully offline.
  Medication Reference - offline FDA drug-label lookup for quick, reliable medication information.
+ Benchmark Score v2 - a rebuilt scoring model, with live telemetry while the test runs and your score revealed at the end.
+ NOMAD.md - give your AI assistant standing instructions it follows in every conversation.
+ Knowledge Base collections - group what the assistant searches by subject, so answers stay on topic.
```

## Why

The 1.34 line shipped **21 features**. The banner named two of them, so the release reads much smaller than it is on the one surface where users actually notice it.

The three added are the ones with the widest user-facing surface. Score v2 in particular changes what everyone who benchmarks sees, and it had no mention anywhere in-app on first launch.

Deliberately capped at five. This is a dismissable dashboard alert, not release notes - the full list already lives on the release notes page.

## Timing

This wants to land **before GA**, not in a patch. The banner is baked into the image, and dismissal is remembered per release line (`nomad:whatsnew-dismissed:1.34`), so anyone who dismisses the two-bullet version never sees an updated one within 1.34.x.

## Also in this change

The two existing bullets used em dashes; converted to spaced hyphens to match project copy convention. No other copy changed.

## Verification

- `npx tsc -p inertia/tsconfig.json --noEmit` introduces no new errors (the existing failures in `icons.ts`, `settings/maps.tsx`, `settings/zim/*` and `supply-depot.tsx` are all present on `rc` already and untouched here).
- No logic change: `WHATS_NEW.highlights` is rendered by an existing `.map()`, the gating and dismissal behaviour are unchanged.
- Not deployed to a test box. This is a content-only change to a string array in an already-rendering component, and hot-patching frontend assets onto a running appliance has previously caused a `.vite/manifest.json` mismatch - not worth that risk for copy. Worth an eyeball on the built image before GA.

## Files

- `admin/inertia/components/WhatsNewBanner.tsx`
