### PR TITLE
fix(kb): keep the collection when a file is indexed after assignment

### DIFF
--- a/admin/app/jobs/embed_file_job.ts
+++ b/admin/app/jobs/embed_file_job.ts
@@ -59,6 +59,15 @@ export class EmbedFileJob {
   async handle(job: Job) {
     const { filePath, fileName, batchOffset, totalArticles, collection } = job.data as EmbedFileJobParams
 
+    // Only the direct KB-upload controller passes `collection` on dispatch; the other
+    // six dispatch sites (download auto-index, scan/sync, re-embed, local ZIM upload,
+    // replaced-file reconcile, and this job's own ZIM batch continuation) do not. Fall
+    // back to whatever the file is already assigned to, so an assignment made *before*
+    // the file was indexed still reaches the vectors. Resolving it here rather than at
+    // each dispatch site keeps one source of truth and covers batch continuations too.
+    const effectiveCollection =
+      collection ?? (await KbIngestState.findBy('file_path', filePath))?.collection ?? undefined
+
     const isZimBatch = batchOffset !== undefined
     const batchInfo = isZimBatch ? ` (batch offset: ${batchOffset})` : ''
     logger.info(`[EmbedFileJob] Starting embedding process for: ${fileName}${batchInfo}`)
@@ -138,7 +147,7 @@ export class EmbedFileJob {
         allowDeletion,
         batchOffset,
         onProgress,
-        collection
+        effectiveCollection
       )
 
       if (!result.success) {
@@ -192,6 +201,9 @@ export class EmbedFileJob {
           totalArticles: totalArticles || result.totalArticles,
           isFinalBatch: false, // Explicitly not final
           chunksSoFar: chunksSoFarNext,
+          // Carry the collection across batches, otherwise only batch 1 of a ZIM
+          // would be tagged and the rest would land uncategorized.
+          ...(effectiveCollection ? { collection: effectiveCollection } : {}),
         })
 
         // Calculate progress based on articles processed.
@@ -244,7 +256,7 @@ export class EmbedFileJob {
       // BullMQ's :completed retention (50 jobs) ages out, so the state row is
       // the only durable record of "this file finished embedding".
       try {
-        await KbIngestState.markIndexed(filePath, totalChunks, collection)
+        await KbIngestState.markIndexed(filePath, totalChunks, effectiveCollection)
       } catch (stateErr) {
         logger.warn(
           `[EmbedFileJob] Failed to persist ingest state for ${fileName}: %s`,

--- a/admin/app/services/rag_service.ts
+++ b/admin/app/services/rag_service.ts
@@ -529,7 +529,8 @@ export class RagService {
     filepath: string,
     deleteAfterEmbedding: boolean,
     batchOffset?: number,
-    onProgress?: (percent: number) => Promise<void>
+    onProgress?: (percent: number) => Promise<void>,
+    collection?: string
   ): Promise<ProcessZIMFileResponse> {
     const zimExtractionService = new ZIMExtractionService()
 
@@ -556,6 +557,9 @@ export class RagService {
       const result = await this.embedAndStoreText(zimChunk.text, {
         source: filepath,
         content_type: 'zim_article',
+        // Without this the ZIM path writes points with no `collection` at all, so
+        // getKnowledgeCollections() (which facets on it) never sees them.
+        ...(collection ? { collection } : {}),
 
         // Article-level context
         article_title: zimChunk.articleTitle,
@@ -783,7 +787,7 @@ export class RagService {
       // Process based on file type
       // ZIM files are handled specially since they have their own embedding workflow
       if (fileType === 'zim') {
-        return await this.processZIMFile(filepath, deleteAfterEmbedding, batchOffset, onProgress)
+        return await this.processZIMFile(filepath, deleteAfterEmbedding, batchOffset, onProgress, collection)
       }
 
       // Extract text based on file type
@@ -1240,11 +1244,13 @@ export class RagService {
         filter: { must: [{ key: 'source', match: { value: source } }] },
       })
 
-      const row = await KbIngestState.query().where('file_path', source).first()
-      if (row) {
-        row.collection = collection
-        await row.save()
-      }
+      // The setPayload above only reaches points that already exist, so for a file
+      // that has not been indexed yet it matches nothing. The row is therefore the
+      // only durable record of the choice until EmbedFileJob picks it up -- create
+      // it when absent rather than reporting success and storing the value nowhere.
+      const row = await KbIngestState.getOrCreate(source)
+      row.collection = collection
+      await row.save()
 
       return { success: true, message: collection ? `Moved to "${collection}".` : 'Moved to Uncategorized.' }
     } catch (error) {


### PR DESCRIPTION
Fixes #1199.

## Problem

Assigning a Knowledge Base collection **before** a file is indexed lost it silently. The per-row value in the table still showed the collection, but **Manage Collections** and the **Search in** dropdown stayed empty.

Found on a live rc.4 box after three devdocs ZIMs were assigned `technology` and then indexed:

```
MySQL kb_ingest_state.collection   ->  technology   (all 3 rows)
Qdrant `collection` payload facet  ->  []           (empty)
```

`getKnowledgeCollections()` facets on the Qdrant payload, so it returned `[]`.

## Five gaps, one path

1. **`updateFileCollection()` writes to points that do not exist yet.** The `setPayload` filter is on `source`; before indexing it matches zero points and succeeds silently.
2. **It also reported success while storing nothing.** The MySQL mirror was guarded `if (row)`, so a file with no `kb_ingest_state` row persisted the value *nowhere* and still returned `Moved to "<name>".`
3. **Six of seven `EmbedFileJob.dispatch` sites never pass `collection`** and none read the existing row, so **Index** dispatched a job that did not know about the assignment.
4. **The ZIM branch dropped `collection` even when the job had one.** `processAndEmbedFile` forwards it on the non-ZIM path but called `processZIMFile(filepath, deleteAfterEmbedding, batchOffset, onProgress)` with no collection, and `processZIMFile` never put it in the payload. **ZIM content could not be tagged at embed time by any path.**
5. **Batch continuations dropped it**, so even a correct job would have tagged only batch 1.

`markIndexed()` guards with `if (collection)`, which is why MySQL kept the value and the UI looked half-right - that is what made this present as a confusing inconsistency rather than an obvious failure.

## Approach

Resolve the effective collection **once**, inside `EmbedFileJob.handle()`:

```ts
const effectiveCollection =
  collection ?? (await KbIngestState.findBy('file_path', filePath))?.collection ?? undefined
```

One source of truth instead of patching seven dispatch sites, and it covers batch continuations for free. Then thread `collection` through `processAndEmbedFile` -> `processZIMFile` -> `embedAndStoreText` metadata, carry it on the continuation dispatch, and switch `updateFileCollection` to `getOrCreate` so a pre-index assignment is durable.

## Verification

End to end on a test appliance running the rc.4 image, reproducing the exact reported flow on a ZIM with **no** prior row and **no** prior points.

1. Assign to an unindexed file:
```
POST /api/rag/update-collection {"source":".../devdocs_en_python_2026-02.zim","collection":"qatest"}
-> {"message":"Moved to \"qatest\"."}
kb_ingest_state -> pending_decision | qatest     # before: no row created at all
```
2. Index it. Log shows real batch continuations, so the carry-forward is genuinely exercised rather than assumed:
```
[EmbedFileJob] Starting embedding process for: devdocs_en_python_2026-02.zim
[EmbedFileJob] Dispatched ... (continuation @ offset 50)
[EmbedFileJob] Dispatched ... (continuation @ offset 100)
```
3. Result:
```
facet `collection`  -> [{"value":"technology","count":20142},{"value":"qatest","count":6106}]
points source=python AND collection=qatest -> 6106      # i.e. all of them, every batch
GET /api/rag/collections -> {"collections":["qatest","technology"]}
```

Before the fix the same sequence left the facet empty and the endpoint returning `[]`.

Backend typecheck (`npx tsc --noEmit`): **0 errors**, before and after.

## Note for anyone already affected

Not worth a migration: only Early Access installs can have hit this, and it resolves for them on upgrade to GA. Re-applying the collection after indexing also repairs it in place with no re-embedding - confirmed on the reported box, 20,142 chunks retagged across three devdocs ZIMs, with the UI lists populating immediately.

## Files

- `admin/app/jobs/embed_file_job.ts`
- `admin/app/services/rag_service.ts`

