### PR TITLE
ci(collections): add weekly schedule trigger to url validation

### DIFF
--- a/.github/workflows/validate-collection-urls.yml
+++ b/.github/workflows/validate-collection-urls.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     paths:
       - 'collections/**.json'
+  schedule:
+    - cron: '17 6 * * 1'
 
 jobs:
   validate-urls:


### PR DESCRIPTION
## Summary

Adds a weekly `schedule` trigger to `validate-collection-urls.yml`, alongside the existing `push`/`pull_request` triggers.

Closes #1216

## Why

The workflow only runs when `collections/**.json` changes. If nobody edits those files, a URL going stale after merge (Kiwix rotating a dated filename, openZIM renaming a resource) is never re-checked until a user hits a 404 and files a bug report. #127 proposed a weekly check for exactly this reason back in February; only the push/PR trigger ended up shipping.

## Changes

- `.github/workflows/validate-collection-urls.yml`: add a weekly cron schedule (`17 6 * * 1`, Monday morning UTC, offset from the top of the hour) to the existing `on:` block. No change to the validation logic itself, which already checks every URL correctly via a range request (hardened recently in #1188).

## Testing

Verified the cron syntax and confirmed the existing push/PR triggers are unchanged. Since this only adds a new trigger condition, there's no functional change to test beyond the workflow still parsing and running as before.

## Note on branches

This targets `dev` per CONTRIBUTING.md, but scheduled triggers only run from the workflow file on the default branch (`main`). Same situation #1188 had to solve for the curl fix in this same file. Called this out in #1216 so it's not a surprise. Happy to open a follow-up against `main` once this lands, or let me know if you'd rather handle that port yourselves.