### PR TITLE
fix(benchmark): show the v2 score in Benchmark History

### DIFF
--- a/admin/inertia/pages/settings/benchmark.tsx
+++ b/admin/inertia/pages/settings/benchmark.tsx
@@ -943,10 +943,34 @@ export default function BenchmarkPage(props: {
                                     ).toLocaleDateString()}
                                   </td>
                                   <td className="p-3 capitalize">{result.benchmark_type}</td>
+                                  {/*
+                                    Show the v2 score when the run has one.
+
+                                    This column rendered nomad_score for every
+                                    row, so a v2 run showed its legacy score
+                                    while the Benchmark Details card directly
+                                    above showed the v2 one. The same run read
+                                    as 65.0 here and 1036.1 there.
+
+                                    Rows predating v2 have no v2 score and can
+                                    only show the legacy number, so the two
+                                    scales end up in one column. They differ by
+                                    more than 10x, and without the scale on
+                                    screen a v2 run next to older runs reads as
+                                    a collapse rather than a rescale. The "/ 100"
+                                    suffix names the legacy scale in place,
+                                    matching the wording the details card
+                                    already uses.
+                                  */}
                                   <td className="p-3">
                                     <span className="font-bold text-desert-green">
-                                      {result.nomad_score.toFixed(1)}
+                                      {(result.nomad_score_v2 ?? result.nomad_score).toFixed(1)}
                                     </span>
+                                    {result.nomad_score_v2 == null && (
+                                      <span className="ml-1 text-xs text-desert-stone-dark">
+                                        / 100
+                                      </span>
+                                    )}
                                   </td>
                                   <td className="p-3 font-mono text-xs">
                                     {result.builder_tag || '—'}


### PR DESCRIPTION
Closes #1209.

The history table rendered `nomad_score` unconditionally, so a v2 run showed its legacy score while the Benchmark Details card directly above showed the v2 one. The same run read as **65.0** in the table and **1036.1** in the card.

Rows predating v2 have no v2 score and can only show the legacy number, so the two scales necessarily share a column. They differ by more than 10x, and without the scale on screen a v2 run sitting above older runs reads as a collapse rather than a rescale. Legacy rows now carry a muted `/ 100` suffix, which names the scale in place and reuses the wording the details card already uses ("Legacy scale: X / 100").

This compounds the re-run guidance in the release notes: someone re-runs on 1.34 as asked, gets a real v2 score, and their own history then shows the old number as though the machine got slower.

Frontend only, one file. `getAllResults()` already returns full rows, so `nomad_score_v2` was in the payload the whole time. No API or migration change.

## Result

| Date | Before | After |
|---|---|---|
| 8/4/2026 (v2 run) | 65.0 | **1036.1** |
| 3/28/2026 (pre-v2) | 71.1 | 71.1 `/ 100` |
| 3/13/2026 (pre-v2) | 86.5 | 86.5 `/ 100` |

The top row now agrees with the Benchmark Details card above it.

## Testing

Browser-verified on a dev environment with a seeded history matching a real mixed case: the v2 row shows `1036.1` with no suffix and agrees with the details card, and the legacy rows show `71.1 / 100` and `86.5 / 100` with the suffix visually subordinate to the number.

Inertia typecheck (`tsc -p inertia/tsconfig.json`) reports the same 30 pre-existing errors as `dev`, with none in this file.