### PR TITLE
fix(downloads): don't retry a rejected entitlement for four hours

### DIFF
--- a/admin/app/jobs/run_download_job.ts
+++ b/admin/app/jobs/run_download_job.ts
@@ -1,7 +1,7 @@
 import { Job, UnrecoverableError } from 'bullmq'
 import { RunDownloadJobParams, DownloadProgressData } from '../../types/downloads.js'
 import { QueueService } from '#services/queue_service'
-import { doResumableDownload } from '../utils/downloads.js'
+import { doResumableDownload, GatedContentAuthError } from '../utils/downloads.js'
 import { createHash } from 'crypto'
 import { DockerService } from '#services/docker_service'
 import { ZimService } from '#services/zim_service'
@@ -315,6 +315,13 @@ export class RunDownloadJob {
       // Check both the flag (Redis poll) and abort reason (in-process cancel).
       if (userCancelled || abortController.signal.reason === 'user-cancel') {
         throw new UnrecoverableError(`Download cancelled: ${error.message}`)
+      }
+      // A rejected entitlement is permanent - this build either has the key or it
+      // doesn't. Left as a plain Error it consumes all 10 attempts with exponential
+      // backoff from 30s, so the job reads `delayed` for ~4h15m and the user sees a
+      // stuck download instead of the message above.
+      if (error instanceof GatedContentAuthError) {
+        throw new UnrecoverableError(error.message)
       }
       throw error
     } finally {

--- a/admin/app/utils/downloads.ts
+++ b/admin/app/utils/downloads.ts
@@ -9,6 +9,21 @@ import { createWriteStream } from 'fs'
 import { rename } from 'fs/promises'
 import path from 'path'
 
+/**
+ * A gated source rejected this install's credentials (401/403).
+ *
+ * Permanent by nature: whether the entitlement key is baked in is a property of
+ * the build, so no amount of retrying changes the answer. Declared here rather
+ * than thrown as an UnrecoverableError directly so this module stays free of a
+ * BullMQ dependency — RunDownloadJob translates it at the queue boundary.
+ */
+export class GatedContentAuthError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'GatedContentAuthError'
+  }
+}
+
 // Some upstream mirrors reject requests with a missing or generic User-Agent.
 // Notably, download.kiwix.org routes the large Wikimedia-family ZIMs (Wikipedia,
 // Wikiversity, Wikibooks — including the flagship full Wikipedia) to
@@ -72,7 +87,7 @@ export async function doResumableDownload({
     // failedReason is surfaced verbatim on the downloads UI.
     const status = error?.response?.status
     if (status === 401 || status === 403) {
-      throw new Error(
+      throw new GatedContentAuthError(
         'This content is hosted by Project NOMAD and requires an official release build. ' +
           `The download server rejected this install's credentials (HTTP ${status}).`
       )


### PR DESCRIPTION
Fixes #1195.

## Problem

The 401/403 branch added in #1172 throws a plain `Error`:

```ts
if (status === 401 || status === 403) {
  throw new Error('This content is hosted by Project NOMAD and requires an official release build. ...')
}
```

`RunDownloadJob` is registered `attempts: 10, backoff: { type: 'exponential', delay: 30000 }`. "This build has no entitlement key" is a permanent condition, so all ten attempts get spent on it: 30s + 60s + ... + 7680s, roughly **4h15m** before the job finally reads `failed`.

For that whole window the job sits at `status: "delayed"`, carrying the correct message where nothing surfaces it as a failure. Observed on rc.4:

```json
{
  "jobId": "1eaef36ec93bbad2",
  "status": "delayed",
  "failedReason": "This content is hosted by Project NOMAD and requires an official release build. The download server rejected this install's credentials (HTTP 401)."
}
```

So the user sees a **stuck download**, not a failed one, which defeats the purpose of the message #1172 added. Each retry also re-hits our own per-IP rate-limited Worker: ten attempts per gated resource per affected install.

## Change

Throw a named `GatedContentAuthError` from `downloads.ts`, and translate it to `UnrecoverableError` at the queue boundary in `RunDownloadJob`, next to the existing cancellation case:

```ts
if (error instanceof GatedContentAuthError) {
  throw new UnrecoverableError(error.message)
}
```

**Why not throw `UnrecoverableError` directly from the util.** `downloads.ts` is also used by `docker_service` and `map_service`, neither of which is a queue consumer. Importing BullMQ there to express "do not retry" couples a generic download helper to the job runner. The named class keeps the util dependency-free and puts the retry decision where retries are actually configured. It also follows the existing precedent in that same catch block, which already converts a cancellation into `UnrecoverableError` rather than having the util know about BullMQ.

## Propagation checked, not assumed

- `RunDownloadJob` calls `doResumableDownload` **directly**, so the error reaches the outer catch unwrapped.
- `doResumableDownloadWithRetry` (used by `docker_service` / `map_service`) rethrows anything that is not a network error immediately - `if (attempt >= max_retries || !isNetworkError) throw error` - so it neither swallows nor wraps this. Those paths do not pass `requestHeaders` and so cannot hit the gated branch anyway.

Backend typecheck: **0 errors**.

## Not verified end to end

Being straight about this: I did not reproduce the four-hour retry and then confirm it stops. Doing so means either waiting out a real backoff cycle or mutating the queue config on a live box, and neither was worth it for a change this size. What is verified is that it typechecks, that the error propagates unwrapped through both call paths (traced above), and that the translation sits in a catch block already proven to work for cancellation.

The behaviour is also directly observable in the linked issue: the job was captured at `delayed` with the right message, which is exactly the state this removes.

## Why now rather than 1.35

Harmless while **no** catalog entry uses `auth` - which is true today. #1204 (the US Military Field Manuals card) is the first one, and it cannot merge until this does, or anyone on a non-official build gets a four-hour phantom download instead of a clear error.

Targeting `rc` rather than `dev` deliberately: if this ships in 1.35 instead, the field-manuals card cannot appear until 1.35 either, since the catalog publishes live to every install and GA users would be the ones seeing the stuck download.

## Files

- `admin/app/utils/downloads.ts` - `GatedContentAuthError`, thrown on 401/403
- `admin/app/jobs/run_download_job.ts` - translate to `UnrecoverableError`
