### PR TITLE
fix(downloads): guard orphaned model jobs

### DIFF
--- a/admin/app/services/download_service.ts
+++ b/admin/app/services/download_service.ts
@@ -56,11 +56,10 @@ export class DownloadService {
   }
 
   async listDownloadJobs(filetype?: string): Promise<DownloadJobWithProgress[]> {
-    const modelQueue = this.queueService.getQueue(DownloadModelJob.queue)
-    const [fileTagged, extractTagged, modelJobs, drugTagged] = await Promise.all([
+    const [fileTagged, extractTagged, modelTagged, drugTagged] = await Promise.all([
       this.fetchJobsWithStates(RunDownloadJob.queue),
       this.fetchJobsWithStates(RunExtractPmtilesJob.queue),
-      modelQueue.getJobs(['waiting', 'active', 'delayed', 'failed']),
+      this.fetchJobsWithStates(DownloadModelJob.queue),
       this.fetchJobsWithStates(DownloadDrugDataJob.queue),
     ])
 
@@ -98,7 +97,7 @@ export class DownloadService {
       }
     })
 
-    const modelDownloads = modelJobs.map((job) => ({
+    const modelDownloads = modelTagged.map(({ job }) => ({
       jobId: job.id!.toString(),
       url: job.data.modelName || 'Unknown Model',
       progress: parseInt(job.progress.toString(), 10),


### PR DESCRIPTION
## Summary

- route the model-download queue through the existing guarded `fetchJobsWithStates()` path
- skip orphaned BullMQ model entries before mapping the downloads response

The model queue was the only path in `listDownloadJobs()` that bypassed the shared orphan guard. A retained orphan could therefore make `GET /api/downloads/jobs` return 500 on every poll.

Closes #1194

## Testing

- reproduced an orphaned `model-downloads` entry: upstream throws on the missing job, while this branch skips it
- `npm run typecheck`
- `npm run build`
- `git diff --check`