### PR TITLE
fix(kb): stop the collection dropdown being clipped, widen the modal

### DIFF
--- a/admin/inertia/components/chat/CollectionCombobox.tsx
+++ b/admin/inertia/components/chat/CollectionCombobox.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 interface CollectionComboboxProps {
   /** Current value. Empty string means "Uncategorized". */
@@ -32,6 +33,8 @@ export default function CollectionCombobox({
   const [query, setQuery] = useState(value)
   const [isOpen, setIsOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const [position, setPosition] = useState<{ left: number; top: number; width: number } | null>(null)
 
   useEffect(() => {
     setQuery(value)
@@ -39,7 +42,12 @@ export default function CollectionCombobox({
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      const target = e.target as Node
+      // The list is portaled to <body>, so it is NOT inside containerRef — check both,
+      // otherwise mousedown on an option closes the list before its click can land.
+      const insideInput = containerRef.current?.contains(target)
+      const insideList = dropdownRef.current?.contains(target)
+      if (!insideInput && !insideList) {
         setIsOpen(false)
         setQuery(value)
       }
@@ -47,6 +55,44 @@ export default function CollectionCombobox({
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [value])
+
+  /**
+   * The list renders in a portal with fixed positioning rather than absolutely inside
+   * the input's own box. Every ancestor that sets `overflow` other than visible would
+   * otherwise clip it: in the Knowledge Base table each cell carries `truncate`
+   * (overflow:hidden), which cropped the list to a single row's height, and the modal
+   * body is an `overflow-y-auto` scroller the list could not escape either. Fixed
+   * positioning against the viewport sidesteps both.
+   */
+  const reposition = useCallback(() => {
+    const input = containerRef.current
+    if (!input) return
+    const rect = input.getBoundingClientRect()
+    const MAX_HEIGHT = 224 // matches max-h-56
+    const GAP = 4
+    const spaceBelow = window.innerHeight - rect.bottom
+    // Flip above the input when the list would run off the bottom of the viewport
+    // and there is more headroom up top.
+    const flipUp = spaceBelow < MAX_HEIGHT + GAP && rect.top > spaceBelow
+    setPosition({
+      left: rect.left,
+      top: flipUp ? Math.max(GAP, rect.top - GAP - MAX_HEIGHT) : rect.bottom + GAP,
+      width: rect.width,
+    })
+  }, [])
+
+  useLayoutEffect(() => {
+    if (!isOpen) return
+    reposition()
+    // `true` for capture so scrolling in any ancestor scroller keeps the list attached
+    // to its input rather than leaving it stranded mid-air.
+    window.addEventListener('scroll', reposition, true)
+    window.addEventListener('resize', reposition)
+    return () => {
+      window.removeEventListener('scroll', reposition, true)
+      window.removeEventListener('resize', reposition)
+    }
+  }, [isOpen, reposition])
 
   const normalizedQuery = query.trim().toLowerCase()
   const filtered = normalizedQuery
@@ -89,8 +135,12 @@ export default function CollectionCombobox({
         placeholder={placeholder}
         className="w-full rounded border border-border-subtle bg-surface-primary px-2 py-1 text-sm text-text-primary disabled:opacity-50"
       />
-      {isOpen && !disabled && (
-        <div className="absolute z-20 mt-1 w-full max-h-56 overflow-auto rounded border border-border-subtle bg-surface-primary shadow-lg">
+      {isOpen && !disabled && position && createPortal(
+        <div
+          ref={dropdownRef}
+          style={{ left: position.left, top: position.top, width: position.width }}
+          className="fixed z-[60] max-h-56 overflow-auto rounded border border-border-subtle bg-surface-primary shadow-lg"
+        >
           {allowUncategorized && (
             <button
               type="button"
@@ -122,7 +172,8 @@ export default function CollectionCombobox({
           {filtered.length === 0 && !showCreateOption && (
             <div className="px-2 py-1.5 text-sm text-text-muted">No matches</div>
           )}
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   )

--- a/admin/inertia/components/chat/KnowledgeBaseModal.tsx
+++ b/admin/inertia/components/chat/KnowledgeBaseModal.tsx
@@ -453,7 +453,7 @@ export default function KnowledgeBaseModal({ aiAssistantName = "AI Assistant", o
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/30 backdrop-blur-sm transition-opacity">
-      <div className="bg-surface-primary rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col">
+      <div className="bg-surface-primary rounded-lg shadow-xl max-w-5xl w-full max-h-[90vh] overflow-hidden flex flex-col">
         <div className="flex items-center justify-between p-6 border-b border-border-subtle shrink-0">
           <h2 className="text-2xl font-semibold text-text-primary">Knowledge Base</h2>
           <button


### PR DESCRIPTION
## Problem

Two layout defects in the Knowledge Base modal, both found during v1.34.0-rc.4 QA, both affecting the collections feature that is new in 1.34.

### 1. The collection dropdown was clipped to one row


This is **not** a stacking-order problem, which is what it looks like. `StyledTable` renders every cell as:

```
relative text-sm whitespace-nowrap max-w-72 truncate break-words text-left ...
```

`truncate` expands to `overflow: hidden`, and the cell is `position: relative`. The dropdown is `position: absolute` inside it, so it gets clipped to the cell's own box - the height of a single row. `z-20` cannot win against a clip.

Opting just that one column out of `truncate` is not enough either: the modal body is an `overflow-y-auto` scroller, so rows lower in the list simply get clipped by *that* instead. Measured on a test box, an overflow override left rows 4 and 6 still 2/5 and 5/5 covered.

### 2. Action buttons cut off at every window size

The modal is capped at `max-w-4xl` (896px) while the table needs 906px in an 833px scroll area. The modal never grows past 896px, so **a larger monitor does not help**:

| Viewport | Modal | Table needs | Overflow | Delete button |
|---|---|---|---|---|
| 1000x880 | 896px | 906px | 73px | 63 of 81px visible |
| 1920x1080 | 896px | 906px | 73px | cut off by 18px |

There is a horizontal scrollbar but no affordance, so the buttons just look broken.

## Fix

**Dropdown:** render the list in a portal (`createPortal` to `document.body`) with `position: fixed`, positioned from the input's `getBoundingClientRect()`. Fixed positioning is measured against the viewport, so no ancestor `overflow` can clip it. Flips above the input when it would run off the bottom of the viewport and there is more headroom up top. Repositions on scroll and resize, with a capture-phase scroll listener so scrolling any ancestor keeps the list attached to its input.

The click-outside handler now checks the portaled list as well as the input container. Without that, `mousedown` on an option closes the list before its `click` can fire and nothing gets selected.

**Modal:** `max-w-4xl` to `max-w-5xl` (1024px). Brings the scroll area to 961px against the table's 906px.

## Verification

Built and installed on a test appliance running the rc.4 image, then measured in-browser. The box was restored to stock afterwards and confirmed healthy.

Dropdown, sampling 5 points down the list for coverage by another element:

| Row | Before | After | Flipped up |
|---|---|---|---|
| 0 | 0/5 covered | 0/5 | no |
| 1 | 4/5 covered | 0/5 | no |
| 2 | 5/5 covered | 0/5 | no |
| 4 | - | 0/5 | yes |
| 6 | - | 0/5 | yes |
| 8 | - | 0/5 | no |
| 10 | - | 0/5 | yes |

All lists stayed fully within the viewport.

Interaction, the main regression risk of portaling:
- `mousedown` then `click` on an option commits the value (`""` to `"diy"`) and closes the list.
- Reverting via the `Uncategorized` option works; test data restored.
- Scrolling the modal body 200px moved the input by -200px and the list by -200px, so it stays attached.

Modal width at 1920x1080: 1024px, horizontal overflow 0px, Delete button fully inside the modal.

Typecheck: `npx tsc -p inertia/tsconfig.json --noEmit` reports 30 errors both before and after this change, none in either touched file. (Those 30 are pre-existing on `rc` - worth noting separately that the Inertia tsconfig is not covered by the pre-push hook, which is presumably how they accumulated.)

## Files

- `admin/inertia/components/chat/CollectionCombobox.tsx` - portal, fixed positioning, flip-up, reposition listeners, click-outside fix
- `admin/inertia/components/chat/KnowledgeBaseModal.tsx` - `max-w-4xl` to `max-w-5xl`
