### PR TITLE
fix(content): re-download content updates after a failed attempt

### DIFF
--- a/admin/app/services/collection_update_service.ts
+++ b/admin/app/services/collection_update_service.ts
@@ -99,15 +99,19 @@ export class CollectionUpdateService {
     update: ResourceUpdateInfo,
     options?: { auto?: boolean }
   ): Promise<{ success: boolean; jobId?: string; error?: string }> {
-    // Check if a download is already in progress for this URL
-    const existingJob = await RunDownloadJob.getByUrl(update.download_url)
+    // Only block when a download is genuinely in progress. getActiveByUrl
+    // removes any terminal (failed/completed) job for this URL first, so a
+    // previous failed attempt doesn't leave a stale job that blocks the
+    // re-dispatch below. Using the raw getByUrl here (unlike every other
+    // dispatch site) meant a failed download stuck the resource forever: the
+    // failed job survived under the deterministic jobId, dispatch hit "job
+    // already exists" and returned it, and applyUpdate reported success while
+    // nothing was re-downloaded.
+    const existingJob = await RunDownloadJob.getActiveByUrl(update.download_url)
     if (existingJob) {
-      const state = await existingJob.getState()
-      if (state === 'active' || state === 'waiting' || state === 'delayed') {
-        return {
-          success: false,
-          error: `A download is already in progress for ${update.resource_id}`,
-        }
+      return {
+        success: false,
+        error: `A download is already in progress for ${update.resource_id}`,
       }
     }
 


### PR DESCRIPTION
## Problem

Once a content-update download fails, that resource can never be updated again — every subsequent "Apply update" (and every auto-update run) reports success while downloading nothing.

`CollectionUpdateService.applyUpdate` guards like this:

```ts
const existingJob = await RunDownloadJob.getByUrl(update.download_url)
if (existingJob) {
  const state = await existingJob.getState()
  if (state === 'active' || state === 'waiting' || state === 'delayed') {
    return { success: false, error: `A download is already in progress ...` }
  }
}
// ... falls through for 'failed'/'completed'
const result = await RunDownloadJob.dispatch({ url: update.download_url, ... })
```

`dispatch` adds the job under a deterministic `jobId = sha256(url)` with `removeOnComplete: true` but **no `removeOnFail`** (it's the only dispatch in the app without it — every other job sets `removeOnFail: { count: 5 }`). So when a download exhausts its 10 attempts, the **failed** job stays in Redis under that id.

On the next apply, `getByUrl` returns that failed job; its state isn't in the active set, so the guard is skipped and `dispatch` runs again. BullMQ dedupes on the existing `jobId` — `queue.add` doesn't resurrect a failed job, and the `catch` for `job already exists` returns the stale failed job. `applyUpdate` then returns `{ success: true, jobId: <stale id> }` without ever re-running the download.

Reachable on normal paths: the first download failing transiently (mirror 5xx after retries, disk full, a gated 401) is ordinary, and `applyUpdate` is called from the "Apply update"/"Apply all" controller and from the content auto-updater.

## Fix

Use `RunDownloadJob.getActiveByUrl`, which **removes** any terminal (failed/completed) job for the URL before returning, so the following `dispatch` creates a fresh, runnable job:

```ts
const existingJob = await RunDownloadJob.getActiveByUrl(update.download_url)
if (existingJob) {
  return { success: false, error: `A download is already in progress for ${update.resource_id}` }
}
```

This is exactly how every other dispatch site already guards (`map_service`, `zim_service`, `creator_pack_service`) — this method was the lone one still using the raw `getByUrl`. An active download is still correctly reported as in-progress; a previously failed one now re-downloads.

## Testing

Verified by tracing the state machine against `RunDownloadJob.getActiveByUrl` (whose own doc comment notes it removes terminal jobs "so it doesn't block re-download") and the `dispatch` dedup/`job already exists` path. The change reuses the helper already exercised by the six sibling call sites. Happy to add a spec if you have a preferred pattern for mocking the job queue in unit tests.