### PR TITLE
docs: add SECURITY.md and tighten .gitignore for credential files

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: 🔒 Report a Security Vulnerability
+    url: https://github.com/Crosstalk-Solutions/project-nomad/security/advisories/new
+    about: Report a security issue privately. Please do not open a public issue for a vulnerability.
   - name: 💬 Discord Community
     url: https://discord.com/invite/crosstalksolutions
     about: Join our Discord community for general questions, support, and discussions

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,31 @@ node_modules/
 
 # dotenv environment variables file
 .env
+.env.*
+!.env.example
+
+# Credentials and keys. Never commit these — the installer generates every
+# password and app key locally at install time, so nothing real belongs in the
+# repo. See SECURITY.md.
+*.pem
+*.key
+*.p12
+*.pfx
+*.ppk
+id_rsa
+id_ed25519
+.npmrc
+.netrc
+.htpasswd
+
+# Local copies of the deployed compose file, which contain the real generated
+# DB passwords and APP_KEY. The tracked install/management_compose.yaml template
+# is the only compose file that belongs in git.
+compose.yml
+compose.yaml
+docker-compose.yml
+docker-compose.yaml
+management_compose.local.yaml
 
 # Build / Dist
 dist

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,98 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest released version of Project NOMAD receives security fixes. If
+you are running an older release, please update before reporting an issue.
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for a security vulnerability.**
+
+Report it privately using GitHub's built-in reporting form:
+
+1. Go to the [Security tab](https://github.com/Crosstalk-Solutions/project-nomad/security)
+2. Click **Report a vulnerability**
+
+This creates a private advisory that only the maintainers can see. It stays
+private until a fix is available and we choose to publish it.
+
+If you cannot use that form for any reason, email
+**chris@crosstalksolutions.com** instead. Please do not include exploit details
+in a Discord message or a public issue.
+
+### What to include
+
+The more of this you can provide, the faster we can confirm and fix it:
+
+- The version of NOMAD you tested against, and the host OS
+- Which component is affected (Command Center, installer, updater sidecar, a
+  Supply Depot app, the benchmark submission path, and so on)
+- Steps to reproduce, ideally with the exact request or command
+- What an attacker gains, and what access they need to start with
+- Any suggested fix, if you have one
+
+### What to expect
+
+Project NOMAD is maintained by a very small team, so we do not offer a
+guaranteed response time. We read every report. If a report is valid, we will
+work with you on a fix and credit you in the published advisory unless you
+would rather stay anonymous.
+
+We do not run a bug bounty program and cannot offer payment for reports.
+
+## Scope
+
+### In scope
+
+- Remote code execution, container escape, or privilege escalation on the host
+- Any path where a remote party who is **not** on the local network can affect a
+  NOMAD instance, including attacks delivered through a user's browser
+- Unauthenticated access to data outside the NOMAD storage root
+- Path traversal, SSRF that reaches beyond the intended target, or injection in
+  the Command Center API
+- Supply chain problems in our build and release pipeline
+- Credentials or secrets committed to this repository
+
+### Out of scope
+
+Some things that look like vulnerabilities are deliberate design decisions for
+an offline, single-appliance, local-network product. Reports covering the
+following will usually be closed:
+
+- **No authentication on the Command Center.** This is intentional and
+  documented in the [README](README.md#about-security). NOMAD is designed to be
+  open on a trusted local network. If you need access control, use
+  network-level controls. There is an open roadmap item if you want to vote for
+  optional authentication:
+  https://roadmap.projectnomad.us/posts/1/user-authentication-please-build-in-user-auth-with-admin-user-roles
+- **Anything that requires exposing NOMAD directly to the internet.** This is
+  explicitly unsupported and advised against.
+- **Access by someone who is already on the local network.** Local network
+  access is the trust boundary by design.
+- **Requests to internal or private addresses.** NOMAD is expected to reach
+  other hosts on the local network, so RFC1918 destinations are not treated as
+  SSRF.
+- The benchmark submission signing key. It ships inside the image because an
+  offline appliance cannot hold a server-side secret. Forged submissions are
+  handled by moderation on the leaderboard, not by the key.
+- Missing security headers, missing rate limits, or similar findings with no
+  demonstrated impact on an appliance of this design.
+- Vulnerabilities in third-party Supply Depot applications. Please report those
+  to the upstream project. Tell us anyway if the issue is caused by how NOMAD
+  configures or deploys the app.
+- Findings from an automated scanner with no working proof of concept.
+
+If you are not sure whether something is in scope, report it. We would rather
+read an out-of-scope report than miss a real one.
+
+## Secrets in this Repository
+
+Secret scanning and push protection are enabled on this repository. If you
+believe a credential has been committed, report it privately using the process
+above rather than opening an issue, so it can be rotated before it is
+advertised.
+
+Note that the installer generates every database password and application key
+locally at install time. The placeholder values in
+`install/management_compose.yaml` are not real credentials.


### PR DESCRIPTION
## What

- Adds `SECURITY.md`
- Adds a security contact link to the issue template chooser
- Extends `.gitignore` to cover credential files

## Why

Private vulnerability reporting is enabled on this repo, but nothing told a reporter it existed. Blank issues are disabled and there was no security option in the chooser, so the only visible route for a security report was a public bug report.

The scope section is deliberate. Several intentional design decisions look like vulnerabilities from the outside, in particular the lack of authentication on the Command Center. Writing them down with links to where they are already documented should reduce repeat reports without discouraging real ones.

The `.gitignore` additions cover `.env` variants, key and certificate files, `.npmrc`/`.netrc`, and local copies of the deployed compose file.

## Notes

- No tracked file is affected by the new ignore rules, verified with `git check-ignore` over `git ls-files`.
- `admin/.env.example` remains tracked and unignored.
- `install/management_compose.yaml` is a tracked template so `.gitignore` cannot protect it. Secret scanning push protection, now enabled on this repo, covers that case.
- Docs and config only, no code paths touched.
