### PR TITLE
fix(queue): clear terminal jobs before re-dispatch so downloads aren't silently dropped

### DIFF
--- a/admin/app/jobs/download_model_job.ts
+++ b/admin/app/jobs/download_model_job.ts
@@ -160,17 +160,49 @@ export class DownloadModelJob {
     return await queue.getJob(jobId)
   }
 
+  /**
+   * Returns the job for this model only when it is genuinely in flight.
+   *
+   * A terminal record (completed or failed) is removed instead, because the
+   * jobId is a hash of the model name and `queue.add` with an existing custom
+   * jobId returns the existing job rather than throwing. Leaving a terminal
+   * record in place therefore makes every later dispatch for that model a
+   * silent no-op. Mirrors RunDownloadJob.getActiveByUrl.
+   */
+  static async getActiveByModelName(modelName: string): Promise<Job | undefined> {
+    const job = await this.getByModelName(modelName)
+    if (!job) return undefined
+
+    const state = await job.getState()
+    if (state === 'active' || state === 'waiting' || state === 'delayed') {
+      return job
+    }
+
+    // Terminal state -- clean up so it doesn't block a re-download
+    try {
+      await job.remove()
+    } catch {
+      // May already be gone
+    }
+    return undefined
+  }
+
   static async dispatch(params: DownloadModelJobParams) {
     const queueService = QueueService.getInstance()
     const queue = queueService.getQueue(this.queue)
     const jobId = this.getJobId(params.modelName)
 
-    // Clear any previous failed job so a fresh attempt can be dispatched
-    const existing = await queue.getJob(jobId)
-    if (existing) {
-      const state = await existing.getState()
-      if (state === 'failed') {
-        await existing.remove()
+    // Return an in-flight download as-is, and clear any terminal record so a
+    // fresh attempt can be dispatched. Previously this only cleared `failed`,
+    // so once a model had been downloaded successfully its retained completed
+    // job deduped every later request: the API still reported success and no
+    // worker ran, leaving the model uninstallable until Redis was flushed.
+    const inFlight = await this.getActiveByModelName(params.modelName)
+    if (inFlight) {
+      return {
+        job: inFlight,
+        created: false,
+        message: `Download already in progress for model ${params.modelName}`,
       }
     }
 

--- a/admin/app/jobs/embed_file_job.ts
+++ b/admin/app/jobs/embed_file_job.ts
@@ -389,6 +389,33 @@ export class EmbedFileJob {
       jobOptions.jobId = initialJobId
     }
 
+    // Deterministic-jobId dispatches must clear a terminal record before adding.
+    // `queue.add` with an existing custom jobId returns that job instead of
+    // throwing, so a retained failed entry (held by `removeOnFail: { count: 20 }`)
+    // made re-indexing that file a silent no-op: the caller got 202 "Indexing
+    // queued" and nothing was enqueued. In-flight jobs are still returned as-is
+    // so a re-click during an active embed stays idempotent.
+    if (!isContinuation && !force) {
+      const existing = await queue.getJob(initialJobId)
+      if (existing) {
+        const state = await existing.getState()
+        if (state === 'active' || state === 'waiting' || state === 'delayed') {
+          logger.info(`[EmbedFileJob] Job already in progress for file: ${params.fileName}`)
+          return {
+            job: existing,
+            created: false,
+            jobId: initialJobId,
+            message: `Embedding job already exists for: ${params.fileName}`,
+          }
+        }
+        try {
+          await existing.remove()
+        } catch {
+          // May already be gone
+        }
+      }
+    }
+
     try {
       const job = await queue.add(this.key, params, jobOptions)
 

--- a/admin/app/services/download_service.ts
+++ b/admin/app/services/download_service.ts
@@ -191,8 +191,13 @@ export class DownloadService {
           if (!modelName) {
             return { success: false, message: 'Cannot retry: model name not found in job data' }
           }
-          await DownloadModelJob.dispatch({ modelName })
+          // Remove the old failed job first, then dispatch a fresh one. The
+          // model jobId is a hash of the model name, so dispatching first meant
+          // this remove() targeted the job we had just enqueued under that same
+          // id rather than the old record, deleting the retry we were creating.
+          // Matches the file-download branch below.
           await job.remove().catch(() => {})
+          await DownloadModelJob.dispatch({ modelName })
           return { success: true, message: `Retrying download for model ${modelName}` }
         }
 


### PR DESCRIPTION
Three dispatch sites pin a deterministic `jobId`. `queue.add` with an existing custom `jobId` returns the existing job rather than throwing, so any retained terminal record turns later dispatches into a silent no-op while the API still reports success.

Diagnosis is @caweis's in #1214, including the two cases beyond the model download. Reimplemented in-house rather than ported, since the fork's files have diverged.

**1. A completed model download blocked that model forever**

`DownloadModelJob.dispatch` cleared a previous job only when its state was `failed`, and completed records are kept (`removeOnComplete: false`). Once a model had downloaded successfully, its retained job deduped every later request for it. Deleting the model and reinstalling did nothing, and a restart didn't help because the record persists in Redis. Completed jobs aren't in the Downloads list either, so no Retry appeared.

Adds `getActiveByModelName`, mirroring the existing `RunDownloadJob.getActiveByUrl`: in-flight jobs are returned as-is, terminal ones are removed before the add.

**2. Retrying a failed model download could delete the job it just dispatched**

The model branch of `retryFailedJob` dispatched before removing. Dispatch enqueues a fresh job under the same id, so `job.remove()` on the old handle removed the new one. Whether the retry survived was a race against the worker taking the lock. Flipped to remove-then-dispatch, matching the file branch directly below it.

**3. Re-indexing a file whose embed failed could no-op**

Failed embed records are retained by `removeOnFail: { count: 20 }`, so `POST /api/rag/files/embed` with `force: false` returned 202 "Indexing queued" with nothing enqueued. On a single-user box that record may never roll off.

Note this clears terminal embed records including `completed`, not just `failed`, so re-indexing an already-indexed file now re-embeds rather than silently doing nothing. The previous dedupe was already inconsistent, since `removeOnComplete: { count: 50 }` means it only held for the 50 most recent jobs.

**Verified on NOMAD3 (v1.34.0 GA, hot-patched):**

- Download `qwen2.5:3b`, delete it, reinstall from the UI. Before: HTTP 200, no console errors, nothing downloaded. After: the job goes active with real progress and the model installs.
- Two dispatches 2s apart for a model in flight produce exactly one job (`wait: 0`, `active: 1`), so in-flight idempotence is unchanged.

Closes #1214
