### PR TITLE
fix(chat): abort abandoned response streams

### DIFF
--- a/admin/inertia/components/chat/index.tsx
+++ b/admin/inertia/components/chat/index.tsx
@@ -14,6 +14,7 @@ import { DEFAULT_QUERY_REWRITE_MODEL } from '../../../constants/ollama'
 import { useSystemSetting } from '~/hooks/useSystemSetting'
 import Switch from '~/components/inputs/Switch'
 import InfoTooltip from '~/components/InfoTooltip'
+import { abortActiveStream, clearStreamIfCurrent } from './stream_abort'
 
 interface ChatProps {
   enabled: boolean
@@ -41,6 +42,19 @@ export default function Chat({
   const [isStreamingResponse, setIsStreamingResponse] = useState(false)
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
   const streamAbortRef = useRef<AbortController | null>(null)
+
+  const abortCurrentStream = useCallback(() => {
+    abortActiveStream(streamAbortRef)
+  }, [])
+
+  useEffect(() => () => abortCurrentStream(), [abortCurrentStream])
+
+  useEffect(() => {
+    if (!enabled) {
+      abortCurrentStream()
+      setIsStreamingResponse(false)
+    }
+  }, [enabled, abortCurrentStream])
 
   useEffect(() => {
     if (!isMobileSidebarOpen) return
@@ -146,6 +160,8 @@ export default function Chat({
   const deleteAllSessionsMutation = useMutation({
     mutationFn: () => api.deleteAllChatSessions(),
     onSuccess: () => {
+      abortCurrentStream()
+      setIsStreamingResponse(false)
       queryClient.invalidateQueries({ queryKey: ['chatSessions'] })
       setActiveSessionId(null)
       setMessages([])
@@ -254,6 +270,8 @@ export default function Chat({
     api.unloadChatModels(newModel).catch((err) => {
       console.warn('Failed to unload previous chat model:', err)
     })
+    abortCurrentStream()
+    setIsStreamingResponse(false)
     setSelectedModel(newModel)
     setPendingModelSwitch(null)
     // Clear the active session and messages — the next user message will
@@ -261,7 +279,7 @@ export default function Chat({
     // which already calls api.createChatSession with `selectedModel`.
     setActiveSessionId(null)
     setMessages([])
-  }, [pendingModelSwitch])
+  }, [pendingModelSwitch, abortCurrentStream])
 
   const handleCancelModelSwitch = useCallback(() => {
     setPendingModelSwitch(null)
@@ -269,9 +287,11 @@ export default function Chat({
 
   const handleNewChat = useCallback(() => {
     // Just clear the active session and messages - don't create a session yet
+    abortCurrentStream()
+    setIsStreamingResponse(false)
     setActiveSessionId(null)
     setMessages([])
-  }, [])
+  }, [abortCurrentStream])
 
   const handleClearHistory = useCallback(() => {
     openModal(
@@ -297,6 +317,8 @@ export default function Chat({
     async (sessionId: string) => {
       // Cancel any ongoing suggestions fetch
       queryClient.cancelQueries({ queryKey: ['chatSuggestions'] })
+      abortCurrentStream()
+      setIsStreamingResponse(false)
 
       setActiveSessionId(sessionId)
       // Load messages for this session
@@ -330,7 +352,7 @@ export default function Chat({
         console.warn('Failed to unload non-target chat models on session switch:', err)
       })
     },
-    [installedModels, queryClient, selectedModel]
+    [installedModels, queryClient, selectedModel, abortCurrentStream]
   )
 
   const handleSendMessage = useCallback(
@@ -363,6 +385,8 @@ export default function Chat({
         ...messages.map((m) => ({ role: m.role, content: m.content })),
         { role: 'user' as const, content },
       ]
+
+      abortCurrentStream()
 
       if (streamingEnabled !== false) {
         // Streaming path
@@ -457,8 +481,9 @@ export default function Chat({
             })
           }
         } finally {
-          setIsStreamingResponse(false)
-          streamAbortRef.current = null
+          if (clearStreamIfCurrent(streamAbortRef, abortController)) {
+            setIsStreamingResponse(false)
+          }
         }
 
         if (fullContent && sessionId) {
@@ -482,7 +507,7 @@ export default function Chat({
         })
       }
     },
-    [activeSessionId, messages, selectedModel, collectionFilter, chatMutation, queryClient, streamingEnabled, effectiveThinking]
+    [activeSessionId, messages, selectedModel, collectionFilter, chatMutation, queryClient, streamingEnabled, effectiveThinking, abortCurrentStream]
   )
 
   return (

--- a/admin/inertia/components/chat/stream_abort.ts
+++ b/admin/inertia/components/chat/stream_abort.ts
@@ -1,0 +1,21 @@
+export interface StreamAbortRef {
+  current: AbortController | null
+}
+
+export function abortActiveStream(ref: StreamAbortRef): boolean {
+  const controller = ref.current
+  if (!controller) return false
+
+  // Clear ownership before aborting. The rejected stream settles asynchronously,
+  // so its finally block must not be allowed to clear a replacement controller.
+  ref.current = null
+  controller.abort()
+  return true
+}
+
+export function clearStreamIfCurrent(ref: StreamAbortRef, controller: AbortController): boolean {
+  if (ref.current !== controller) return false
+
+  ref.current = null
+  return true
+}

--- a/admin/tests/unit/chat_stream_abort.spec.ts
+++ b/admin/tests/unit/chat_stream_abort.spec.ts
@@ -1,0 +1,41 @@
+import * as assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  abortActiveStream,
+  clearStreamIfCurrent,
+  type StreamAbortRef,
+} from '../../inertia/components/chat/stream_abort.js'
+
+test('aborts and releases the active stream', () => {
+  const controller = new AbortController()
+  const ref: StreamAbortRef = { current: controller }
+
+  assert.equal(abortActiveStream(ref), true)
+  assert.equal(controller.signal.aborted, true)
+  assert.equal(ref.current, null)
+})
+
+test('does nothing when no stream is active', () => {
+  const ref: StreamAbortRef = { current: null }
+
+  assert.equal(abortActiveStream(ref), false)
+  assert.equal(ref.current, null)
+})
+
+test('clears the controller owned by the settling stream', () => {
+  const controller = new AbortController()
+  const ref: StreamAbortRef = { current: controller }
+
+  assert.equal(clearStreamIfCurrent(ref, controller), true)
+  assert.equal(ref.current, null)
+})
+
+test('does not clear a replacement stream controller', () => {
+  const staleController = new AbortController()
+  const replacementController = new AbortController()
+  const ref: StreamAbortRef = { current: replacementController }
+
+  assert.equal(clearStreamIfCurrent(ref, staleController), false)
+  assert.equal(ref.current, replacementController)
+})


### PR DESCRIPTION
## Summary

- abort an active streaming fetch when Chat is unmounted or disabled, or when its conversation context is replaced
- retain controller ownership so a stale stream cannot clear a newer stream's loading state
- add focused unit coverage for abort and replacement-controller behavior

## Why

Abandoned HTTP/1.1 response streams keep browser connections occupied and can eventually exhaust the per-origin connection pool. This addresses the leaked-stream portion of #1211.

## Testing

- Ran: `node --loader ts-node-maintained/esm --test tests/unit/chat_stream_abort.spec.ts` (4 passed)
- Ran: `npm run typecheck`
- Ran: `npm run build`
- Checked: real Chromium harness using the actual Chat component for stream replacement, unmount, and session-switch paths