### PR TITLE
[HOLD UNTIL GA + jrsphoto OK] catalog: surface US Military Field Manuals in Survival > Comprehensive

### DIFF
--- a/collections/kiwix-categories.json
+++ b/collections/kiwix-categories.json
@@ -246,6 +246,15 @@
               "description": "Practical guides to food production, water and sanitation, construction, and village-scale manufacturing without industrial supply chains",
               "url": "https://download.kiwix.org/zim/zimit/cd3wdproject.org_en_all_2025-11.zim",
               "size_mb": 581
+            },
+            {
+              "id": "field-manuals",
+              "version": "2026-07",
+              "title": "US Military Field Manuals",
+              "description": "Around 180 public-domain US Army, USMC, Navy and Joint field manuals. Built and maintained by community member jrsphoto (github.com/jrsphoto/ZIM-military-field-manuals).",
+              "url": "https://nomad-packs-worker.chris-556.workers.dev/content/field-manuals_2026-07.zim",
+              "size_mb": 2124,
+              "auth": "nomad_app_key"
             }
           ]
         }


### PR DESCRIPTION
> **DO NOT MERGE until v1.34.0 GA is published, and not before jrsphoto has agreed to it.** Draft deliberately. Two independent gates, both below.

## What

Adds `field-manuals` to **Survival & Preparedness > Comprehensive**. This is the **first catalog entry to use `auth: "nomad_app_key"`** from #1172, so it is also the first real exercise of that feature.

```json
{
  "id": "field-manuals",
  "version": "2026-07",
  "title": "US Military Field Manuals",
  "description": "Around 180 public-domain US Army, USMC, Navy and Joint field manuals. Built and maintained by community member jrsphoto (github.com/jrsphoto/ZIM-military-field-manuals).",
  "url": "https://nomad-packs-worker.chris-556.workers.dev/content/field-manuals_2026-07.zim",
  "size_mb": 2124,
  "auth": "nomad_app_key"
}
```

## Gate 1: not before GA

`auth` does not exist in v1.33.0 and earlier. VineJS **strips unknown keys rather than rejecting them**, so on an older install the field silently vanishes, the download goes out with no `Authorization` header, and **every pre-GA user gets a 401**. Manifests are fetched live from `main`, so merging early breaks it for everyone who has not upgraded yet.

## Gate 2: not before jrsphoto agrees

The ZIM is **byte-identical** to the community build by [jrsphoto](https://github.com/jrsphoto/ZIM-military-field-manuals):

```
local  field_manuals.zim          2,123,720,730 B   sha256 055a0b3a...dce1ea
R2     field-manuals_2026-07.zim  2,123,720,730 B   sha256 055a0b3a...dce1ea
```

We are redistributing their exact artifact from our own CDN, behind a gate that restricts it to official builds. **That repo carries no license** (`gh api` reports `"license": "none"`). The ~180 manuals are public-domain US Government works, but the HTML index, presentation layer and compiled ZIM are jrsphoto's and are not licensed for redistribution. Their agreement should come first.

## Why the filename changed

Not for Kiwix, which was always fine with the original. `parseZimFilename()` requires `<id>_<YYYY-MM>.zim`, and the original parses to null - visible in any install's logs:

```
Processing ZIM file: field_manuals.zim
Parsed ZIM filename: null
```

Without a parseable name the file cannot be version-tracked, matched to a catalog id, or updated. Hence `field-manuals_2026-07.zim`, with `id` equal to the filename base as the convention requires.

## Attribution

Credit currently lives in the entry `description`, which is what renders on the content card.

**This is not sufficient on its own.** The ZIM's embedded metadata reads:

```
creator   "US Government"
publisher "ProjectNomad"
```

jrsphoto appears nowhere in the artifact, and Kiwix surfaces `publisher` in its own library UI. Fixing that means rebuilding the ZIM with corrected metadata, which produces a new artifact and a new hash and is deliberately **not** done here - it should follow whatever jrsphoto prefers, not precede asking them.

## Verification

Worker serves the object correctly, checked from a NOMAD3 container:

```
no auth   -> 401
with key  -> HTTP/2 200, content-length: 2123720730
```

- `id` + `version` reconstruct the filename exactly (`field-manuals_2026-07.zim`).
- `size_mb: 2124` is decimal MB per the manifest convention (2,123,720,730 / 1e6 = 2123.7).
- JSON parses; no duplicate id anywhere in the catalog.

## Depends on

**#1195 must merge first.** A gated 401 currently retries ten times over roughly 4h15m and shows as a stuck download rather than a failure. That is harmless only while no `auth` entry exists in the catalog - this PR is precisely what ends that. Merging this before #1195 means anyone on a non-official build sees a download that appears frozen for four hours instead of the clear message #1172 wrote for them.
