### PR TITLE
feat(install): offline artifact bundle mode for air-gapped installs

### DIFF
--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -1,0 +1,49 @@
+name: Install Scripts
+
+# Guards the installer and the offline artifact bundle tooling. These scripts
+# bootstrap machines that may have no internet access, so a syntax error or a
+# regression in artifact mode is expensive to discover in the field.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'install/**'
+      - '.github/workflows/install-scripts.yml'
+  pull_request:
+    paths:
+      - 'install/**'
+      - '.github/workflows/install-scripts.yml'
+
+jobs:
+  shell:
+    name: Syntax, lint and artifact-mode tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check shell syntax
+        run: |
+          status=0
+          while IFS= read -r script; do
+            echo "bash -n ${script}"
+            bash -n "${script}" || status=1
+          done < <(find install -type f -name '*.sh' | sort)
+          exit "${status}"
+
+      - name: ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+          # Errors fail the build across all installer scripts. The offline
+          # bundle tooling is additionally held to the warning level.
+          find install -type f -name '*.sh' -print0 | xargs -0 shellcheck --severity=error
+          shellcheck --severity=warning \
+            install/build_offline_bundle.sh \
+            install/build_offline_bundle_docker.sh \
+            install/verify_offline_bundle.sh \
+            install/capture_installed_images.sh \
+            install/tests/offline_artifact_tests.sh
+
+      - name: Offline artifact mode regression tests
+        run: bash install/tests/offline_artifact_tests.sh

--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ Project NOMAD is now installed on your device! Open a browser and navigate to `h
 
 For a complete step-by-step walkthrough (including Ubuntu installation), see the [Installation Guide](https://www.projectnomad.us/install). For Windows users, see the [WSL2 install guide](https://www.projectnomad.us/install/wsl2) — community-supported path covering native Docker and Docker Desktop install routes.
 
+### Offline (Air-Gapped) Installation
+The quick install above needs an internet connection to download dependencies. If your target machine has no connectivity — or you want to be able to rebuild it after connectivity is gone — you can build an offline artifact bundle on a connected machine and install from it:
+
+```bash
+# On a connected machine, from a Project NOMAD checkout (Docker is the only requirement):
+./install/build_offline_bundle_docker.sh --target ubuntu:26.04 --output /media/usb/NOMAD
+```
+
+```bash
+# On the disconnected target, from inside the bundle directory:
+sudo bash ./install_nomad.sh --artifacts .
+```
+
+Bundles are specific to one OS, version, and architecture, and cover the core Command Center stack — not offline content or Supply Depot apps. See the [Offline Installation Guide](admin/docs/offline-install.md) for the full workflow, bundle format, and limitations.
+
 ### Advanced Installation
 For more control over the installation process, copy and paste the [Docker Compose template](https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/main/install/management_compose.yaml) into a `docker-compose.yml` file and customize it to your liking (be sure to replace any placeholders with your actual values). Then, run `docker compose up -d` to start the Command Center and its dependencies. Note: this method is recommended for advanced users only, as it requires familiarity with Docker and manual configuration before starting.
 
@@ -78,7 +93,7 @@ At its core, however, NOMAD is still very lightweight. For a barebones installat
 - RAM: 4GB system memory
 - Storage: At least 5 GB free disk space
 - OS: Debian-based (Ubuntu 26.04 LTS recommended)
-- Stable internet connection (required during install only)
+- Stable internet connection (required during install only, or use an [offline artifact bundle](admin/docs/offline-install.md))
 
 To run LLMs and other included AI tools:
 
@@ -88,7 +103,7 @@ To run LLMs and other included AI tools:
 - Graphics: NVIDIA RTX 3060 or AMD equivalent or better (more VRAM = run larger models)
 - Storage: At least 250 GB free disk space (preferably on SSD)
 - OS: Debian-based (Ubuntu 26.04 LTS recommended)
-- Stable internet connection (required during install only)
+- Stable internet connection (required during install only, or use an [offline artifact bundle](admin/docs/offline-install.md))
 
 **For detailed build recommendations at three price points ($150–$1,000+), see the [Hardware Guide](https://www.projectnomad.us/hardware).**
 
@@ -105,6 +120,8 @@ For answers to common questions about Project NOMAD, please see our [FAQ](FAQ.md
 
 ## About Internet Usage & Privacy
 Project NOMAD is designed for offline usage. An internet connection is only required during the initial installation (to download dependencies) and if you (the user) decide to download additional tools and resources at a later time. Otherwise, NOMAD does not require an internet connection and has ZERO built-in telemetry.
+
+If even the initial installation needs to happen without connectivity, see the [Offline Installation Guide](admin/docs/offline-install.md) — dependencies are prepared on a connected machine and carried to the target instead.
 
 To test internet connectivity, NOMAD first attempts to make a request to Cloudflare's utility endpoint, `https://1.1.1.1/cdn-cgi/trace`. If that endpoint is unreachable (for example, because your network blocks `1.1.1.1`), it falls back to other endpoints the application already contacts (the GitHub API and the Project NOMAD API) and considers the connection online if any of them respond.
 

--- a/admin/app/controllers/easy_setup_controller.ts
+++ b/admin/app/controllers/easy_setup_controller.ts
@@ -1,3 +1,4 @@
+import { DockerService } from '#services/docker_service'
 import { SystemService } from '#services/system_service'
 import { ZimService } from '#services/zim_service'
 import { CollectionManifestService } from '#services/collection_manifest_service'
@@ -9,18 +10,33 @@ import type { HttpContext } from '@adonisjs/core/http'
 export default class EasySetupController {
   constructor(
     private systemService: SystemService,
-    private zimService: ZimService
+    private zimService: ZimService,
+    private dockerService: DockerService
   ) {}
 
   async index({ inertia }: HttpContext) {
-    const [services, remoteOllamaUrl] = await Promise.all([
+    const [services, remoteOllamaUrl, localImageTags] = await Promise.all([
       this.systemService.getServices({ installedOnly: false }),
       KVStore.getValue('ai.remoteOllamaUrl'),
+      this.dockerService.listLocalImageTags(),
     ])
+
+    // Apps whose image is already in the local Docker daemon install without
+    // touching a registry (createContainerPreflight skips the pull when the
+    // image is present). An offline artifact bundle built with --with-apps
+    // loads exactly these, so this is what makes the wizard's offline mode
+    // honest: it can say which capabilities are genuinely installable now
+    // instead of pulling and failing halfway.
+    const localImages = new Set(localImageTags)
+    const locallyAvailableServices = services
+      .filter((service) => !!service.container_image && localImages.has(service.container_image))
+      .map((service) => service.service_name)
+
     return inertia.render('easy-setup/index', {
       system: {
         services: services,
         remoteOllamaUrl: remoteOllamaUrl ?? '',
+        locallyAvailableServices,
       },
     })
   }

--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -2302,20 +2302,31 @@ export class DockerService {
   }
 
   /**
+   * Every image tag present in the local Docker daemon.
+   *
+   * Exposed so callers that need to test several images at once (the Easy Setup
+   * wizard asking which apps are installable with no internet) can do it with a
+   * single daemon round-trip instead of one per image. Returns an empty list if
+   * the daemon can't be reached, which callers read as "nothing is local" —
+   * the same fail-safe direction as `_checkImageExists`.
+   */
+  async listLocalImageTags(): Promise<string[]> {
+    try {
+      const images = await this.docker.listImages()
+      return images.flatMap((image) => image.RepoTags ?? [])
+    } catch (error: any) {
+      logger.warn(`Error listing local Docker images: ${error.message}`)
+      return []
+    }
+  }
+
+  /**
    * Check if a Docker image exists locally.
    * @param imageName - The name and tag of the image (e.g., "nginx:latest")
    * @returns - True if the image exists locally, false otherwise
    */
   private async _checkImageExists(imageName: string): Promise<boolean> {
-    try {
-      const images = await this.docker.listImages()
-
-      // Check if any image has a RepoTag that matches the requested image
-      return images.some((image) => image.RepoTags && image.RepoTags.includes(imageName))
-    } catch (error: any) {
-      logger.warn(`Error checking if image exists: ${error.message}`)
-      // If run into an error, assume the image does not exist
-      return false
-    }
+    const tags = await this.listLocalImageTags()
+    return tags.includes(imageName)
   }
 }

--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -21,7 +21,7 @@ import { KiwixLibraryService } from './kiwix_library_service.js'
 import { SERVICE_NAMES } from '../../constants/service_names.js'
 import { exec } from 'child_process'
 import { promisify } from 'util'
-import { readFile, mkdir, copyFile, chown, chmod, access, writeFile } from 'node:fs/promises'
+import { readFile, mkdir, copyFile, chown, chmod, access, writeFile, readdir } from 'node:fs/promises'
 import { randomBytes } from 'node:crypto'
 import KVStore from '#models/kv_store'
 import { BROADCAST_CHANNELS } from '../../constants/broadcast.js'
@@ -949,6 +949,21 @@ export class DockerService {
     }
   }
 
+  /**
+   * ZIM files already sitting in storage, e.g. seeded from an offline artifact
+   * bundle or left by a previous install. Never throws — an unreadable or
+   * missing directory simply means "none present".
+   */
+  private async _listExistingZimFiles(): Promise<string[]> {
+    try {
+      const zimDir = join(process.cwd(), ZIM_STORAGE_PATH)
+      const entries = await readdir(zimDir)
+      return entries.filter((entry) => entry.toLowerCase().endsWith('.zim'))
+    } catch {
+      return []
+    }
+  }
+
   private async _runPreinstallActions__KiwixServe(): Promise<void> {
     /**
      * At least one .zim file must be available before we can start the kiwix container.
@@ -958,13 +973,36 @@ export class DockerService {
       'https://github.com/Crosstalk-Solutions/project-nomad/raw/refs/heads/main/install/wikipedia_en_100_mini_2026-01.zim'
     const filename = 'wikipedia_en_100_mini_2026-01.zim'
     const filepath = join(process.cwd(), ZIM_STORAGE_PATH, filename)
-    logger.info(`[DockerService] Kiwix Serve pre-install: Downloading ZIM file to ${filepath}`)
 
     this._broadcast(
       SERVICE_NAMES.KIWIX,
       'preinstall',
       `Running pre-install actions for Kiwix Serve...`
     )
+
+    // The requirement is "at least one ZIM present", so if storage already has
+    // one there is nothing to fetch. Checking here matters for offline installs:
+    // the downloader's own idempotency check sits behind a HEAD request, so
+    // without this an air-gapped host fails even with the ZIM already in place.
+    // Mirrors how Calibre-Web seeds its bundled library below.
+    const existingZims = await this._listExistingZimFiles()
+    if (existingZims.length > 0) {
+      logger.info(
+        `[DockerService] Kiwix Serve pre-install: ${existingZims.length} ZIM file(s) already present, skipping download`
+      )
+      this._broadcast(
+        SERVICE_NAMES.KIWIX,
+        'preinstall',
+        `Found ${existingZims.length} existing ZIM file(s); skipping download.`
+      )
+
+      const kiwixLibraryService = new KiwixLibraryService()
+      await kiwixLibraryService.rebuildFromDisk()
+      this._broadcast(SERVICE_NAMES.KIWIX, 'preinstall', 'Generated kiwix library XML.')
+      return
+    }
+
+    logger.info(`[DockerService] Kiwix Serve pre-install: Downloading ZIM file to ${filepath}`)
     this._broadcast(
       SERVICE_NAMES.KIWIX,
       'preinstall',

--- a/admin/app/services/zim_service.ts
+++ b/admin/app/services/zim_service.ts
@@ -21,8 +21,6 @@ import {
 } from '../utils/fs.js'
 import { join, resolve, sep } from 'path'
 import { WikipediaOption, WikipediaState } from '../../types/downloads.js'
-import vine from '@vinejs/vine'
-import { wikipediaOptionsFileSchema } from '#validators/curated_collections'
 import WikipediaSelection from '#models/wikipedia_selection'
 import InstalledResource from '#models/installed_resource'
 import CollectionManifest from '#models/collection_manifest'
@@ -33,14 +31,13 @@ import { SERVICE_NAMES } from '../../constants/service_names.js'
 import { CollectionManifestService } from './collection_manifest_service.js'
 import { KiwixCatalogService } from './kiwix_catalog_service.js'
 import { KiwixLibraryService } from './kiwix_library_service.js'
-import type { CategoryWithStatus } from '../../types/collections.js'
+import type { CategoryWithStatus, WikipediaSpec } from '../../types/collections.js'
 import CustomLibrarySource from '#models/custom_library_source'
 import { assertNotPrivateUrl } from '#validators/common'
 import { resolveZimDownload } from '../utils/zim_download_resolution.js'
 import { getHostedContentHeaders } from '../utils/hosted_content_auth.js'
 
 const ZIM_MIME_TYPES = ['application/x-zim', 'application/x-openzim', 'application/octet-stream']
-const WIKIPEDIA_OPTIONS_URL = 'https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/main/collections/wikipedia.json'
 
 @inject()
 export class ZimService {
@@ -693,21 +690,28 @@ export class ZimService {
 
   // Wikipedia selector methods
 
+  /**
+   * The Wikipedia catalog, refreshed from the remote manifest when reachable and
+   * served from the cached copy when it isn't.
+   *
+   * This used to fetch the manifest directly and throw on any failure, which
+   * turned `GET /api/zim/wikipedia` into a 500 on an air-gapped host and put an
+   * "internal error" toast on the Easy Setup wizard. Routing through
+   * CollectionManifestService reuses the same cached-spec fallback the curated
+   * categories, maps and creator packs already rely on. An air-gapped host that
+   * has never cached the manifest gets an empty list — the wizard renders no
+   * Wikipedia selector rather than failing.
+   */
   async getWikipediaOptions(): Promise<WikipediaOption[]> {
-    try {
-      const response = await axios.get(WIKIPEDIA_OPTIONS_URL)
-      const data = response.data
-
-      const validated = await vine.validate({
-        schema: wikipediaOptionsFileSchema,
-        data,
-      })
-
-      return validated.options
-    } catch (error) {
-      logger.error(`[ZimService] Failed to fetch Wikipedia options:`, error)
-      throw new Error('Failed to fetch Wikipedia options')
+    const manifestService = new CollectionManifestService()
+    const spec = await manifestService.getSpecWithFallback<WikipediaSpec>('wikipedia')
+    if (!spec) {
+      logger.warn(
+        '[ZimService] No Wikipedia manifest available (remote unreachable and nothing cached)'
+      )
+      return []
     }
+    return spec.options
   }
 
   async getWikipediaSelection(): Promise<WikipediaSelection | null> {

--- a/admin/app/validators/curated_collections.ts
+++ b/admin/app/validators/curated_collections.ts
@@ -101,16 +101,9 @@ export const creatorPacksSpecSchema = vine.object({
   ).minLength(1),
 })
 
-// ---- Wikipedia validators (used by ZimService) ----
-
-export const wikipediaOptionSchema = vine.object({
-  id: vine.string(),
-  name: vine.string(),
-  description: vine.string(),
-  size_mb: vine.number().min(0),
-  url: vine.string().url().nullable(),
-})
-
-export const wikipediaOptionsFileSchema = vine.object({
-  options: vine.array(wikipediaOptionSchema).minLength(1),
-})
+// The Wikipedia catalog had a second, laxer schema here that ZimService used to
+// validate its own direct fetch of collections/wikipedia.json. Having two
+// schemas for one remote file is what let the offline path diverge: that fetch
+// had no cache fallback, so an air-gapped host 500'd the Wikipedia endpoint.
+// ZimService now reads the manifest through CollectionManifestService like every
+// other catalog, and `wikipediaSpecSchema` above is the only schema for it.

--- a/admin/docs/offline-install.md
+++ b/admin/docs/offline-install.md
@@ -70,13 +70,31 @@ coreutils is required on the host, and the machine does not need to resemble the
 target: the package closure is resolved inside a container of the target
 distribution, so any build machine produces the same bundle.
 
-**Build from Linux, macOS, or WSL2.** The builder mounts the Docker socket and
-the working directories into its container, which needs a real Unix socket and
-un-rewritten paths. Windows *native* shells — Git Bash, MSYS, Cygwin — cannot
-provide either: Docker Desktop is reached over a named pipe, and MSYS rewrites
-the Unix-looking paths in every `-v` argument. The wrapper detects this and says
-so rather than failing obscurely part-way through. On Windows, build from a WSL2
-distribution with Docker Desktop's WSL integration enabled.
+Linux, macOS, WSL2 and Windows Git Bash all work. On Windows the wrapper hands
+the daemon Windows-form mount sources and mounts them inside the build container
+at `/run/desktop/mnt/host/<drive>/…`, the path Docker Desktop's VM resolves to
+the same directory — the build starts further containers, and their bind mounts
+are resolved by the host daemon, so a path has to mean the same thing on both
+sides.
+
+### Building from, or onto, a drive Docker cannot share
+
+Docker Desktop shares fixed drives; removable and exFAT volumes usually read as
+an **empty** directory rather than failing, which would otherwise yield a bundle
+that builds, passes its own verification, and contains nothing.
+
+The builder probes each directory up front and works around what it finds:
+
+- **Checkout on an unshared drive** — the working tree is copied to a mountable
+  staging directory and built from there, `.git` and uncommitted changes
+  included, so the manifest still records the right commit.
+- **`--output` on an unshared drive** — the bundle is built in staging and then
+  copied across with ordinary file I/O, which removable media accepts perfectly
+  well. Writing a bundle straight to the USB stick it will travel on is the
+  normal case and is fully supported.
+- **Neither mountable** — one clear error naming the fix, before any work starts.
+
+Set `TMPDIR` if the default staging location is itself on an unshared volume.
 
 ```bash
 git clone https://github.com/Crosstalk-Solutions/project-nomad.git

--- a/admin/docs/offline-install.md
+++ b/admin/docs/offline-install.md
@@ -1,0 +1,521 @@
+# Offline (Air-Gapped) Installation
+
+Project NOMAD is built to *run* without an internet connection, but a normal
+installation still needs one: the installer downloads Docker, host packages,
+container images and its own helper scripts. That leaves a gap for anyone who
+wants to prepare a machine now and deploy it somewhere with no connectivity —
+or rebuild a machine after connectivity is gone.
+
+**Offline artifact mode** closes that gap. You build a bundle once on a
+connected machine, carry it to the target on a USB drive, and run the ordinary
+installer against it.
+
+```bash
+# On a connected build machine, from a Project NOMAD checkout (needs only Docker):
+./install/build_offline_bundle_docker.sh --target ubuntu:26.04 --output /media/usb/NOMAD
+
+# On the disconnected target, from inside the bundle directory:
+sudo bash ./install_nomad.sh --artifacts .
+```
+
+There is only one installer. `install_nomad.sh` with no `--artifacts` argument
+behaves exactly as it always has.
+
+---
+
+## Table of Contents
+
+- [What the bundle covers](#what-the-bundle-covers)
+- [Building a bundle](#building-a-bundle)
+- [Installing on a disconnected target](#installing-on-a-disconnected-target)
+- [Verifying a bundle](#verifying-a-bundle)
+- [Bundle layout](#bundle-layout)
+- [How artifact mode stays offline](#how-artifact-mode-stays-offline)
+- [GPU support](#gpu-support)
+- [Bundling Supply Depot apps](#bundling-supply-depot-apps)
+- [Updating an air-gapped installation](#updating-an-air-gapped-installation)
+- [Optional images and pre-staged content](#optional-images-and-pre-staged-content)
+- [Known limitations](#known-limitations)
+- [Troubleshooting](#troubleshooting)
+- [Verified offline behaviour](#verified-offline-behaviour)
+
+---
+
+## What the bundle covers
+
+A bundle contains everything needed to bring up the **core NOMAD management
+stack** — the Command Center and its supporting services — on a clean machine:
+
+- Docker Engine, CLI, containerd, Buildx and Compose v2, plus the host
+  utilities the installer uses, as `.deb` packages with their dependencies
+- every container image referenced by `install/management_compose.yaml`
+- the management compose file, the start/stop/update helper scripts, and the
+  uninstall script
+- the exact `install_nomad.sh` from the checkout the bundle was built from
+
+Supply Depot applications can be added with
+[`--with-apps`](#bundling-supply-depot-apps). Offline content — ZIM files beyond
+a small Wikipedia sample, maps, AI models, Kolibri channels — is fetched from
+remote catalogs at runtime and is **not** covered; see
+[Known limitations](#known-limitations).
+
+---
+
+## Building a bundle
+
+The build machine needs **internet access and Docker** — that's the whole list.
+The entire build runs in containers, so no `git`, `bash` version, or GNU
+coreutils is required on the host, and the machine does not need to resemble the
+target: Linux, macOS and Windows build machines all produce the same bundle,
+because the package closure is resolved inside a container of the target
+distribution.
+
+```bash
+git clone https://github.com/Crosstalk-Solutions/project-nomad.git
+cd project-nomad
+
+./install/build_offline_bundle_docker.sh --target ubuntu:26.04
+```
+
+With no `--output`, the builder asks where to write the bundle, offering the
+directory you are running from, any connected removable drives (so you can
+write straight to the USB stick it will travel on), and your home directory. To
+skip the question, pass `--output DIR`, or `--no-prompt` to accept the default.
+Prompting is disabled automatically when stdin is not a terminal, so scripts and
+CI never hang.
+
+`build_offline_bundle_docker.sh` is a thin wrapper: it mounts the checkout, the
+output directory and the Docker socket into a container and runs
+`build_offline_bundle.sh` there, passing every option straight through. Call
+`build_offline_bundle.sh` directly only if you are already inside a Linux
+environment with `git` and coreutils available.
+
+This produces `/media/usb/NOMAD/project-nomad-offline-ubuntu-26.04-amd64-<commit>/`.
+
+The dependency closure is resolved inside a **pristine** container of the target
+release — nothing is installed there first, because APT only downloads packages
+it does not already have, and a contaminated container silently produces an
+incomplete bundle. Before finishing, the builder re-runs the target's exact
+isolated APT installation in a clean container with `--network none`. If the
+bundle cannot satisfy its own package list offline, the build fails rather than
+handing you a bundle that breaks in the field.
+
+| Option | Purpose |
+|--------|---------|
+| `--repo PATH` | Source checkout to build from (default: parent of the script) |
+| `--target OS:VERSION` | Target operating system (default: `ubuntu:26.04`) |
+| `--arch ARCH` | Target architecture (default: `amd64`) |
+| `--output DIR` | Where to create the bundle (default: `./dist`) |
+| `--without-nvidia-toolkit` | Omit the NVIDIA Container Toolkit packages |
+| `--extra-image-list FILE` | Also pull and bundle the image references in `FILE` |
+| `--extra-image-archive FILE` | Include an existing `docker save` archive |
+| `--with-apps LIST` | Bundle Supply Depot app images (`default`, `all`, or a list) |
+| `--list-apps` | Print the installable app names and exit |
+| `--content-dir DIR` | Include pre-staged NOMAD storage content |
+| `--archive` | Also produce a `.tar.gz` of the finished bundle |
+
+### Why the build runs in a container
+
+Every path-valued option is resolved to an absolute host path and mounted into
+the build container at that same location. This matters because the build starts
+*further* containers, and their bind mounts are resolved by the host Docker
+daemon — a path that existed only inside the build container would silently fail
+to mount. The wrapper handles this for `--output`, `--repo`, `--content-dir`,
+`--extra-image-archive` and `--extra-image-list`.
+
+Two environment variables are available if your setup is unusual:
+
+| Variable | Purpose |
+|---|---|
+| `NOMAD_BUILDER_IMAGE` | Build container image (default `docker:cli`) |
+| `NOMAD_DOCKER_SOCKET` | Docker socket path (default `/var/run/docker.sock`) |
+| `NOMAD_NO_PROMPT` | Set to `1` to never ask where to write the bundle |
+
+### Building onto FAT/exFAT removable media
+
+Writing a bundle straight to a USB stick is supported and expected. Note that
+macOS deposits AppleDouble sidecars (`._name`) and `.DS_Store` files on such
+filesystems. These are OS metadata rather than bundle content, so the builder
+removes them and excludes them from `SHA256SUMS`, and the installer ignores them
+when loading image archives. Without that, a `._core-images.tar` sidecar would
+both break checksum verification and be handed to `docker load`.
+
+### Bundles are specific
+
+A bundle is valid for **one operating system, one version, and one
+architecture**. The package closure is resolved for that exact combination, so
+an Ubuntu 26.04 bundle will not install on Debian 12, and the installer refuses
+to try. Build one bundle per target platform.
+
+The bundle records the git commit it was built from and carries that commit's
+installer, so the target runs the same code the bundle was built against.
+
+---
+
+## Installing on a disconnected target
+
+The target needs a clean, supported OS install and nothing else. In particular,
+**do not install Docker first** — it comes from the bundle:
+
+| Normal install | Offline install |
+|---|---|
+| Install a supported OS | **Same** |
+| Connect to the internet | Not needed |
+| `apt-get install curl` | Not needed — provided by the bundle |
+| `curl … install_nomad.sh` | Not needed — the bundle carries the installer |
+| Installer fetches Docker from `get.docker.com` | Docker installs from the bundle |
+| Installer pulls images from GHCR / Docker Hub | Images load from the bundle |
+| Installer downloads helper scripts from GitHub | Provided by the bundle |
+
+Copy the bundle directory to the target (USB drive, external disk, whatever
+moves bytes), then:
+
+```bash
+cd /media/usb/NOMAD/project-nomad-offline-ubuntu-26.04-amd64-<commit>
+sudo bash ./install_nomad.sh --artifacts .
+```
+
+The environment variable form is equivalent:
+
+```bash
+sudo NOMAD_ARTIFACT_PATH=/media/usb/NOMAD/project-nomad-offline-... \
+  bash ./install_nomad.sh
+```
+
+If both are supplied, the `--artifacts` argument wins.
+
+Installation proceeds as usual from there — same prompts, same license
+acceptance, same result. When it finishes, the Command Center is available at
+`http://localhost:8080`, and at `http://<device-ip>:8080` if the machine has a
+LAN address.
+
+A completely disconnected machine may have no LAN address at all. That is fine:
+artifact mode falls back to `localhost` instead of failing, and simply doesn't
+advertise a LAN URL.
+
+---
+
+## Verifying a bundle
+
+Before transferring a bundle — or on the target before installing — check it:
+
+```bash
+./install/verify_offline_bundle.sh /media/usb/NOMAD/project-nomad-offline-...
+```
+
+This confirms every required file is present, verifies the checksums, and
+prints the manifest. It runs entirely offline and installs nothing.
+
+The installer performs the same validation automatically before it touches the
+system.
+
+---
+
+## Bundle layout
+
+```text
+project-nomad-offline-<os>-<version>-<arch>-<commit>/
+├── install_nomad.sh              # the installer from the source commit
+├── manifest                      # bundle metadata (data, never sourced)
+├── README.txt
+├── SHA256SUMS                    # covers every other file in the bundle
+├── packages/
+│   └── apt/                      # flat local APT repository
+│       ├── Packages
+│       ├── Packages.gz
+│       └── *.deb
+├── images/
+│   ├── core-images.txt           # image references in the bundle
+│   ├── core-image-metadata.tsv   # image IDs and repo digests
+│   ├── core-images.tar           # docker save archive
+│   └── optional-images.tar       # optional
+├── payload/
+│   └── nomad/
+│       ├── management_compose.yaml
+│       ├── compose.artifact.yml  # generated pull_policy: never override
+│       ├── start_nomad.sh
+│       ├── stop_nomad.sh
+│       ├── update_nomad.sh
+│       └── uninstall_nomad.sh
+└── content/                      # optional pre-staged storage content
+```
+
+### The manifest
+
+```text
+BUNDLE_FORMAT_VERSION=1
+NOMAD_COMMIT=<full git sha>
+TARGET_OS=ubuntu
+TARGET_VERSION=26.04
+TARGET_ARCH=amd64
+WITH_NVIDIA_TOOLKIT=1
+CREATED_AT_UTC=2026-08-14T16:00:00Z
+```
+
+The manifest is plain data. The installer reads individual keys from it and
+never executes it as shell.
+
+### Checksums
+
+`SHA256SUMS` covers every regular file in the bundle except itself, and is
+verified before any package is installed or image loaded.
+
+This proves the bundle **transferred intact**. It is not a publisher signature
+and does not establish who produced the bundle — verify provenance separately
+if that matters to you.
+
+---
+
+## How artifact mode stays offline
+
+Artifact mode is *fail-closed*. Once an artifact path is given, the installer
+never falls back to the network to fill a gap. A missing package, image,
+payload file, manifest field or checksum stops the installation with an
+actionable error.
+
+Concretely, in artifact mode the installer does not use `curl` or `wget` to
+acquire anything, does not run `docker pull`, and does not contact GitHub,
+GHCR, Docker Hub, the Docker convenience script, or NVIDIA's package
+repository.
+
+**Host packages** are installed from the bundle's flat APT repository through a
+temporary source that excludes the machine's own configuration:
+
+```text
+deb [trusted=yes] file:/tmp/nomad-artifact-apt.XXXXXX/repo ./
+```
+
+APT is invoked with `Dir::Etc::sourcelist` pointing at that file,
+`Dir::Etc::sourceparts=-` to exclude `/etc/apt/sources.list.d`,
+`Dir::State::Lists` pointing at a private directory so the host's package lists
+are left alone, `APT::Get::List-Cleanup=0`, and `Acquire::Retries=0`. The
+machine's configured remote repositories take no part in dependency resolution,
+which is why a missing dependency fails instead of quietly downloading.
+
+**Container images** are loaded with `docker load`. Because
+`management_compose.yaml` legitimately uses `pull_policy: always` for online
+installs, the builder generates `compose.artifact.yml` setting
+`pull_policy: never` for every service. Artifact mode layers both files:
+
+```bash
+docker compose -p project-nomad \
+  -f /opt/project-nomad/compose.yml \
+  -f /opt/project-nomad/compose.artifact.yml \
+  up -d --pull never
+```
+
+The canonical compose file is never rewritten just to make an offline install
+work.
+
+A practical consequence: a bundle tested on a machine that happens to be online
+behaves identically once the cable is pulled. If it works connected, it works
+disconnected.
+
+---
+
+## GPU support
+
+Artifact mode keeps the installer's existing non-blocking GPU behaviour — GPU
+problems warn, they never fail the install.
+
+- NVIDIA hardware is detected with the same logic as an online install.
+- If the bundle includes `nvidia-container-toolkit` (the default; disable with
+  `--without-nvidia-toolkit`) **and** a working host NVIDIA driver is present,
+  the Docker runtime is configured locally.
+- If the host driver is missing, you get a warning and the install continues.
+- NVIDIA's package repository is never contacted.
+
+**Host NVIDIA drivers are out of scope for this version of the bundle format.**
+Bundling kernel drivers means matching kernel versions and handling DKMS, which
+is a materially larger problem. Install the driver on the target separately if
+you need GPU acceleration offline.
+
+AMD GPU detection and the marker files the Command Center reads are unchanged.
+
+---
+
+## Bundling Supply Depot apps
+
+A core bundle gets you the Command Center, but the Supply Depot will be unable
+to install anything without a network. `--with-apps` carries the app images too:
+
+```bash
+./install/build_offline_bundle_docker.sh \
+  --target ubuntu:26.04 \
+  --with-apps default
+```
+
+| Value | Meaning |
+|---|---|
+| `default` | A useful starter set: Kiwix, CyberChef, IT-Tools, FlatNotes, Excalidraw, File Browser, Stirling PDF |
+| `all` | Every app in the catalog (large — includes Ollama, Kolibri, Jellyfin) |
+| `kiwix,cyberchef,…` | An explicit comma-separated list |
+
+Run `./install/build_offline_bundle.sh --list-apps` to see the available names.
+An unrecognised name fails the build rather than quietly producing a bundle
+without the app you asked for.
+
+This works because the app catalog is **not fetched from the internet**: it is
+seeded into the Command Center's database from a file baked into the admin
+image, with pinned image tags. The installer then skips the registry pull for
+any image already present locally. Loading the images from a bundle is therefore
+enough for the Supply Depot to install those apps offline.
+
+The image references are read from that same seeder at build time, so a bundle
+cannot drift from the catalog the UI will offer.
+
+### Apps with extra requirements
+
+Most apps need nothing beyond their image. Two exceptions are worth knowing:
+
+- **Kiwix** refuses to start without at least one ZIM file, and its pre-install
+  step fetches a sample from GitHub. When Kiwix is selected, the builder includes
+  the small Wikipedia sample from the checkout as pre-staged content, and the
+  pre-install step skips the download when storage already holds a ZIM.
+
+  That skip is a change to the admin application, so it only takes effect once
+  it ships in a released `ghcr.io/crosstalk-solutions/project-nomad` image.
+  Against an older admin image, installing Kiwix on an air-gapped host fails
+  with `getaddrinfo EAI_AGAIN github.com` even when the ZIM is already in
+  storage, because the downloader's idempotency check sits behind a HEAD
+  request.
+- **The AI Assistant (Ollama)** ships as an image, but *models* are downloaded
+  separately from the Ollama registry at first use. Bundling the image does not
+  make model downloads work offline.
+
+Content that is fetched from remote catalogs at runtime — ZIM files beyond the
+bundled sample, maps, Kolibri channels, AI models — is not covered. Use
+`--content-dir` to pre-stage such files if you already have them in NOMAD's
+storage layout.
+
+## Updating an air-gapped installation
+
+Re-running the installer with a newer bundle updates in place. This is the
+supported offline update path — build a new bundle on a connected machine, carry
+it over, and run the same command:
+
+```bash
+sudo bash ./install_nomad.sh --artifacts .
+```
+
+Re-running is safe and repeatable. When an existing installation is detected the
+installer:
+
+- keeps the database, installed apps, settings and content;
+- reuses the credentials the database was initialised with, rather than
+  generating new ones (MySQL only applies those on first startup, so
+  regenerating is precisely what would force wiping the data directory);
+- preserves the URL the instance is already reachable at;
+- loads any new or updated images from the bundle and recreates the changed
+  containers;
+- adds new pre-staged content without overwriting files you have changed.
+
+Use it to move to a newer NOMAD version, or simply to add apps: rebuild with a
+wider `--with-apps` set and re-run.
+
+Note that `update_nomad.sh` — the online update path — still pulls from a
+registry and will not work air-gapped. Use a new bundle instead.
+
+## Optional images and pre-staged content
+
+Two further extension points exist. Both are **transport mechanisms**, not
+guarantees.
+
+### Additional images
+
+On a machine with NOMAD already installed and apps set up:
+
+```bash
+./install/capture_installed_images.sh --output /tmp/nomad-extra-images
+```
+
+Then include the archive:
+
+```bash
+./install/build_offline_bundle.sh \
+  --target ubuntu:26.04 \
+  --extra-image-archive /tmp/nomad-extra-images/optional-images.tar \
+  --output /media/usb/NOMAD
+```
+
+This moves the Docker images to the target. It does **not** by itself make
+those applications installable offline — Supply Depot install flows and catalog
+metadata may have their own network dependencies. Test any app you care about
+individually before relying on it.
+
+### Pre-staged content
+
+```bash
+./install/build_offline_bundle.sh \
+  --target ubuntu:26.04 \
+  --content-dir /srv/nomad-storage-seed \
+  --output /media/usb/NOMAD
+```
+
+The directory is copied into `/opt/project-nomad/storage` before the stack
+starts. It must already match NOMAD's storage layout.
+
+---
+
+## Known limitations
+
+Be precise about what offline artifact mode does and does not claim:
+
+- **Apps need `--with-apps`; content is mostly not covered.** A core bundle
+  installs the Command Center only. App images can be bundled, but offline
+  content (ZIMs beyond the bundled sample, maps, AI models, Kolibri channels) is
+  fetched from remote catalogs at runtime and is not covered.
+- **`update_nomad.sh` still needs the internet.** Update an air-gapped install by
+  building a new bundle and re-running the installer against it.
+- **Host NVIDIA drivers are not bundled.** See [GPU support](#gpu-support).
+- **Checksums are integrity, not provenance.** See
+  [Checksums](#checksums).
+- **One bundle, one platform.** OS, version and architecture must match.
+- **x86_64 only**, matching the installer's supported architecture.
+- **The Command Center still probes for connectivity at runtime.** It shows
+  an offline status and falls back to bundled data rather than failing, but
+  those requests are attempted. This is existing behaviour, unchanged here.
+
+---
+
+## Troubleshooting
+
+**"This bundle targets ubuntu 26.04, but this host runs 24.04."**
+Bundles carry a package set resolved for one exact OS version. Build a bundle
+for the target's version.
+
+**"The offline artifact bundle failed checksum verification."**
+The copy is corrupt or incomplete — a common outcome of pulling a USB drive
+early. Copy it again and re-run `verify_offline_bundle.sh`.
+
+**"Failed to install host dependencies from the offline artifact bundle."**
+The bundle is missing a package this machine needs. The builder resolves the
+dependency closure inside a pristine base image of the target release and
+verifies offline that it resolves, so this normally means the target is more
+minimal than a stock install of that release. Note which package APT names and
+rebuild the bundle for the target's exact OS version.
+
+**"The bundle lists image X but it is not present after loading."**
+The image archive is incomplete. Rebuild the bundle on a connected machine.
+
+**The installer says it cannot find the bundle.**
+Pass a path to the bundle *directory* (the one containing `manifest`), and
+remember `sudo` — the path must be readable by root. Mount points containing
+spaces are handled.
+
+---
+
+## Verified offline behaviour
+
+What has actually been exercised on a disconnected Ubuntu 26.04 host, with all
+egress denied:
+
+| Step | Result |
+|---|---|
+| Fresh install from a core bundle | Works — all six management containers healthy |
+| Reboot with egress still denied | Works — stack returns on its own |
+| Docker installed from the bundle | Works — no repository added to the host |
+| Re-running with a newer bundle | Works — database, apps, settings and content preserved |
+| Installing CyberChef / IT-Tools offline | Works — installed and serving |
+| Installing Kiwix offline | Requires the pre-install fix above in the admin image |
+| Downloading content (ZIMs, maps, models) | Not supported offline by design |

--- a/admin/docs/offline-install.md
+++ b/admin/docs/offline-install.md
@@ -33,6 +33,7 @@ behaves exactly as it always has.
 - [How artifact mode stays offline](#how-artifact-mode-stays-offline)
 - [GPU support](#gpu-support)
 - [Bundling Supply Depot apps](#bundling-supply-depot-apps)
+- [Easy Setup with no internet](#easy-setup-with-no-internet)
 - [Updating an air-gapped installation](#updating-an-air-gapped-installation)
 - [Optional images and pre-staged content](#optional-images-and-pre-staged-content)
 - [Known limitations](#known-limitations)
@@ -383,10 +384,45 @@ Most apps need nothing beyond their image. Two exceptions are worth knowing:
   separately from the Ollama registry at first use. Bundling the image does not
   make model downloads work offline.
 
+  On a host with an **AMD GPU** the installer switches Ollama to the ROCm image
+  (`ollama/ollama:rocm`), which `--with-apps` does not carry — it bundles the
+  catalog's pinned tag. An air-gapped AMD host therefore needs that tag added
+  explicitly with `--extra-image-list`, or AMD acceleration turned off (KV key
+  `ai.amdGpuAcceleration` set to `false`) so the bundled CPU image is used.
+
 Content that is fetched from remote catalogs at runtime — ZIM files beyond the
 bundled sample, maps, Kolibri channels, AI models — is not covered. Use
 `--content-dir` to pre-stage such files if you already have them in NOMAD's
 storage layout.
+
+## Easy Setup with no internet
+
+The Command Center's Easy Setup wizard is the first thing an operator sees after
+an install, and it works air-gapped — for the part of it that can.
+
+**Apps install offline when their image is already on the machine.** The wizard
+asks Docker which images are present and offers exactly those. An app whose
+image came from a `--with-apps` bundle is selectable and installs without
+touching a registry; one that would need a pull is shown greyed out with a
+*Needs internet* badge, so nothing fails halfway through.
+
+**Content downloads stay unavailable.** Map regions, curated content tiers,
+creator packs, AI models and Wikipedia all come from remote catalogs. Offline,
+those steps explain themselves and their cards can't be selected. You can walk
+through every step, skip them, and finish the wizard with just the apps.
+
+If the wizard is offline and *no* app images are on the machine, it says so
+plainly rather than offering a set of installs that would all fail. That is the
+signal to re-run the installer against a bundle built with `--with-apps`.
+
+Two consequences of a truly air-gapped first boot are worth knowing:
+
+- The wizard shows **no Wikipedia selector**. The catalog that populates it is
+  fetched from GitHub and cached; a machine that has never been online has no
+  cached copy, so the section is omitted. It appears on the Content step (and in
+  the ZIM manager) the first time the machine reaches the internet.
+- The Kiwix app still needs at least one ZIM to start. A bundle that includes
+  Kiwix pre-stages the small Wikipedia sample for exactly this reason.
 
 ## Updating an air-gapped installation
 
@@ -473,8 +509,12 @@ Be precise about what offline artifact mode does and does not claim:
 - **One bundle, one platform.** OS, version and architecture must match.
 - **x86_64 only**, matching the installer's supported architecture.
 - **The Command Center still probes for connectivity at runtime.** It shows
-  an offline status and falls back to bundled data rather than failing, but
-  those requests are attempted. This is existing behaviour, unchanged here.
+  an offline status and falls back to cached or bundled data rather than
+  failing, but those requests are attempted.
+- **Easy Setup offline installs apps, not content.** See
+  [Easy Setup with no internet](#easy-setup-with-no-internet). Only apps whose
+  images are already on the machine are offered; every download-backed step is
+  disabled with an explanation.
 
 ---
 

--- a/admin/docs/offline-install.md
+++ b/admin/docs/offline-install.md
@@ -12,7 +12,7 @@ installer against it.
 
 ```bash
 # On a connected build machine, from a Project NOMAD checkout (needs only Docker):
-./install/build_offline_bundle_docker.sh --target ubuntu:26.04 --output /media/usb/NOMAD
+./install/build_offline_bundle_docker.sh --with-apps core,default --output /media/usb/NOMAD
 
 # On the disconnected target, from inside the bundle directory:
 sudo bash ./install_nomad.sh --artifacts .
@@ -393,14 +393,24 @@ to install anything without a network. `--with-apps` carries the app images too:
 ```bash
 ./install/build_offline_bundle_docker.sh \
   --target ubuntu:26.04 \
-  --with-apps default
+  --with-apps core,default
 ```
 
 | Value | Meaning |
 |---|---|
-| `default` | A useful starter set: Kiwix, CyberChef, IT-Tools, FlatNotes, Excalidraw, File Browser, Stirling PDF |
-| `all` | Every app in the catalog (large — includes Ollama, Kolibri, Jellyfin) |
+| `core` | The three Easy Setup capabilities: Kiwix, Kolibri, Ollama, plus Qdrant for the AI knowledge base |
+| `default` | A light starter set: Kiwix, CyberChef, IT-Tools, FlatNotes, Excalidraw, File Browser, Stirling PDF |
+| `all` | Every app in the catalog (large — includes Jellyfin) |
 | `kiwix,cyberchef,…` | An explicit comma-separated list |
+
+Sets combine with each other and with individual names, so `--with-apps
+core,default` is the usual choice and `--with-apps core,jellyfin` works too.
+
+**`default` alone is not enough for onboarding.** It omits Kolibri and Ollama,
+and Easy Setup only offers a capability whose image is already present — so a
+`default` bundle greys out Education and the AI Assistant on an air-gapped
+target. Use `core`, or `core,default`, whenever the target's users are expected
+to pick their own capabilities.
 
 Run `./install/build_offline_bundle.sh --list-apps` to see the available names.
 An unrecognised name fails the build rather than quietly producing a bundle

--- a/admin/docs/offline-install.md
+++ b/admin/docs/offline-install.md
@@ -67,9 +67,16 @@ remote catalogs at runtime and is **not** covered; see
 The build machine needs **internet access and Docker** — that's the whole list.
 The entire build runs in containers, so no `git`, `bash` version, or GNU
 coreutils is required on the host, and the machine does not need to resemble the
-target: Linux, macOS and Windows build machines all produce the same bundle,
-because the package closure is resolved inside a container of the target
-distribution.
+target: the package closure is resolved inside a container of the target
+distribution, so any build machine produces the same bundle.
+
+**Build from Linux, macOS, or WSL2.** The builder mounts the Docker socket and
+the working directories into its container, which needs a real Unix socket and
+un-rewritten paths. Windows *native* shells — Git Bash, MSYS, Cygwin — cannot
+provide either: Docker Desktop is reached over a named pipe, and MSYS rewrites
+the Unix-looking paths in every `-v` argument. The wrapper detects this and says
+so rather than failing obscurely part-way through. On Windows, build from a WSL2
+distribution with Docker Desktop's WSL integration enabled.
 
 ```bash
 git clone https://github.com/Crosstalk-Solutions/project-nomad.git

--- a/admin/docs/offline-install.md
+++ b/admin/docs/offline-install.md
@@ -112,6 +112,7 @@ handing you a bundle that breaks in the field.
 | `--extra-image-archive FILE` | Include an existing `docker save` archive |
 | `--with-apps LIST` | Bundle Supply Depot app images (`default`, `all`, or a list) |
 | `--list-apps` | Print the installable app names and exit |
+| `--use-local-images` | Bundle images already in the local Docker daemon instead of pulling them |
 | `--content-dir DIR` | Include pre-staged NOMAD storage content |
 | `--archive` | Also produce a `.tar.gz` of the finished bundle |
 
@@ -140,6 +141,29 @@ filesystems. These are OS metadata rather than bundle content, so the builder
 removes them and excludes them from `SHA256SUMS`, and the installer ignores them
 when loading image archives. Without that, a `._core-images.tar` sidecar would
 both break checksum verification and be handed to `docker load`.
+
+### Testing an unreleased Command Center
+
+`management_compose.yaml` pins the published
+`ghcr.io/crosstalk-solutions/project-nomad:latest`, and the builder pulls it. A
+bundle therefore carries the *released* Command Center, not whatever is in your
+checkout — so a change to the admin application cannot be tested air-gapped
+until it ships in an image.
+
+`--use-local-images` closes that loop. Build the image from your checkout, tag it
+as the reference the compose file uses, then build the bundle:
+
+```bash
+docker build -t ghcr.io/crosstalk-solutions/project-nomad:latest .
+./install/build_offline_bundle_docker.sh --target ubuntu:26.04 --use-local-images
+```
+
+Any image already present in the daemon is taken as-is; anything missing is still
+pulled, so the flag can never quietly produce a bundle with a gap in it.
+
+Bundles built this way record `USED_LOCAL_IMAGES=1` in the manifest and carry a
+note in `README.txt`, because they may contain unreleased code and should not be
+distributed.
 
 ### Bundles are specific
 
@@ -250,6 +274,7 @@ TARGET_OS=ubuntu
 TARGET_VERSION=26.04
 TARGET_ARCH=amd64
 WITH_NVIDIA_TOOLKIT=1
+USED_LOCAL_IMAGES=0
 CREATED_AT_UTC=2026-08-14T16:00:00Z
 ```
 

--- a/admin/inertia/lib/offline_setup.ts
+++ b/admin/inertia/lib/offline_setup.ts
@@ -1,0 +1,106 @@
+/**
+ * What the Easy Setup wizard can and cannot do with no internet connection.
+ *
+ * NOMAD can be installed air-gapped from an offline artifact bundle (see
+ * docs/offline-install.md). A bundle built with `--with-apps` carries the app
+ * images, so the Command Center really can install those capabilities with the
+ * cable pulled — the install path skips the registry pull whenever the image is
+ * already in the local Docker daemon. Everything else the wizard offers (map
+ * regions, curated content tiers, creator packs, AI models, Wikipedia) is
+ * fetched from a remote catalog at run time and genuinely cannot work offline.
+ *
+ * The wizard used to draw no distinction: a single `!isOnline` check disabled
+ * Next and Complete Setup, so an air-gapped operator could not install the
+ * capabilities their bundle had already put on disk. These helpers split the
+ * two cases so the UI can allow the first and explain the second.
+ *
+ * Pure functions, no React — unit-tested in tests/unit/offline_setup.spec.ts.
+ */
+
+/** The kinds of selection the review step can be carrying. */
+export type OfflineBlocker =
+  | 'services'
+  | 'maps'
+  | 'content'
+  | 'creator-packs'
+  | 'ai-models'
+  | 'wikipedia'
+
+export type WizardSelections = {
+  /** service_name values queued for install. */
+  services: string[]
+  mapCollections: string[]
+  creatorPacks: string[]
+  /** Number of curated category tiers picked (selectedTiers.size). */
+  categoryTierCount: number
+  aiModels: string[]
+  /** Wikipedia option id, or null when untouched. 'none' means "remove/skip". */
+  wikipediaOptionId: string | null
+}
+
+/** Human-readable reason shown next to the disabled Complete Setup button. */
+export const OFFLINE_BLOCKER_LABELS: Record<OfflineBlocker, string> = {
+  services: 'apps whose image is not on this machine',
+  maps: 'map regions',
+  content: 'content categories',
+  'creator-packs': 'creator packs',
+  'ai-models': 'AI models',
+  wikipedia: 'Wikipedia',
+}
+
+/**
+ * True when this app can be installed with no internet: its image is already in
+ * the local Docker daemon (loaded from an offline bundle, or left behind by a
+ * previous install/uninstall), so the install skips the registry pull.
+ */
+export function isServiceInstallableOffline(
+  serviceName: string,
+  locallyAvailableServices: string[]
+): boolean {
+  return locallyAvailableServices.includes(serviceName)
+}
+
+/**
+ * The selections that would need to reach the internet to complete. Empty means
+ * the whole setup can run air-gapped.
+ *
+ * A Wikipedia pick of 'none' is a local deletion, not a download, so it never
+ * blocks. Order is stable (declaration order) so the message reads the same way
+ * every time.
+ */
+export function offlineBlockers(
+  selections: WizardSelections,
+  locallyAvailableServices: string[]
+): OfflineBlocker[] {
+  const blockers: OfflineBlocker[] = []
+
+  const needsPull = selections.services.some(
+    (service) => !isServiceInstallableOffline(service, locallyAvailableServices)
+  )
+  if (needsPull) blockers.push('services')
+  if (selections.mapCollections.length > 0) blockers.push('maps')
+  if (selections.categoryTierCount > 0) blockers.push('content')
+  if (selections.creatorPacks.length > 0) blockers.push('creator-packs')
+  if (selections.aiModels.length > 0) blockers.push('ai-models')
+  if (selections.wikipediaOptionId !== null && selections.wikipediaOptionId !== 'none') {
+    blockers.push('wikipedia')
+  }
+
+  return blockers
+}
+
+/** True when every selection can be carried out with no internet connection. */
+export function canCompleteSetupOffline(
+  selections: WizardSelections,
+  locallyAvailableServices: string[]
+): boolean {
+  return offlineBlockers(selections, locallyAvailableServices).length === 0
+}
+
+/** "map regions and AI models" — for the message explaining a blocked finish. */
+export function describeOfflineBlockers(blockers: OfflineBlocker[]): string {
+  const labels = blockers.map((blocker) => OFFLINE_BLOCKER_LABELS[blocker])
+  if (labels.length === 0) return ''
+  if (labels.length === 1) return labels[0]
+  return `${labels.slice(0, -1).join(', ')} and ${labels[labels.length - 1]}`
+}

--- a/admin/inertia/pages/easy-setup/index.tsx
+++ b/admin/inertia/pages/easy-setup/index.tsx
@@ -22,6 +22,13 @@ import { getPrimaryDiskInfo } from '~/hooks/useDiskDisplayData'
 import classNames from 'classnames'
 import type { CategoryWithStatus, SpecTier, SpecResource } from '../../../types/collections'
 import { resolveTierResources } from '~/lib/collections'
+import {
+  canCompleteSetupOffline,
+  describeOfflineBlockers,
+  isServiceInstallableOffline,
+  offlineBlockers,
+  type WizardSelections,
+} from '~/lib/offline_setup'
 import { SERVICE_NAMES } from '../../../constants/service_names'
 
 // Capability definitions - maps user-friendly categories to services
@@ -107,7 +114,17 @@ const CURATED_CATEGORIES_KEY = 'curated-categories'
 const WIKIPEDIA_STATE_KEY = 'wikipedia-state'
 
 export default function EasySetupWizard(props: {
-  system: { services: ServiceSlim[]; remoteOllamaUrl: string }
+  system: {
+    services: ServiceSlim[]
+    remoteOllamaUrl: string
+    /**
+     * service_name values whose container image is already in the local Docker
+     * daemon — the apps an air-gapped host can install right now, because the
+     * install path skips the registry pull when the image is present. Populated
+     * by an offline artifact bundle built with `--with-apps`.
+     */
+    locallyAvailableServices?: string[]
+  }
 }) {
   const { aiAssistantName } = usePage<{ aiAssistantName: string }>().props
   const CORE_CAPABILITIES = buildCoreCapabilities(aiAssistantName)
@@ -351,13 +368,34 @@ export default function EasySetupWizard(props: {
   // Get primary disk/filesystem info for storage projection
   const storageInfo = getPrimaryDiskInfo(systemInfo?.disk, systemInfo?.fsSize)
 
+  // Offline capability (docs/offline-install.md). An air-gapped host installed
+  // from an artifact bundle has the app images on disk already, so installing
+  // those capabilities works with no internet; only the remote catalogs (maps,
+  // content, packs, models, Wikipedia) genuinely need a connection. The wizard
+  // used to gate *everything* on isOnline, which locked offline operators out
+  // of the one thing their bundle had prepared for them.
+  const locallyAvailableServices = props.system.locallyAvailableServices ?? []
+
+  const currentSelections: WizardSelections = {
+    services: selectedServices,
+    mapCollections: selectedMapCollections,
+    creatorPacks: selectedCreatorPacks,
+    categoryTierCount: selectedTiers.size,
+    aiModels: selectedAiModels,
+    wikipediaOptionId: selectedWikipedia,
+  }
+
+  const offlineOnlyBlockers = offlineBlockers(currentSelections, locallyAvailableServices)
+  const canFinishOffline = canCompleteSetupOffline(currentSelections, locallyAvailableServices)
+
   // The review step is always the last active step. Read by canProceedToNextStep
   // and the bottom-bar Next-vs-Finish switch.
   const finalStep: WizardStep = activeSteps[activeSteps.length - 1]
 
   const canProceedToNextStep = () => {
-    if (!isOnline) return false // Must be online to proceed
-    // Every step before the review is skippable; the review step shows Finish, not Next.
+    // Navigation itself needs nothing from the network — the per-step controls
+    // decide what an offline user may actually pick. The review step shows
+    // Finish, not Next.
     return currentStep < finalStep
   }
 
@@ -376,10 +414,12 @@ export default function EasySetupWizard(props: {
   }
 
   const handleFinish = async () => {
-    if (!isOnline) {
+    // Offline is only a problem for the selections that have to fetch something.
+    // Installing an app whose image is already local is fine air-gapped.
+    if (!isOnline && !canFinishOffline) {
       addNotification({
         type: 'error',
-        message: 'You must have an internet connection to complete the setup.',
+        message: `Without an internet connection NOMAD can't set up ${describeOfflineBlockers(offlineOnlyBlockers)}. Remove those selections to continue offline.`,
       })
       return
     }
@@ -592,10 +632,22 @@ export default function EasySetupWizard(props: {
     )
   }
 
+  // Offline, a capability is installable only if every image it needs is
+  // already in the local Docker daemon — otherwise the install would try to
+  // pull and fail. Online this is always true; the pull just happens.
+  const isCapabilityAvailable = (capability: Capability) => {
+    if (isOnline) return true
+    return capability.services.every((service) =>
+      isServiceInstallableOffline(service, locallyAvailableServices)
+    )
+  }
+
   // Toggle all services for a capability (only if not already installed)
   const toggleCapability = (capability: Capability) => {
     // Don't allow toggling installed capabilities
     if (isCapabilityInstalled(capability)) return
+    // Offline with no local image there is nothing to install from.
+    if (!isCapabilityAvailable(capability)) return
 
     const isSelected = isCapabilitySelected(capability)
 
@@ -637,6 +689,7 @@ export default function EasySetupWizard(props: {
     const selected = isCapabilitySelected(capability)
     const installed = isCapabilityInstalled(capability)
     const exists = capabilityExists(capability)
+    const unavailableOffline = !installed && !isCapabilityAvailable(capability)
 
     if (!exists) return null
 
@@ -651,9 +704,11 @@ export default function EasySetupWizard(props: {
           'p-6 rounded-lg border-2 transition-all',
           installed
             ? 'border-desert-green bg-desert-green/20 cursor-default'
-            : selected
-              ? 'border-desert-green bg-desert-green shadow-md cursor-pointer'
-              : 'border-desert-stone-light bg-surface-primary hover:border-desert-green hover:shadow-sm cursor-pointer'
+            : unavailableOffline
+              ? 'border-desert-stone-light bg-surface-primary opacity-50 cursor-not-allowed'
+              : selected
+                ? 'border-desert-green bg-desert-green shadow-md cursor-pointer'
+                : 'border-desert-stone-light bg-surface-primary hover:border-desert-green hover:shadow-sm cursor-pointer'
         )}
       >
         <div className="flex items-start justify-between">
@@ -670,6 +725,11 @@ export default function EasySetupWizard(props: {
               {installed && (
                 <span className="text-xs bg-desert-green text-white px-2 py-0.5 rounded-full">
                   Installed
+                </span>
+              )}
+              {unavailableOffline && (
+                <span className="text-xs bg-surface-secondary text-text-muted border border-border-default px-2 py-0.5 rounded-full">
+                  Needs internet
                 </span>
               )}
             </div>
@@ -853,6 +913,19 @@ export default function EasySetupWizard(props: {
     )
   }
 
+  // Steps 2-5 all hand out remote content. Offline they stay browsable but
+  // unselectable, so say why rather than leaving the user clicking dead cards.
+  const renderOfflineDownloadNotice = (what: string) =>
+    !isOnline ? (
+      <Alert
+        title="Unavailable offline"
+        message={`${what} download from a remote catalog, so they can't be added while this machine has no internet connection. Skip this step — apps whose images are already on disk still install — and come back here once you're connected.`}
+        type="info"
+        variant="bordered"
+        className="mb-6"
+      />
+    ) : null
+
   const renderStep2 = () => (
     <div className="space-y-6">
       <div className="text-center mb-6">
@@ -862,6 +935,7 @@ export default function EasySetupWizard(props: {
           regions later.
         </p>
       </div>
+      {renderOfflineDownloadNotice('Map regions')}
       <div className="mx-auto max-w-2xl rounded-lg border border-border-subtle bg-surface-secondary p-3 text-center">
         <p className="text-sm text-text-secondary">
           Only need a specific country, or want the whole world? Individual countries and a full
@@ -931,6 +1005,8 @@ export default function EasySetupWizard(props: {
               : 'Configure content for your selected capabilities.'}
           </p>
         </div>
+
+        {renderOfflineDownloadNotice('Wikipedia and curated content collections')}
 
         {/* Wikipedia Selection - Only show if Information capability is selected */}
         {isInformationSelected && (
@@ -1028,6 +1104,8 @@ export default function EasySetupWizard(props: {
           </p>
         </div>
 
+        {renderOfflineDownloadNotice('Creator packs')}
+
         {creatorPacks.length > 0 ? (
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             {creatorPacks.map((pack) => (
@@ -1063,6 +1141,8 @@ export default function EasySetupWizard(props: {
             Choose models to download and set how {aiAssistantName} handles new content.
           </p>
         </div>
+
+        {renderOfflineDownloadNotice('AI models')}
 
         <div className="flex items-center gap-3 mb-4">
           <div className="w-10 h-10 rounded-full bg-surface-primary border border-border-subtle flex items-center justify-center shadow-sm">
@@ -1379,12 +1459,25 @@ export default function EasySetupWizard(props: {
               </div>
             )}
 
-            <Alert
-              title="Ready to Start"
-              message="Click 'Complete Setup' to begin installing apps and downloading content. This may take some time depending on your internet connection and the size of the downloads."
-              type="info"
-              variant="solid"
-            />
+            {!isOnline && !canFinishOffline ? (
+              <Alert
+                title="Some selections need an internet connection"
+                message={`This machine is offline, so NOMAD can't set up ${describeOfflineBlockers(offlineOnlyBlockers)}. Go back and clear those selections to finish the rest now, or connect to the internet and return here.`}
+                type="warning"
+                variant="solid"
+              />
+            ) : (
+              <Alert
+                title="Ready to Start"
+                message={
+                  isOnline
+                    ? "Click 'Complete Setup' to begin installing apps and downloading content. This may take some time depending on your internet connection and the size of the downloads."
+                    : "Click 'Complete Setup' to install the selected apps from images already on this machine. No internet connection is needed for these."
+                }
+                type="info"
+                variant="solid"
+              />
+            )}
           </div>
         )}
       </div>
@@ -1397,7 +1490,11 @@ export default function EasySetupWizard(props: {
       {!isOnline && (
         <Alert
           title="No Internet Connection"
-          message="You'll need an internet connection to proceed. Please connect to the internet and try again."
+          message={
+            locallyAvailableServices.length > 0
+              ? 'You can still install apps whose images are already on this machine — an offline install bundle puts them there. Downloads (maps, content, creator packs, AI models, Wikipedia) need a connection and stay unavailable until you have one.'
+              : "No app images are available locally, so there's nothing this wizard can install right now. Connect to the internet, or re-run the installer against an offline bundle built with --with-apps."
+          }
           type="warning"
           variant="solid"
           className="mb-8"
@@ -1477,7 +1574,9 @@ export default function EasySetupWizard(props: {
                 ) : (
                   <StyledButton
                     onClick={handleFinish}
-                    disabled={isProcessing || !isOnline || !anySelectionMade}
+                    disabled={
+                      isProcessing || !anySelectionMade || (!isOnline && !canFinishOffline)
+                    }
                     loading={isProcessing}
                     variant="success"
                     icon="IconCheck"

--- a/admin/tests/unit/offline_setup.spec.ts
+++ b/admin/tests/unit/offline_setup.spec.ts
@@ -1,0 +1,87 @@
+import * as assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  canCompleteSetupOffline,
+  describeOfflineBlockers,
+  isServiceInstallableOffline,
+  offlineBlockers,
+} from '../../inertia/lib/offline_setup.js'
+import type { WizardSelections } from '../../inertia/lib/offline_setup.js'
+
+const NOTHING_SELECTED: WizardSelections = {
+  services: [],
+  mapCollections: [],
+  creatorPacks: [],
+  categoryTierCount: 0,
+  aiModels: [],
+  wikipediaOptionId: null,
+}
+
+const selections = (overrides: Partial<WizardSelections>): WizardSelections => ({
+  ...NOTHING_SELECTED,
+  ...overrides,
+})
+
+test('an app whose image is loaded locally installs offline', () => {
+  assert.equal(isServiceInstallableOffline('kiwix', ['kiwix', 'kolibri']), true)
+  assert.equal(isServiceInstallableOffline('ollama', ['kiwix', 'kolibri']), false)
+})
+
+test('installing only locally-available apps is possible offline', () => {
+  const picks = selections({ services: ['kiwix', 'kolibri'] })
+  assert.deepEqual(offlineBlockers(picks, ['kiwix', 'kolibri', 'ollama']), [])
+  assert.equal(canCompleteSetupOffline(picks, ['kiwix', 'kolibri', 'ollama']), true)
+})
+
+test('an app with no local image blocks an offline finish', () => {
+  const picks = selections({ services: ['kiwix', 'ollama'] })
+  assert.deepEqual(offlineBlockers(picks, ['kiwix']), ['services'])
+  assert.equal(canCompleteSetupOffline(picks, ['kiwix']), false)
+})
+
+test('every remote-catalog selection blocks an offline finish', () => {
+  assert.deepEqual(offlineBlockers(selections({ mapCollections: ['north-america'] }), []), ['maps'])
+  assert.deepEqual(offlineBlockers(selections({ categoryTierCount: 1 }), []), ['content'])
+  assert.deepEqual(offlineBlockers(selections({ creatorPacks: ['pack-a'] }), []), ['creator-packs'])
+  assert.deepEqual(offlineBlockers(selections({ aiModels: ['llama3'] }), []), ['ai-models'])
+  assert.deepEqual(offlineBlockers(selections({ wikipediaOptionId: 'full' }), []), ['wikipedia'])
+})
+
+test("Wikipedia 'none' is a local deletion, not a download", () => {
+  assert.deepEqual(offlineBlockers(selections({ wikipediaOptionId: 'none' }), []), [])
+  assert.equal(canCompleteSetupOffline(selections({ wikipediaOptionId: 'none' }), []), true)
+})
+
+test('an empty wizard is trivially completable offline', () => {
+  assert.equal(canCompleteSetupOffline(NOTHING_SELECTED, []), true)
+})
+
+test('blockers are reported in a stable order', () => {
+  const picks = selections({
+    services: ['ollama'],
+    mapCollections: ['north-america'],
+    categoryTierCount: 2,
+    creatorPacks: ['pack-a'],
+    aiModels: ['llama3'],
+    wikipediaOptionId: 'full',
+  })
+  assert.deepEqual(offlineBlockers(picks, []), [
+    'services',
+    'maps',
+    'content',
+    'creator-packs',
+    'ai-models',
+    'wikipedia',
+  ])
+})
+
+test('blocker descriptions read as a sentence fragment', () => {
+  assert.equal(describeOfflineBlockers([]), '')
+  assert.equal(describeOfflineBlockers(['maps']), 'map regions')
+  assert.equal(describeOfflineBlockers(['maps', 'ai-models']), 'map regions and AI models')
+  assert.equal(
+    describeOfflineBlockers(['maps', 'content', 'ai-models']),
+    'map regions, content categories and AI models'
+  )
+})

--- a/admin/types/downloads.ts
+++ b/admin/types/downloads.ts
@@ -88,10 +88,6 @@ export type WikipediaOption = {
   url: string | null
 }
 
-export type WikipediaOptionsFile = {
-  options: WikipediaOption[]
-}
-
 export type WikipediaCurrentSelection = {
   optionId: string
   status: 'none' | 'downloading' | 'installed' | 'failed'

--- a/install/build_offline_bundle.sh
+++ b/install/build_offline_bundle.sh
@@ -1,0 +1,741 @@
+#!/bin/bash
+
+# Project NOMAD Offline Artifact Bundle Builder
+
+###################################################################################################################################################################################################
+
+# Script                | Project NOMAD Offline Artifact Bundle Builder
+# Version               | 1.0.0
+# Author                | Crosstalk Solutions, LLC
+# Website               | https://crosstalksolutions.com
+
+###################################################################################################################################################################################################
+#
+# Builds an offline artifact bundle from a Project NOMAD source checkout.
+#
+# This script runs on a CONNECTED build machine. The bundle it produces lets
+# install_nomad.sh --artifacts install Project NOMAD on a disconnected target of
+# the same OS, version and architecture. See admin/docs/offline-install.md.
+#
+###################################################################################################################################################################################################
+
+set -Eeuo pipefail
+
+###################################################################################################################################################################################################
+#                                                                                                                                                                                                 #
+#                                                                                           Color Codes                                                                                           #
+#                                                                                                                                                                                                 #
+###################################################################################################################################################################################################
+
+RESET='\033[0m'
+YELLOW='\033[1;33m'
+RED='\033[1;31m' # Light Red.
+GREEN='\033[1;32m' # Light Green.
+
+###################################################################################################################################################################################################
+#                                                                                                                                                                                                 #
+#                                                                                  Constants & Variables                                                                                          #
+#                                                                                                                                                                                                 #
+###################################################################################################################################################################################################
+
+# Bumped only when the on-disk bundle layout changes in a way install_nomad.sh
+# must be able to reject. Keep in sync with SUPPORTED_BUNDLE_FORMAT_VERSION.
+BUNDLE_FORMAT_VERSION='1'
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+TARGET_OS='ubuntu'
+TARGET_VERSION='26.04'
+TARGET_ARCH='amd64'
+OUTPUT_BASE="${PWD}/dist"
+WITH_NVIDIA='1'
+EXTRA_IMAGE_LIST=''
+EXTRA_IMAGE_ARCHIVE=''
+CONTENT_DIR=''
+WITH_APPS=''
+LIST_APPS='0'
+
+# Supply Depot apps whose images are worth carrying by default: broadly useful,
+# and modest in size compared with the AI/education stack.
+DEFAULT_APP_SET='kiwix,cyberchef,it_tools,flatnotes,excalidraw,filebrowser,stirling_pdf'
+CREATE_ARCHIVE='0'
+
+# Host packages installed on the target from the bundle. Must stay in step with
+# the package list in install_packages_from_artifacts (install_nomad.sh).
+ARTIFACT_PACKAGES=(
+  ca-certificates
+  curl
+  gnupg
+  jq
+  pciutils
+  docker-ce
+  docker-ce-cli
+  containerd.io
+  docker-buildx-plugin
+  docker-compose-plugin
+)
+
+###################################################################################################################################################################################################
+#                                                                                                                                                                                                 #
+#                                                                                           Functions                                                                                             #
+#                                                                                                                                                                                                 #
+###################################################################################################################################################################################################
+
+log() { echo -e "${YELLOW}#${RESET} $*"; }
+ok() { echo -e "${GREEN}#${RESET} $*"; }
+die() {
+  echo -e "${RED}#${RESET} $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Project NOMAD Offline Artifact Bundle Builder
+
+Usage:
+  ./build_offline_bundle.sh [options]
+
+Options:
+  --repo PATH                  Project NOMAD source checkout (default: the
+                               parent directory of this script)
+  --target OS:VERSION          Target operating system (default: ubuntu:26.04)
+  --arch ARCH                  Target architecture (default: amd64)
+  --output DIR                 Directory to create the bundle in (default: ./dist)
+  --with-apps LIST             Also bundle Supply Depot app images so apps can
+                               be installed on the offline target. LIST is a
+                               comma-separated set of app names, "default" for a
+                               useful starter set, or "all". Adds significant
+                               size — see --list-apps.
+  --list-apps                  Print the installable app names and exit
+  --without-nvidia-toolkit     Omit the NVIDIA Container Toolkit packages
+  --extra-image-list FILE      Also pull and bundle the image references in FILE
+  --extra-image-archive FILE   Copy an existing docker-save archive into the
+                               bundle as images/optional-images.tar
+  --content-dir DIR            Copy pre-staged NOMAD storage content into the bundle
+  --archive                    Also produce a .tar.gz of the finished bundle
+  -h, --help                   Show this help text and exit
+
+Requirements on the build machine:
+  internet access, docker with compose v2, git, sha256sum, gzip, tar
+
+The bundle is specific to one OS, version and architecture, and carries the
+install_nomad.sh from the source checkout it was built from.
+EOF
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo)
+        [[ $# -ge 2 ]] || die "--repo requires a path."
+        REPO_ROOT="$(cd -- "$2" 2>/dev/null && pwd)" || die "Source checkout not found: $2"
+        shift
+        ;;
+      --target)
+        [[ $# -ge 2 ]] || die "--target requires OS:VERSION."
+        [[ "$2" == *:* ]] || die "--target must be given as OS:VERSION (for example ubuntu:26.04)."
+        TARGET_OS="${2%%:*}"
+        TARGET_VERSION="${2#*:}"
+        shift
+        ;;
+      --arch)
+        [[ $# -ge 2 ]] || die "--arch requires a value."
+        TARGET_ARCH="$2"
+        shift
+        ;;
+      --output)
+        [[ $# -ge 2 ]] || die "--output requires a directory."
+        OUTPUT_BASE="$2"
+        shift
+        ;;
+      --with-apps)
+        [[ $# -ge 2 ]] || die "--with-apps requires a list, \"default\" or \"all\"."
+        WITH_APPS="$2"
+        shift
+        ;;
+      --list-apps)
+        LIST_APPS='1'
+        ;;
+      --without-nvidia-toolkit)
+        WITH_NVIDIA='0'
+        ;;
+      --extra-image-list)
+        [[ $# -ge 2 ]] || die "--extra-image-list requires a file."
+        EXTRA_IMAGE_LIST="$2"
+        shift
+        ;;
+      --extra-image-archive)
+        [[ $# -ge 2 ]] || die "--extra-image-archive requires a file."
+        EXTRA_IMAGE_ARCHIVE="$2"
+        shift
+        ;;
+      --content-dir)
+        [[ $# -ge 2 ]] || die "--content-dir requires a directory."
+        CONTENT_DIR="$2"
+        shift
+        ;;
+      --archive)
+        CREATE_ARCHIVE='1'
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        usage >&2
+        die "Unknown option: $1"
+        ;;
+    esac
+    shift
+  done
+}
+
+check_build_requirements() {
+  local cmd
+  for cmd in docker git sha256sum awk sed gzip tar; do
+    command -v "$cmd" > /dev/null 2>&1 ||
+      die "Required build command not found: ${cmd}. Run build_offline_bundle_docker.sh instead, which supplies a complete build environment and needs only Docker."
+  done
+
+  docker compose version > /dev/null 2>&1 ||
+    die "Docker Compose v2 is required on the build machine."
+
+  [[ -f "${REPO_ROOT}/install/install_nomad.sh" ]] ||
+    die "install/install_nomad.sh not found under ${REPO_ROOT}. Point --repo at a Project NOMAD checkout."
+  [[ -f "${REPO_ROOT}/install/management_compose.yaml" ]] ||
+    die "install/management_compose.yaml not found under ${REPO_ROOT}."
+
+  git -C "${REPO_ROOT}" rev-parse HEAD > /dev/null 2>&1 ||
+    die "${REPO_ROOT} is not a git checkout, so the bundle commit cannot be recorded."
+
+  # The upstream installer supports x86_64 only. Widening this belongs with the
+  # architecture support work, not here.
+  [[ "${TARGET_ARCH}" == 'amd64' ]] ||
+    die "This builder currently supports --arch amd64 only, matching the installer's supported architecture."
+}
+
+detect_target_os_release() {
+  # The manifest must record the values install_nomad.sh compares against
+  # /etc/os-release on the target, which are not always the image tag (for
+  # example debian:12 reports VERSION_ID=12, but a "bookworm" tag would not).
+  local os_release
+  os_release="$(docker run --rm --platform "linux/${TARGET_ARCH}" "${TARGET_OS}:${TARGET_VERSION}" cat /etc/os-release)" ||
+    die "Could not read /etc/os-release from ${TARGET_OS}:${TARGET_VERSION}."
+
+  local detected_id detected_version
+  detected_id="$(echo "${os_release}" | awk -F= '$1 == "ID" { gsub(/^"|"$/, "", $2); print $2; exit }')"
+  detected_version="$(echo "${os_release}" | awk -F= '$1 == "VERSION_ID" { gsub(/^"|"$/, "", $2); print $2; exit }')"
+
+  [[ -n "${detected_id}" && -n "${detected_version}" ]] ||
+    die "${TARGET_OS}:${TARGET_VERSION} does not report a usable ID/VERSION_ID."
+
+  if [[ "${detected_id}" != "${TARGET_OS}" ]]; then
+    die "Image ${TARGET_OS}:${TARGET_VERSION} reports ID=${detected_id}. Use --target ${detected_id}:${TARGET_VERSION}."
+  fi
+
+  if [[ "${detected_version}" != "${TARGET_VERSION}" ]]; then
+    log "Recording TARGET_VERSION=${detected_version} (reported by ${TARGET_OS}:${TARGET_VERSION})."
+    TARGET_VERSION="${detected_version}"
+  fi
+}
+
+copy_installer_and_payload() {
+  # The bundle carries the ordinary installer from this exact checkout, so the
+  # target runs the same code that was reviewed and built against.
+  cp "${REPO_ROOT}/install/install_nomad.sh" "${BUNDLE_DIR}/install_nomad.sh"
+  chmod 0755 "${BUNDLE_DIR}/install_nomad.sh"
+
+  local name
+  for name in management_compose.yaml start_nomad.sh stop_nomad.sh update_nomad.sh; do
+    [[ -f "${REPO_ROOT}/install/${name}" ]] || die "Expected ${REPO_ROOT}/install/${name} to exist."
+    cp "${REPO_ROOT}/install/${name}" "${BUNDLE_DIR}/payload/nomad/${name}"
+  done
+
+  # A disconnected host cannot fetch the uninstall script later, so ship it when
+  # the checkout has one.
+  if [[ -f "${REPO_ROOT}/install/uninstall_nomad.sh" ]]; then
+    cp "${REPO_ROOT}/install/uninstall_nomad.sh" "${BUNDLE_DIR}/payload/nomad/uninstall_nomad.sh"
+  fi
+
+  ok "Copied installer and payload from ${REPO_ROOT}."
+}
+
+target_packages() {
+  local packages=("${ARTIFACT_PACKAGES[@]}")
+  [[ "${WITH_NVIDIA}" != '1' ]] || packages+=(nvidia-container-toolkit)
+  echo "${packages[*]}"
+}
+
+fetch_third_party_apt_config() {
+  # Fetching the Docker and NVIDIA repository keys needs curl and gnupg, which
+  # would pollute the package set of whatever container installs them. So this
+  # runs in a throwaway container and hands the resulting files to the resolver,
+  # which must stay pristine.
+  local config_dir="$1"
+
+  # -i is required: the build steps are fed to the container over stdin.
+  docker run --rm -i \
+    --platform "linux/${TARGET_ARCH}" \
+    -e TARGET_OS="${TARGET_OS}" \
+    -e WITH_NVIDIA="${WITH_NVIDIA}" \
+    -v "${config_dir}:/aptcfg" \
+    "${TARGET_OS}:${TARGET_VERSION}" \
+    bash -s <<'CONTAINER_SCRIPT' || die "Failed to fetch third-party APT repository configuration."
+set -Eeuo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y --no-install-recommends ca-certificates curl gnupg
+
+. /etc/os-release
+
+# The resolver needs to reach HTTPS repositories without installing
+# ca-certificates (which would take openssl out of the dependency closure), so
+# hand it the trust store as a plain file.
+cp /etc/ssl/certs/ca-certificates.crt /aptcfg/ca-certificates.crt
+
+curl -fsSL "https://download.docker.com/linux/${TARGET_OS}/gpg" -o /aptcfg/docker.asc
+chmod a+r /aptcfg/docker.asc
+
+arch="$(dpkg --print-architecture)"
+echo "deb [arch=${arch} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${TARGET_OS} ${VERSION_CODENAME} stable" \
+  > /aptcfg/docker.list
+
+if [[ "${WITH_NVIDIA}" == '1' ]]; then
+  curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+    | gpg --dearmor -o /aptcfg/nvidia-container-toolkit-keyring.gpg
+
+  curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
+    | sed 's#deb https://#deb [signed-by=/etc/apt/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+    > /aptcfg/nvidia-container-toolkit.list
+fi
+CONTAINER_SCRIPT
+}
+
+build_local_apt_repo() {
+  local out_dir="${BUNDLE_DIR}/packages/apt"
+  local config_dir
+  config_dir="$(mktemp -d)" || die "Could not create a temporary directory."
+
+  log "Building local APT repository for ${TARGET_OS} ${TARGET_VERSION} (${TARGET_ARCH})..."
+
+  fetch_third_party_apt_config "${config_dir}"
+
+  # Resolve the closure in a PRISTINE container of the target distribution.
+  # APT only downloads packages that are not already installed, so anything
+  # installed here first would silently drop out of the bundle and fail on the
+  # target. A base image is a subset of any real install of the same release,
+  # so its closure is a superset of what the target needs.
+  docker run --rm -i \
+    --platform "linux/${TARGET_ARCH}" \
+    -e PACKAGES="$(target_packages)" \
+    -v "${config_dir}:/aptcfg:ro" \
+    -v "${out_dir}:/out" \
+    "${TARGET_OS}:${TARGET_VERSION}" \
+    bash -s <<'CONTAINER_SCRIPT' || die "Failed to resolve the host package closure."
+set -Eeuo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+# File copies only — installing packages at this point would corrupt the closure.
+install -m 0755 -d /etc/apt/keyrings
+install -m 0644 /aptcfg/docker.asc /etc/apt/keyrings/docker.asc
+install -m 0644 /aptcfg/docker.list /etc/apt/sources.list.d/docker.list
+if [[ -f /aptcfg/nvidia-container-toolkit-keyring.gpg ]]; then
+  install -m 0644 /aptcfg/nvidia-container-toolkit-keyring.gpg /etc/apt/keyrings/nvidia-container-toolkit-keyring.gpg
+  install -m 0644 /aptcfg/nvidia-container-toolkit.list /etc/apt/sources.list.d/nvidia-container-toolkit.list
+fi
+
+# The Docker and NVIDIA repositories are HTTPS. Point APT at the trust store
+# supplied by the fetcher rather than installing ca-certificates, which would
+# take openssl out of the dependency closure.
+apt_opts=(-o "Acquire::https::CaInfo=/aptcfg/ca-certificates.crt")
+
+apt-get "${apt_opts[@]}" update
+
+read -ra packages <<< "${PACKAGES}"
+apt-get "${apt_opts[@]}" install -y --download-only --reinstall "${packages[@]}"
+
+cp /var/cache/apt/archives/*.deb /out/
+
+# Only now, with the closure already copied out, is it safe to install the
+# tooling that generates the package index.
+apt-get "${apt_opts[@]}" install -y --no-install-recommends dpkg-dev
+cd /out
+dpkg-scanpackages . /dev/null > Packages
+gzip -9c Packages > Packages.gz
+CONTAINER_SCRIPT
+
+  rm -rf "${config_dir}"
+
+  [[ -s "${out_dir}/Packages" && -s "${out_dir}/Packages.gz" ]] ||
+    die "Local APT repository generation failed — no package index was produced."
+
+  local deb_count
+  deb_count="$(find "${out_dir}" -maxdepth 1 -name '*.deb' ! -name '._*' | wc -l | tr -d ' ')"
+  [[ "${deb_count}" -gt 0 ]] || die "Local APT repository contains no .deb packages."
+
+  ok "Local APT repository created (${deb_count} packages)."
+}
+
+verify_local_apt_repo() {
+  local out_dir="${BUNDLE_DIR}/packages/apt"
+
+  log "Verifying the local APT repository resolves with no network..."
+
+  # Dry-run the exact isolated installation the target performs, in a clean
+  # container of the target distribution with no network at all. An incomplete
+  # closure fails here, on the build machine, instead of in the field.
+  docker run --rm -i \
+    --platform "linux/${TARGET_ARCH}" \
+    --network none \
+    -e PACKAGES="$(target_packages)" \
+    -v "${out_dir}:/repo:ro" \
+    "${TARGET_OS}:${TARGET_VERSION}" \
+    bash -s <<'CONTAINER_SCRIPT' || die "The bundled APT repository cannot satisfy its own package list offline. The bundle would fail on the target."
+set -Eeuo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+mkdir -p /tmp/apt/lists/partial
+echo 'deb [trusted=yes] file:/repo ./' > /tmp/apt/sources.list
+
+apt_opts=(
+  -o Dir::Etc::sourcelist=/tmp/apt/sources.list
+  -o Dir::Etc::sourceparts=-
+  -o Dir::State::Lists=/tmp/apt/lists
+  -o APT::Get::List-Cleanup=0
+  -o Acquire::Languages=none
+  -o Acquire::Retries=0
+)
+
+apt-get "${apt_opts[@]}" update
+read -ra packages <<< "${PACKAGES}"
+apt-get "${apt_opts[@]}" install -y --no-install-recommends --simulate "${packages[@]}"
+CONTAINER_SCRIPT
+
+  ok "Local APT repository resolves offline."
+}
+
+discover_and_save_images() {
+  local compose_file="${REPO_ROOT}/install/management_compose.yaml"
+  local image_list="${BUNDLE_DIR}/images/core-images.txt"
+
+  log "Discovering management images from management_compose.yaml..."
+  docker compose -f "${compose_file}" config --images | sort -u > "${image_list}" ||
+    die "Could not read service images from ${compose_file}."
+
+  if [[ -n "${EXTRA_IMAGE_LIST}" ]]; then
+    [[ -f "${EXTRA_IMAGE_LIST}" ]] || die "Extra image list not found: ${EXTRA_IMAGE_LIST}"
+    grep -Ev '^[[:space:]]*(#|$)' "${EXTRA_IMAGE_LIST}" >> "${image_list}" || true
+    sort -u -o "${image_list}" "${image_list}"
+  fi
+
+  # Read with a loop rather than mapfile so the builder also runs under the
+  # bash 3.2 that ships with macOS.
+  local images=()
+  local image
+  while IFS= read -r image; do
+    [[ -n "${image}" ]] || continue
+    images+=("${image}")
+  done < "${image_list}"
+  [[ ${#images[@]} -gt 0 ]] || die "No images were discovered from ${compose_file}."
+
+  for image in "${images[@]}"; do
+    log "Pulling ${image}..."
+    docker pull --platform "linux/${TARGET_ARCH}" "${image}" ||
+      die "Failed to pull ${image}. The build machine needs internet access and registry availability."
+  done
+
+  log "Saving ${#images[@]} image(s) to images/core-images.tar..."
+  docker save -o "${BUNDLE_DIR}/images/core-images.tar" "${images[@]}" ||
+    die "docker save failed."
+
+  {
+    printf 'IMAGE\tID\tREPO_DIGESTS\n'
+    for image in "${images[@]}"; do
+      printf '%s\t%s\t%s\n' \
+        "${image}" \
+        "$(docker image inspect --format '{{.Id}}' "${image}")" \
+        "$(docker image inspect --format '{{join .RepoDigests ","}}' "${image}")"
+    done
+  } > "${BUNDLE_DIR}/images/core-image-metadata.tsv"
+
+  ok "Saved ${#images[@]} management image(s)."
+}
+
+app_seeder_path() {
+  echo "${REPO_ROOT}/admin/database/seeders/service_seeder.ts"
+}
+
+# Supply Depot apps are seeded into the Command Center's database from a file
+# baked into the admin image — the catalog is local, not fetched — so reading the
+# same file here keeps bundled images in step with what the UI will offer.
+discover_app_images() {
+  local seeder
+  seeder="$(app_seeder_path)"
+  [[ -f "${seeder}" ]] || die "Could not find the app seeder at ${seeder}."
+
+  awk '
+    /service_name: SERVICE_NAMES\./ {
+      name = $0
+      sub(/.*SERVICE_NAMES\./, "", name)
+      sub(/,.*/, "", name)
+    }
+    /container_image: '"'"'/ {
+      image = $0
+      sub(/.*container_image: '"'"'/, "", image)
+      sub(/'"'"'.*/, "", image)
+      if (name != "") {
+        print tolower(name) "\t" image
+        name = ""
+      }
+    }
+  ' "${seeder}"
+}
+
+list_apps() {
+  echo 'Supply Depot apps available to bundle with --with-apps:'
+  echo ''
+  local name image
+  while IFS="$(printf '\t')" read -r name image; do
+    [[ -n "${name}" ]] || continue
+    printf '  %-16s %s\n' "${name}" "${image}"
+  done < <(discover_app_images)
+  echo ''
+  echo "Default set (--with-apps default): ${DEFAULT_APP_SET}"
+  echo 'Use "all" for every app, or a comma-separated list of names.'
+}
+
+# Resolves WITH_APPS into the image references to bundle.
+selected_app_images() {
+  local requested="${WITH_APPS}"
+  [[ "${requested}" != 'default' ]] || requested="${DEFAULT_APP_SET}"
+
+  local name image
+  if [[ "${requested}" == 'all' ]]; then
+    while IFS="$(printf '\t')" read -r name image; do
+      [[ -n "${image}" ]] || continue
+      echo "${image}"
+    done < <(discover_app_images)
+    return 0
+  fi
+
+  # Validate every requested name so a typo fails the build rather than silently
+  # producing a bundle without the app the user asked for.
+  local available
+  available="$(discover_app_images)"
+  local wanted
+  IFS=',' read -ra wanted <<< "${requested}"
+  local entry match
+  for entry in "${wanted[@]}"; do
+    entry="$(echo "${entry}" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+    [[ -n "${entry}" ]] || continue
+    match="$(echo "${available}" | awk -F'\t' -v want="${entry}" '$1 == want { print $2; exit }')"
+    [[ -n "${match}" ]] ||
+      die "Unknown app '${entry}'. Run --list-apps to see the available names."
+    echo "${match}"
+  done
+}
+
+bundle_app_images() {
+  [[ -n "${WITH_APPS}" ]] || return 0
+
+  local images=()
+  local image
+  while IFS= read -r image; do
+    [[ -n "${image}" ]] || continue
+    images+=("${image}")
+  done < <(selected_app_images | sort -u)
+
+  [[ ${#images[@]} -gt 0 ]] || die "--with-apps selected no images."
+
+  log "Bundling ${#images[@]} Supply Depot app image(s)..."
+  for image in "${images[@]}"; do
+    log "Pulling ${image}"
+    docker pull --platform "linux/${TARGET_ARCH}" "${image}" ||
+      die "Failed to pull ${image}."
+  done
+
+  printf '%s\n' "${images[@]}" > "${BUNDLE_DIR}/images/app-images.txt"
+  docker save -o "${BUNDLE_DIR}/images/app-images.tar" "${images[@]}" ||
+    die "Failed to save app images."
+
+  ok "Saved ${#images[@]} app image(s)."
+
+  # Kiwix refuses to install without at least one ZIM present, and its
+  # pre-install step fetches one from GitHub. Carry the small Wikipedia sample
+  # from this checkout so the file is already in storage on the target.
+  if printf '%s\n' "${images[@]}" | grep -q 'kiwix'; then
+    local zim
+    zim="$(find "${REPO_ROOT}/install" -maxdepth 1 -name 'wikipedia_en_*.zim' ! -name '._*' | sort | tail -1)"
+    if [[ -n "${zim}" ]]; then
+      mkdir -p "${BUNDLE_DIR}/content/zim"
+      cp "${zim}" "${BUNDLE_DIR}/content/zim/$(basename "${zim}")"
+      ok "Included $(basename "${zim}") for Kiwix."
+    else
+      log "Warning: no wikipedia_en_*.zim found in the checkout; Kiwix will have no starter content."
+    fi
+  fi
+}
+
+write_pull_never_override() {
+  # Kept separate from service discovery so it can be unit tested without Docker.
+  local override_path="$1"
+  shift
+  local services=("$@")
+
+  [[ ${#services[@]} -gt 0 ]] || die "Refusing to write a Compose override with no services."
+
+  {
+    echo "# Generated by install/build_offline_bundle.sh — do not edit."
+    echo "#"
+    echo "# Layered over compose.yml during artifact-mode installs so that every service"
+    echo "# uses the images loaded from the bundle instead of contacting a registry."
+    echo "services:"
+    local service
+    for service in "${services[@]}"; do
+      echo "  ${service}:"
+      echo "    pull_policy: never"
+    done
+  } > "${override_path}"
+}
+
+generate_pull_never_override() {
+  local compose_file="${REPO_ROOT}/install/management_compose.yaml"
+  local services=()
+  local service
+  while IFS= read -r service; do
+    [[ -n "${service}" ]] || continue
+    services+=("${service}")
+  done < <(docker compose -f "${compose_file}" config --services | sort)
+  [[ ${#services[@]} -gt 0 ]] || die "No Compose services were discovered from ${compose_file}."
+
+  write_pull_never_override "${BUNDLE_DIR}/payload/nomad/compose.artifact.yml" "${services[@]}"
+  ok "Generated pull_policy: never override for ${#services[@]} service(s)."
+}
+
+add_optional_content() {
+  if [[ -n "${EXTRA_IMAGE_ARCHIVE}" ]]; then
+    [[ -f "${EXTRA_IMAGE_ARCHIVE}" ]] || die "Extra image archive not found: ${EXTRA_IMAGE_ARCHIVE}"
+    log "Adding optional image archive..."
+    cp "${EXTRA_IMAGE_ARCHIVE}" "${BUNDLE_DIR}/images/optional-images.tar"
+  fi
+
+  if [[ -n "${CONTENT_DIR}" ]]; then
+    [[ -d "${CONTENT_DIR}" ]] || die "Content directory not found: ${CONTENT_DIR}"
+    log "Copying pre-staged NOMAD storage content..."
+    mkdir -p "${BUNDLE_DIR}/content"
+    cp -a "${CONTENT_DIR}/." "${BUNDLE_DIR}/content/"
+  fi
+}
+
+write_manifest() {
+  # Plain data, read key by key on the target. Never sourced as shell.
+  cat > "${BUNDLE_DIR}/manifest" <<EOF
+BUNDLE_FORMAT_VERSION=${BUNDLE_FORMAT_VERSION}
+NOMAD_COMMIT=${NOMAD_COMMIT}
+TARGET_OS=${TARGET_OS}
+TARGET_VERSION=${TARGET_VERSION}
+TARGET_ARCH=${TARGET_ARCH}
+WITH_NVIDIA_TOOLKIT=${WITH_NVIDIA}
+CREATED_AT_UTC=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+
+  cat > "${BUNDLE_DIR}/README.txt" <<EOF
+Project NOMAD Offline Artifact Bundle
+=====================================
+
+NOMAD commit : ${NOMAD_COMMIT}
+Target       : ${TARGET_OS} ${TARGET_VERSION} (${TARGET_ARCH})
+
+Install on a matching, disconnected target:
+
+  sudo bash ./install_nomad.sh --artifacts .
+
+Artifact mode never falls back to the network. If a required package, image or
+payload file is missing from this bundle, the installation stops with an error.
+
+The SHA256SUMS file verifies that this bundle transferred intact. It is not a
+publisher signature.
+EOF
+}
+
+write_checksums() {
+  # Bundles are routinely built straight onto FAT/exFAT removable media, where
+  # macOS deposits AppleDouble sidecars ("._name") and .DS_Store alongside real
+  # files. They are OS metadata, not bundle content: they appear and vanish
+  # outside our control, so checksumming them produces a bundle that fails its
+  # own verification. Remove them, and never list them.
+  find "${BUNDLE_DIR}" -type f \( -name '._*' -o -name '.DS_Store' \) -delete 2>/dev/null || true
+
+  log "Generating SHA-256 checksums..."
+  (
+    cd "${BUNDLE_DIR}"
+    find . -type f ! -name SHA256SUMS ! -name '._*' ! -name '.DS_Store' -print0 \
+      | sort -z | xargs -0 sha256sum > SHA256SUMS
+  )
+  (
+    cd "${BUNDLE_DIR}"
+    sha256sum -c SHA256SUMS > /dev/null
+  ) || die "Checksum verification of the finished bundle failed."
+  ok "Checksums written and verified."
+}
+
+main() {
+  parse_args "$@"
+
+  if [[ "${LIST_APPS}" == '1' ]]; then
+    list_apps
+    exit 0
+  fi
+
+  check_build_requirements
+  detect_target_os_release
+
+  NOMAD_COMMIT="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+  BUNDLE_NAME="project-nomad-offline-${TARGET_OS}-${TARGET_VERSION}-${TARGET_ARCH}-${NOMAD_COMMIT:0:12}"
+  BUNDLE_DIR="${OUTPUT_BASE%/}/${BUNDLE_NAME}"
+
+  if ! git -C "${REPO_ROOT}" diff --quiet HEAD 2>/dev/null; then
+    log "Warning: ${REPO_ROOT} has uncommitted changes. The manifest records ${NOMAD_COMMIT:0:12} regardless."
+  fi
+
+  log "Building ${BUNDLE_NAME}"
+  rm -rf "${BUNDLE_DIR}"
+  mkdir -p "${BUNDLE_DIR}/packages/apt" "${BUNDLE_DIR}/images" "${BUNDLE_DIR}/payload/nomad"
+
+  copy_installer_and_payload
+  build_local_apt_repo
+  verify_local_apt_repo
+  discover_and_save_images
+  bundle_app_images
+  generate_pull_never_override
+  add_optional_content
+  write_manifest
+  write_checksums
+
+  if [[ "${CREATE_ARCHIVE}" == '1' ]]; then
+    log "Creating ${BUNDLE_DIR}.tar.gz..."
+    tar -C "${OUTPUT_BASE%/}" -czf "${BUNDLE_DIR}.tar.gz" "${BUNDLE_NAME}"
+    ok "Created ${BUNDLE_DIR}.tar.gz"
+  fi
+
+  echo ''
+  ok "Bundle ready: ${BUNDLE_DIR}"
+  echo ''
+  echo -e "${GREEN}#${RESET} Copy it to the target and run:"
+  echo -e "${GREEN}#${RESET}   sudo bash ./install_nomad.sh --artifacts ."
+}
+
+###################################################################################################################################################################################################
+#                                                                                                                                                                                                 #
+#                                                                                           Main Script                                                                                           #
+#                                                                                                                                                                                                 #
+###################################################################################################################################################################################################
+
+# The test suite sources this script to exercise individual functions. Every
+# other invocation builds a bundle normally.
+if [[ "${NOMAD_BUNDLE_LIB_ONLY:-}" == '1' ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+main "$@"

--- a/install/build_offline_bundle.sh
+++ b/install/build_offline_bundle.sh
@@ -54,6 +54,7 @@ EXTRA_IMAGE_ARCHIVE=''
 CONTENT_DIR=''
 WITH_APPS=''
 LIST_APPS='0'
+USE_LOCAL_IMAGES='0'
 
 # Supply Depot apps whose images are worth carrying by default: broadly useful,
 # and modest in size compared with the AI/education stack.
@@ -107,6 +108,12 @@ Options:
                                useful starter set, or "all". Adds significant
                                size — see --list-apps.
   --list-apps                  Print the installable app names and exit
+  --use-local-images           Skip the registry pull for any image already
+                               present in the local Docker daemon. Lets a bundle
+                               carry an image built from this checkout (e.g. an
+                               unreleased Command Center) instead of the
+                               published tag. Images that are NOT local are
+                               still pulled as usual.
   --without-nvidia-toolkit     Omit the NVIDIA Container Toolkit packages
   --extra-image-list FILE      Also pull and bundle the image references in FILE
   --extra-image-archive FILE   Copy an existing docker-save archive into the
@@ -173,6 +180,9 @@ parse_args() {
         [[ $# -ge 2 ]] || die "--content-dir requires a directory."
         CONTENT_DIR="$2"
         shift
+        ;;
+      --use-local-images)
+        USE_LOCAL_IMAGES='1'
         ;;
       --archive)
         CREATE_ARCHIVE='1'
@@ -415,6 +425,31 @@ CONTAINER_SCRIPT
   ok "Local APT repository resolves offline."
 }
 
+# Make an image available locally so `docker save` can write it into the bundle.
+#
+# Normally that means pulling the published tag. With --use-local-images, an
+# image already in the daemon is taken as-is: the point is to bundle a Command
+# Center built from this checkout rather than the released
+# ghcr.io/crosstalk-solutions/project-nomad:latest that management_compose.yaml
+# pins, so unreleased changes can be tested on an air-gapped target. Images that
+# are not present locally are still pulled, so the flag never silently produces
+# a bundle with something missing.
+#
+# Deliberately narrow: it does not verify the local image resembles the tag it
+# claims. A bundle built this way carries whatever you built, which is the whole
+# point — and the reason it is opt-in rather than the default.
+acquire_image() {
+  local image="$1"
+
+  if [[ "${USE_LOCAL_IMAGES}" == '1' ]] && docker image inspect "${image}" >/dev/null 2>&1; then
+    log "Using local ${image} (not pulling)."
+    return 0
+  fi
+
+  log "Pulling ${image}..."
+  docker pull --platform "linux/${TARGET_ARCH}" "${image}"
+}
+
 discover_and_save_images() {
   local compose_file="${REPO_ROOT}/install/management_compose.yaml"
   local image_list="${BUNDLE_DIR}/images/core-images.txt"
@@ -440,8 +475,7 @@ discover_and_save_images() {
   [[ ${#images[@]} -gt 0 ]] || die "No images were discovered from ${compose_file}."
 
   for image in "${images[@]}"; do
-    log "Pulling ${image}..."
-    docker pull --platform "linux/${TARGET_ARCH}" "${image}" ||
+    acquire_image "${image}" ||
       die "Failed to pull ${image}. The build machine needs internet access and registry availability."
   done
 
@@ -550,9 +584,7 @@ bundle_app_images() {
 
   log "Bundling ${#images[@]} Supply Depot app image(s)..."
   for image in "${images[@]}"; do
-    log "Pulling ${image}"
-    docker pull --platform "linux/${TARGET_ARCH}" "${image}" ||
-      die "Failed to pull ${image}."
+    acquire_image "${image}" || die "Failed to pull ${image}."
   done
 
   printf '%s\n' "${images[@]}" > "${BUNDLE_DIR}/images/app-images.txt"
@@ -637,6 +669,7 @@ TARGET_OS=${TARGET_OS}
 TARGET_VERSION=${TARGET_VERSION}
 TARGET_ARCH=${TARGET_ARCH}
 WITH_NVIDIA_TOOLKIT=${WITH_NVIDIA}
+USED_LOCAL_IMAGES=${USE_LOCAL_IMAGES}
 CREATED_AT_UTC=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 EOF
 
@@ -646,7 +679,11 @@ Project NOMAD Offline Artifact Bundle
 
 NOMAD commit : ${NOMAD_COMMIT}
 Target       : ${TARGET_OS} ${TARGET_VERSION} (${TARGET_ARCH})
-
+$(if [[ "${USE_LOCAL_IMAGES}" == '1' ]]; then
+  printf '\nNOTE: Built with --use-local-images. One or more images came from the\n'
+  printf 'build machine rather than a registry, so this bundle may carry\n'
+  printf 'unreleased code. Not for distribution.\n'
+fi)
 Install on a matching, disconnected target:
 
   sudo bash ./install_nomad.sh --artifacts .

--- a/install/build_offline_bundle.sh
+++ b/install/build_offline_bundle.sh
@@ -478,6 +478,34 @@ acquire_image() {
 # tree it was built from — which makes an admin-side change impossible to test on
 # an air-gapped target. The image reference is read from the compose file rather
 # than hardcoded so a fork's own tag is honoured.
+# docker save straight into the bundle, then copy the finished archive in.
+#
+# The bundle directory is a bind mount of the host, and on Docker Desktop that is
+# virtiofs. Writing a multi-GB archive through it fails with "cannot allocate
+# memory" — the daemon buffers far more than the mount can absorb. Saving to the
+# VM's own disk first keeps that write local, and the copy afterwards streams in
+# ordinary chunks the mount handles fine. Matters most with --build-admin, where
+# a locally built Command Center is several times the size of the published one.
+save_images_archive() {
+  local dest="$1"
+  shift
+
+  local tmp
+  tmp="$(mktemp -d)" || die "Could not create a temporary directory for docker save."
+
+  if ! docker save -o "${tmp}/images.tar" "$@"; then
+    rm -rf "${tmp}"
+    die "docker save failed."
+  fi
+
+  if ! cp "${tmp}/images.tar" "${dest}"; then
+    rm -rf "${tmp}"
+    die "Could not copy the image archive into the bundle at ${dest}."
+  fi
+
+  rm -rf "${tmp}"
+}
+
 build_admin_image() {
   [[ "${BUILD_ADMIN}" == '1' ]] || return 0
 
@@ -525,8 +553,7 @@ discover_and_save_images() {
   done
 
   log "Saving ${#images[@]} image(s) to images/core-images.tar..."
-  docker save -o "${BUNDLE_DIR}/images/core-images.tar" "${images[@]}" ||
-    die "docker save failed."
+  save_images_archive "${BUNDLE_DIR}/images/core-images.tar" "${images[@]}"
 
   {
     printf 'IMAGE\tID\tREPO_DIGESTS\n'
@@ -655,8 +682,7 @@ bundle_app_images() {
   done
 
   printf '%s\n' "${images[@]}" > "${BUNDLE_DIR}/images/app-images.txt"
-  docker save -o "${BUNDLE_DIR}/images/app-images.tar" "${images[@]}" ||
-    die "Failed to save app images."
+  save_images_archive "${BUNDLE_DIR}/images/app-images.tar" "${images[@]}"
 
   ok "Saved ${#images[@]} app image(s)."
 

--- a/install/build_offline_bundle.sh
+++ b/install/build_offline_bundle.sh
@@ -55,6 +55,16 @@ CONTENT_DIR=''
 WITH_APPS=''
 LIST_APPS='0'
 USE_LOCAL_IMAGES='0'
+BUILD_ADMIN='0'
+
+# The apps behind Easy Setup's three core capabilities — Information Library
+# (Kiwix), Education Platform (Kolibri) and the AI Assistant (Ollama, with Qdrant
+# for its knowledge base). Without these an air-gapped target can offer none of
+# them: the wizard only lets you select a capability whose image is already
+# present, so a bundle missing them greys out the very choices onboarding is
+# built around. Large — Ollama and Kolibri are multi-GB — which is why this is a
+# named set rather than part of the light default.
+CORE_APP_SET='kiwix,kolibri_gen2,ollama,qdrant'
 
 # Supply Depot apps whose images are worth carrying by default: broadly useful,
 # and modest in size compared with the AI/education stack.
@@ -104,10 +114,16 @@ Options:
   --output DIR                 Directory to create the bundle in (default: ./dist)
   --with-apps LIST             Also bundle Supply Depot app images so apps can
                                be installed on the offline target. LIST is a
-                               comma-separated set of app names, "default" for a
-                               useful starter set, or "all". Adds significant
-                               size — see --list-apps.
+                               comma-separated set of app names and/or the named
+                               sets "core" (the three Easy Setup capabilities),
+                               "default" (a light starter set) or "all". Sets
+                               combine: --with-apps core,default. Adds
+                               significant size — see --list-apps.
   --list-apps                  Print the installable app names and exit
+  --build-admin                Build the Command Center image from this checkout
+                               and bundle that instead of the published one, so
+                               the bundle carries the code you have rather than
+                               the last release. Implies --use-local-images.
   --use-local-images           Skip the registry pull for any image already
                                present in the local Docker daemon. Lets a bundle
                                carry an image built from this checkout (e.g. an
@@ -182,6 +198,10 @@ parse_args() {
         shift
         ;;
       --use-local-images)
+        USE_LOCAL_IMAGES='1'
+        ;;
+      --build-admin)
+        BUILD_ADMIN='1'
         USE_LOCAL_IMAGES='1'
         ;;
       --archive)
@@ -450,6 +470,31 @@ acquire_image() {
   docker pull --platform "linux/${TARGET_ARCH}" "${image}"
 }
 
+# Build the Command Center from this checkout, tagged as the reference
+# management_compose.yaml pins, so the rest of the build bundles it in place of
+# the published image.
+#
+# Without this a bundle always carries the last RELEASE, no matter what is in the
+# tree it was built from — which makes an admin-side change impossible to test on
+# an air-gapped target. The image reference is read from the compose file rather
+# than hardcoded so a fork's own tag is honoured.
+build_admin_image() {
+  [[ "${BUILD_ADMIN}" == '1' ]] || return 0
+
+  local compose_file="${REPO_ROOT}/install/management_compose.yaml"
+  local admin_image
+  admin_image="$(docker compose -f "${compose_file}" config --images |
+    grep -m1 'project-nomad:' || true)"
+  [[ -n "${admin_image}" ]] ||
+    die "Could not determine the Command Center image reference from ${compose_file}."
+
+  log "Building ${admin_image} from ${REPO_ROOT} (this takes a few minutes)..."
+  docker build --platform "linux/${TARGET_ARCH}" -t "${admin_image}" "${REPO_ROOT}" ||
+    die "Failed to build the Command Center image from ${REPO_ROOT}."
+
+  ok "Built ${admin_image} from this checkout."
+}
+
 discover_and_save_images() {
   local compose_file="${REPO_ROOT}/install/management_compose.yaml"
   local image_list="${BUNDLE_DIR}/images/core-images.txt"
@@ -535,17 +580,39 @@ list_apps() {
     printf '  %-16s %s\n' "${name}" "${image}"
   done < <(discover_app_images)
   echo ''
-  echo "Default set (--with-apps default): ${DEFAULT_APP_SET}"
-  echo 'Use "all" for every app, or a comma-separated list of names.'
+  echo "Named sets:"
+  echo "  core     ${CORE_APP_SET}"
+  echo "           (Easy Setup's three core capabilities — needed for the target"
+  echo "            to offer them offline)"
+  echo "  default  ${DEFAULT_APP_SET}"
+  echo "  all      every app listed above"
+  echo
+  echo 'Sets combine with each other and with individual names:'
+  echo '  --with-apps core,default'
 }
 
 # Resolves WITH_APPS into the image references to bundle.
 selected_app_images() {
   local requested="${WITH_APPS}"
-  [[ "${requested}" != 'default' ]] || requested="${DEFAULT_APP_SET}"
+
+  # Expand the named sets anywhere in the list, so "core,default" and
+  # "core,jellyfin" work rather than only a bare set name. Duplicates are
+  # harmless — the caller sorts -u before pulling.
+  local expanded='' part
+  IFS=',' read -ra parts <<< "${requested}"
+  for part in "${parts[@]}"; do
+    part="$(echo "${part}" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+    case "${part}" in
+      '')        continue ;;
+      core)      expanded="${expanded},${CORE_APP_SET}" ;;
+      default)   expanded="${expanded},${DEFAULT_APP_SET}" ;;
+      *)         expanded="${expanded},${part}" ;;
+    esac
+  done
+  requested="${expanded#,}"
 
   local name image
-  if [[ "${requested}" == 'all' ]]; then
+  if [[ ",${requested}," == *,all,* ]]; then
     while IFS="$(printf '\t')" read -r name image; do
       [[ -n "${image}" ]] || continue
       echo "${image}"
@@ -741,6 +808,7 @@ main() {
   mkdir -p "${BUNDLE_DIR}/packages/apt" "${BUNDLE_DIR}/images" "${BUNDLE_DIR}/payload/nomad"
 
   copy_installer_and_payload
+  build_admin_image
   build_local_apt_repo
   verify_local_apt_repo
   discover_and_save_images

--- a/install/build_offline_bundle_docker.sh
+++ b/install/build_offline_bundle_docker.sh
@@ -37,6 +37,11 @@ GREEN='\033[1;32m'
 # Alpine image carrying the Docker CLI and Compose v2. Override for a mirror.
 BUILDER_IMAGE="${NOMAD_BUILDER_IMAGE:-docker:cli}"
 DOCKER_SOCKET="${NOMAD_DOCKER_SOCKET:-/var/run/docker.sock}"
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+  MINGW*|MSYS*|CYGWIN*) HOST_IS_WINDOWS='1' ;;
+  *)                    HOST_IS_WINDOWS='0' ;;
+esac
 NO_PROMPT="${NOMAD_NO_PROMPT:-0}"
 
 # A finished bundle is roughly 1 GB; the build needs headroom on top of that.
@@ -91,28 +96,72 @@ check_docker_available() {
   docker info > /dev/null 2>&1 ||
     die "The Docker daemon is not reachable. Start Docker and try again."
 
-  # The build starts further containers, and their bind mounts are resolved by
-  # the host daemon — so the socket has to be mountable, not merely reachable.
-  #
-  # Under Git Bash / MSYS / Cygwin there is no Unix socket to mount: Docker
-  # Desktop is reached over a named pipe, and MSYS rewrites the Unix-looking
-  # paths in every -v argument on the way to the CLI. Relaxing this check alone
-  # does not make the build work there; it just moves the failure somewhere less
-  # obvious. Say so plainly instead.
-  case "$(uname -s 2>/dev/null || echo unknown)" in
-    MINGW*|MSYS*|CYGWIN*)
-      die "This wrapper cannot run under Git Bash / MSYS: Docker Desktop exposes a
-   named pipe rather than a mountable Unix socket, and MSYS rewrites the bind-mount
-   paths the build depends on.
+  # Docker Desktop on Windows has no Unix socket to stat — it is reached over a
+  # named pipe, and the daemon resolves the literal string /var/run/docker.sock
+  # against its own Linux VM, where the socket does exist. So the filesystem test
+  # only means something where a socket file is what gets mounted.
+  if [[ "${HOST_IS_WINDOWS}" != '1' ]]; then
+    [[ -S "${DOCKER_SOCKET}" ]] ||
+      die "No Docker socket at ${DOCKER_SOCKET}. Set NOMAD_DOCKER_SOCKET if yours lives elsewhere."
+  fi
+}
 
-   Build from a WSL2 Linux distribution with Docker Desktop's WSL integration
-   enabled (where /var/run/docker.sock exists), or from a Linux or macOS machine.
-   The bundle produced is identical wherever it is built."
-      ;;
-  esac
+# Whether the daemon can actually see a host directory through a bind mount.
+#
+# Not a formality. Docker Desktop silently yields an EMPTY directory for a path
+# it does not share — removable and exFAT volumes among them — so a build whose
+# source or output lives there produces a hollow bundle that still passes its own
+# verification, because every check reads the same phantom directory. Detect it
+# up front by planting a marker and looking for it from inside a container.
+docker_can_mount() {
+  local dir="$1" marker=".nomad-mount-probe.$$" found=''
 
-  [[ -S "${DOCKER_SOCKET}" ]] ||
-    die "No Docker socket at ${DOCKER_SOCKET}. Set NOMAD_DOCKER_SOCKET if yours lives elsewhere."
+  : > "${dir}/${marker}" 2>/dev/null || return 1
+  found="$(MSYS_NO_PATHCONV=1 docker run --rm \
+    -v "$(host_mount_source "${dir}"):/probe:ro" \
+    "${BUILDER_IMAGE}" \
+    sh -c "[ -f '/probe/${marker}' ] && echo yes" 2>/dev/null || true)"
+  rm -f "${dir}/${marker}"
+
+  [[ "${found}" == 'yes' ]]
+}
+
+# The string the DAEMON needs in order to resolve a host directory. Under MSYS,
+# a POSIX path like /d/foo means nothing to Docker Desktop, so hand it the
+# Windows form; everywhere else the path is already what the daemon expects.
+host_mount_source() {
+  local dir="$1"
+  if [[ "${HOST_IS_WINDOWS}" == '1' ]]; then
+    cygpath -m "${dir}" 2>/dev/null || echo "${dir}"
+  else
+    echo "${dir}"
+  fi
+}
+
+# Where a host directory must live INSIDE the build container.
+#
+# The build starts further containers, and their bind mounts are resolved by the
+# host daemon — so a path has to mean the same thing in both places. On Linux
+# that is free: mount the host path at itself. On Windows it is not, because the
+# daemon speaks Windows paths and a Linux container cannot have a directory
+# called C:/Users. Docker Desktop bridges this by exposing host drives inside its
+# VM at /run/desktop/mnt/host/<drive>, and the daemon resolves that form too — so
+# mounting there makes the path identical from both sides.
+#
+# Without this the resolver container writes its .debs into a phantom directory
+# and the build fails with "no package index was produced", or worse, quietly
+# produces a bundle with nothing in it.
+daemon_identity_path() {
+  local dir="$1" win drive rest
+  if [[ "${HOST_IS_WINDOWS}" != '1' ]]; then
+    echo "${dir}"
+    return
+  fi
+
+  win="$(cygpath -m "${dir}" 2>/dev/null)" || { echo "${dir}"; return; }
+  drive="$(printf '%s' "${win:0:1}" | tr '[:upper:]' '[:lower:]')"
+  rest="${win:2}"
+  echo "/run/desktop/mnt/host/${drive}${rest}"
 }
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -358,6 +407,84 @@ fi
 #                                                                                                                                                                                                 #
 ###################################################################################################################################################################################################
 
+# A destination the daemon cannot mount is still a perfectly good place to PUT a
+# finished bundle — the host can write there even when Docker cannot read there.
+# Removable and exFAT volumes are the common case, and carrying the bundle away
+# on one is the entire point of this tool. So build somewhere mountable and copy
+# the result to where it was asked for, rather than refusing.
+STAGING_ROOT=''
+staged_output=''
+
+cleanup_staging() {
+  [[ -n "${STAGING_ROOT}" && -d "${STAGING_ROOT}" ]] && rm -rf "${STAGING_ROOT}"
+}
+trap cleanup_staging EXIT
+
+ensure_staging_root() {
+  [[ -z "${STAGING_ROOT}" ]] || return 0
+
+  STAGING_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/nomad-bundle-staging.XXXXXX")" ||
+    die "Could not create a staging directory."
+
+  docker_can_mount "${STAGING_ROOT}" || die "\
+Docker cannot bind-mount the staging directory ${STAGING_ROOT} either.
+
+   Docker Desktop shares only fixed drives by default. Set TMPDIR to a directory
+   on a shared drive, or add this drive under Docker Desktop → Settings →
+   Resources → File sharing."
+}
+
+# The daemon cannot read a checkout on an unshared volume — the build container
+# would see an empty directory and produce a hollow bundle that still passes its
+# own verification, because every check reads the same phantom path. Copy the
+# source somewhere mountable and build from the copy. The working tree is copied
+# as-is, uncommitted changes and .git included, so the bundle records the right
+# commit and carries exactly what is checked out.
+if ! docker_can_mount "${REPO_ROOT}"; then
+  ensure_staging_root
+  log "Docker cannot mount ${REPO_ROOT} (removable or unshared drive)."
+  log "Copying the checkout to ${STAGING_ROOT}/src to build from..."
+
+  mkdir -p "${STAGING_ROOT}/src" || die "Could not create the source staging directory."
+  tar -cf - -C "${REPO_ROOT}" \
+    --exclude='./admin/node_modules' \
+    --exclude='./admin/node_modules_stale_delete_me' \
+    --exclude='./node_modules' \
+    --exclude='./dist' \
+    . | tar -xf - -C "${STAGING_ROOT}/src" ||
+    die "Could not copy the checkout to ${STAGING_ROOT}/src."
+
+  REPO_ROOT="${STAGING_ROOT}/src"
+  mount_paths[0]="${REPO_ROOT}"
+  # A --repo the caller passed explicitly pointed at the same unusable volume.
+  for i in "${!passthrough_args[@]}"; do
+    [[ "${passthrough_args[$i]}" == '--repo' ]] || continue
+    passthrough_args[$((i + 1))]="${REPO_ROOT}"
+    break
+  done
+fi
+
+# A destination the daemon cannot mount is still a perfectly good place to PUT a
+# finished bundle — the host can write there even when Docker cannot read there.
+# Removable volumes are the common case, and carrying the bundle away on one is
+# the entire point of this tool. So build somewhere mountable and copy across.
+if ! docker_can_mount "${output_dir}"; then
+  ensure_staging_root
+  log "Docker cannot mount ${output_dir} (removable or unshared drive)."
+  log "Building into staging, then copying the finished bundle across."
+
+  staged_output="${STAGING_ROOT}/out"
+  mkdir -p "${staged_output}" || die "Could not create the output staging directory."
+
+  # Replace the --output already queued for the inner script.
+  for i in "${!passthrough_args[@]}"; do
+    [[ "${passthrough_args[$i]}" == '--output' ]] || continue
+    passthrough_args[$((i + 1))]="${staged_output}"
+    break
+  done
+  mount_paths[${#mount_paths[@]} - 1]="${staged_output}"
+fi
+
 # Sort shortest-first so an ancestor is always seen before anything nested
 # inside it, then skip paths an existing mount already covers.
 mount_args=()
@@ -373,7 +500,10 @@ while IFS= read -r path; do
   done
   [[ "${covered}" == 'false' ]] || continue
   mounted+=("${path}")
-  mount_args+=(-v "${path}:${path}")
+  # Source is what the daemon must resolve; target is the path the build (and
+  # every container it starts) will use, chosen so the daemon resolves it to the
+  # same directory. On Linux both are the host path.
+  mount_args+=(-v "$(host_mount_source "${path}"):$(daemon_identity_path "${path}")")
 done < <(printf '%s\n' "${mount_paths[@]}" | awk '{ print length, $0 }' | sort -n | cut -d' ' -f2-)
 
 log "Building in ${BUILDER_IMAGE} (host needs only Docker)..."
@@ -381,10 +511,23 @@ log "Bundle will be written to ${output_dir}"
 
 # git safe.directory is set because the checkout is owned by the host user, not
 # by root inside the container.
-docker run --rm \
+# MSYS_NO_PATHCONV stops Git Bash rewriting the Unix-looking paths in -v and -w
+# into Windows ones. The mount SOURCES are converted deliberately above; the
+# targets, the socket path and the working directory must survive verbatim.
+# Every path the inner script receives has to be the in-container form, since
+# it both reads them directly and hands them to nested containers.
+for i in "${!passthrough_args[@]}"; do
+  case "${passthrough_args[$i]}" in
+    --output|--repo|--content-dir|--extra-image-list|--extra-image-archive)
+      passthrough_args[$((i + 1))]="$(daemon_identity_path "${passthrough_args[$((i + 1))]}")"
+      ;;
+  esac
+done
+
+MSYS_NO_PATHCONV=1 docker run --rm \
   -v "${DOCKER_SOCKET}:/var/run/docker.sock" \
   "${mount_args[@]}" \
-  -w "${REPO_ROOT}" \
+  -w "$(daemon_identity_path "${REPO_ROOT}")" \
   "${BUILDER_IMAGE}" \
   sh -c '
     set -e
@@ -392,6 +535,12 @@ docker run --rm \
     git config --global --add safe.directory "*"
     exec bash install/build_offline_bundle.sh "$@"
   ' sh "${passthrough_args[@]}"
+
+if [[ -n "${staged_output}" ]]; then
+  log "Copying the finished bundle to ${output_dir}..."
+  cp -R "${staged_output}"/. "${output_dir}/" ||
+    die "The bundle built successfully but could not be copied to ${output_dir}."
+fi
 
 echo ''
 echo -e "${GREEN}#${RESET} Done. The bundle is in ${output_dir}"

--- a/install/build_offline_bundle_docker.sh
+++ b/install/build_offline_bundle_docker.sh
@@ -91,6 +91,26 @@ check_docker_available() {
   docker info > /dev/null 2>&1 ||
     die "The Docker daemon is not reachable. Start Docker and try again."
 
+  # The build starts further containers, and their bind mounts are resolved by
+  # the host daemon — so the socket has to be mountable, not merely reachable.
+  #
+  # Under Git Bash / MSYS / Cygwin there is no Unix socket to mount: Docker
+  # Desktop is reached over a named pipe, and MSYS rewrites the Unix-looking
+  # paths in every -v argument on the way to the CLI. Relaxing this check alone
+  # does not make the build work there; it just moves the failure somewhere less
+  # obvious. Say so plainly instead.
+  case "$(uname -s 2>/dev/null || echo unknown)" in
+    MINGW*|MSYS*|CYGWIN*)
+      die "This wrapper cannot run under Git Bash / MSYS: Docker Desktop exposes a
+   named pipe rather than a mountable Unix socket, and MSYS rewrites the bind-mount
+   paths the build depends on.
+
+   Build from a WSL2 Linux distribution with Docker Desktop's WSL integration
+   enabled (where /var/run/docker.sock exists), or from a Linux or macOS machine.
+   The bundle produced is identical wherever it is built."
+      ;;
+  esac
+
   [[ -S "${DOCKER_SOCKET}" ]] ||
     die "No Docker socket at ${DOCKER_SOCKET}. Set NOMAD_DOCKER_SOCKET if yours lives elsewhere."
 }

--- a/install/build_offline_bundle_docker.sh
+++ b/install/build_offline_bundle_docker.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+
+# Project NOMAD Offline Artifact Bundle Builder — Docker entry point
+
+###################################################################################################################################################################################################
+
+# Script                | Project NOMAD Offline Bundle Builder (Docker entry point)
+# Version               | 1.1.0
+# Author                | Crosstalk Solutions, LLC
+# Website               | https://crosstalksolutions.com
+
+###################################################################################################################################################################################################
+#
+# Runs build_offline_bundle.sh inside a container so the build environment is
+# identical everywhere and the build machine needs nothing but Docker.
+#
+#   ./install/build_offline_bundle_docker.sh --target ubuntu:26.04
+#
+# With no --output the script asks where to put the bundle, offering the current
+# location and any connected removable drives. Use --no-prompt for unattended
+# builds. All other options are passed straight through to
+# build_offline_bundle.sh.
+#
+# Requirements on the build machine: Docker (running, with internet access).
+# No git, bash 4, coreutils or other host tooling is needed — the container
+# supplies all of it.
+#
+###################################################################################################################################################################################################
+
+set -Eeuo pipefail
+
+RESET='\033[0m'
+YELLOW='\033[1;33m'
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+
+# Alpine image carrying the Docker CLI and Compose v2. Override for a mirror.
+BUILDER_IMAGE="${NOMAD_BUILDER_IMAGE:-docker:cli}"
+DOCKER_SOCKET="${NOMAD_DOCKER_SOCKET:-/var/run/docker.sock}"
+NO_PROMPT="${NOMAD_NO_PROMPT:-0}"
+
+# A finished bundle is roughly 1 GB; the build needs headroom on top of that.
+REQUIRED_SPACE_KB=3145728
+
+log() { echo -e "${YELLOW}#${RESET} $*"; }
+die() {
+  echo -e "${RED}#${RESET} $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Project NOMAD Offline Bundle Builder — Docker entry point
+
+Usage:
+  ./install/build_offline_bundle_docker.sh [options]
+
+Runs the bundle build inside a container. Docker is the only requirement on
+this machine.
+
+Options handled here:
+  --output DIR     Where to write the bundle. If omitted you are asked, with
+                   the current location and any connected removable drives
+                   offered as choices.
+  --no-prompt      Never ask; use the default location. Implied when this is
+                   not an interactive terminal (CI, pipes).
+  -h, --help       Show this help text and exit.
+
+Environment:
+  NOMAD_NO_PROMPT=1        Same as --no-prompt
+  NOMAD_BUILDER_IMAGE      Build container image (default: docker:cli)
+  NOMAD_DOCKER_SOCKET      Docker socket (default: /var/run/docker.sock)
+
+Every other option is passed through to install/build_offline_bundle.sh:
+
+  --target OS:VERSION          Target operating system (default: ubuntu:26.04)
+  --arch ARCH                  Target architecture (default: amd64)
+  --repo PATH                  Project NOMAD source checkout
+  --without-nvidia-toolkit     Omit the NVIDIA Container Toolkit packages
+  --extra-image-list FILE      Also pull and bundle these image references
+  --extra-image-archive FILE   Include an existing docker-save archive
+  --content-dir DIR            Include pre-staged NOMAD storage content
+  --archive                    Also produce a .tar.gz of the bundle
+EOF
+}
+
+check_docker_available() {
+  command -v docker > /dev/null 2>&1 ||
+    die "docker was not found. Docker is the only requirement for building a bundle."
+
+  docker info > /dev/null 2>&1 ||
+    die "The Docker daemon is not reachable. Start Docker and try again."
+
+  [[ -S "${DOCKER_SOCKET}" ]] ||
+    die "No Docker socket at ${DOCKER_SOCKET}. Set NOMAD_DOCKER_SOCKET if yours lives elsewhere."
+}
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+###################################################################################################################################################################################################
+#                                                                                                                                                                                                 #
+#                                                                                    Output Location                                                                                              #
+#                                                                                                                                                                                                 #
+###################################################################################################################################################################################################
+
+# Free space on the nearest existing ancestor of a not-yet-created directory.
+space_of() {
+  local path="$1" unit="$2"
+  while [[ ! -d "${path}" && "${path}" != '/' ]]; do
+    path="$(dirname -- "${path}")"
+  done
+  if [[ "${unit}" == 'kb' ]]; then
+    df -Pk "${path}" 2>/dev/null | awk 'NR == 2 { print $4 }'
+  else
+    df -h "${path}" 2>/dev/null | awk 'NR == 2 { print $4 }'
+  fi
+}
+
+is_mount_point() {
+  local path="$1" parent
+  parent="$(dirname -- "${path}")"
+  [[ "$(df -P "${path}" 2>/dev/null | awk 'NR == 2 { print $1 }')" \
+     != "$(df -P "${parent}" 2>/dev/null | awk 'NR == 2 { print $1 }')" ]]
+}
+
+# Removable/external volumes, so a bundle can be written straight to the USB
+# drive it will be carried on. Platform-specific because there is no portable
+# way to enumerate mounted media.
+detect_removable_mounts() {
+  local volume base
+  case "$(uname -s)" in
+    Darwin)
+      for volume in /Volumes/*; do
+        # The boot volume appears here as a symlink to /.
+        [[ -d "${volume}" && ! -L "${volume}" && -w "${volume}" ]] || continue
+        echo "${volume}"
+      done
+      ;;
+    Linux)
+      for base in "/media/$(id -un)" /media "/run/media/$(id -un)" /mnt; do
+        [[ -d "${base}" ]] || continue
+        for volume in "${base}"/*; do
+          [[ -d "${volume}" && -w "${volume}" ]] || continue
+          is_mount_point "${volume}" || continue
+          echo "${volume}"
+        done
+      done
+      ;;
+  esac
+}
+
+# Which volume, if any, the checkout itself lives on — used to point out that a
+# choice keeps everything together on one drive.
+containing_volume() {
+  local path="$1" volume
+  while IFS= read -r volume; do
+    [[ -n "${volume}" ]] || continue
+    if [[ "${path}" == "${volume}" || "${path}" == "${volume}"/* ]]; then
+      echo "${volume}"
+      return 0
+    fi
+  done < <(detect_removable_mounts)
+  return 1
+}
+
+# Populates OUTPUT_CANDIDATES / OUTPUT_LABELS: where the build is running from
+# first, then any connected removable drives, then the home directory.
+build_output_candidates() {
+  local default_dir="${PWD}/dist"
+  local repo_volume='' volume label
+
+  OUTPUT_CANDIDATES=("${default_dir}")
+  OUTPUT_LABELS=('here (current directory)')
+
+  repo_volume="$(containing_volume "${REPO_ROOT}" || true)"
+
+  while IFS= read -r volume; do
+    [[ -n "${volume}" ]] || continue
+    # Already covered by the "here" option.
+    [[ "${volume}/nomad-bundles" != "${default_dir}" ]] || continue
+    label="removable drive: $(basename -- "${volume}")"
+    [[ "${volume}" != "${repo_volume}" ]] || label="${label} — same drive as this checkout"
+    OUTPUT_CANDIDATES+=("${volume}/nomad-bundles")
+    OUTPUT_LABELS+=("${label}")
+  done < <(detect_removable_mounts | sort -u)
+
+  OUTPUT_CANDIDATES+=("${HOME}/nomad-bundles")
+  OUTPUT_LABELS+=('home directory')
+}
+
+# Renders the menu and reads a choice. Assumes stdin is worth reading; the
+# interactivity decision belongs to choose_output_dir.
+prompt_for_output_dir() {
+  build_output_candidates
+
+  echo ''
+  echo -e "${GREEN}#${RESET} Where should the bundle be written? (about 1 GB)"
+  echo ''
+  local index=1 free
+  while [[ "${index}" -le "${#OUTPUT_CANDIDATES[@]}" ]]; do
+    free="$(space_of "${OUTPUT_CANDIDATES[$((index - 1))]}" 'human')"
+    printf '  %d) %s\n' "${index}" "${OUTPUT_CANDIDATES[$((index - 1))]}"
+    printf '     %s%s\n' "${OUTPUT_LABELS[$((index - 1))]}" "${free:+ — ${free} free}"
+    [[ "${index}" -ne 1 ]] || printf '     [default]\n'
+    index=$((index + 1))
+  done
+  echo '  c) enter a custom path'
+  echo ''
+
+  local reply chosen=''
+  while [[ -z "${chosen}" ]]; do
+    read -r -p "Choice [1]: " reply || reply=''
+    reply="${reply:-1}"
+    case "${reply}" in
+      c|C)
+        read -r -p 'Path: ' reply || reply=''
+        [[ -n "${reply}" ]] || continue
+        chosen="${reply}"
+        ;;
+      *[!0-9]*)
+        echo 'Please enter one of the numbers above, or c for a custom path.'
+        ;;
+      *)
+        if [[ "${reply}" -ge 1 && "${reply}" -le "${#OUTPUT_CANDIDATES[@]}" ]]; then
+          chosen="${OUTPUT_CANDIDATES[$((reply - 1))]}"
+        else
+          echo 'Please enter one of the numbers above, or c for a custom path.'
+        fi
+        ;;
+    esac
+  done
+
+  OUTPUT_CHOICE="${chosen}"
+}
+
+choose_output_dir() {
+  # Non-interactive: never block a script or CI run waiting on stdin.
+  if [[ "${NO_PROMPT}" == '1' || ! -t 0 ]]; then
+    OUTPUT_CHOICE="${PWD}/dist"
+    log "Writing the bundle to ${OUTPUT_CHOICE} (use --output to change it)."
+    return 0
+  fi
+
+  prompt_for_output_dir
+}
+
+###################################################################################################################################################################################################
+#                                                                                                                                                                                                 #
+#                                                                                        Main Script                                                                                              #
+#                                                                                                                                                                                                 #
+###################################################################################################################################################################################################
+
+# The test suite sources this script to exercise individual functions. Every
+# other invocation runs the build normally.
+if [[ "${NOMAD_BUILDER_LIB_ONLY:-}" == '1' ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+# --help must work without a running daemon, so handle it before any checks.
+for arg in "$@"; do
+  case "${arg}" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+  esac
+done
+
+check_docker_available
+
+[[ -f "${REPO_ROOT}/install/build_offline_bundle.sh" ]] ||
+  die "Could not find install/build_offline_bundle.sh next to this script."
+
+# The build starts further containers whose bind mounts are resolved by the host
+# Docker daemon, so every path the build touches has to exist at the SAME
+# absolute location inside the container as on the host. Resolve each
+# path-valued option to an absolute host path and mount it there.
+mount_paths=("${REPO_ROOT}")
+passthrough_args=()
+output_dir=''
+
+require_value() { [[ $2 -ge 2 ]] || die "$1 requires a value."; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      require_value "$1" $#
+      mkdir -p "$2" || die "Could not create output directory: $2"
+      output_dir="$(cd -- "$2" && pwd)"
+      shift 2
+      ;;
+    --no-prompt)
+      NO_PROMPT='1'
+      shift
+      ;;
+    --repo|--content-dir)
+      require_value "$1" $#
+      [[ -d "$2" ]] || die "$1: directory not found: $2"
+      resolved="$(cd -- "$2" && pwd)"
+      mount_paths+=("${resolved}")
+      passthrough_args+=("$1" "${resolved}")
+      shift 2
+      ;;
+    --extra-image-archive|--extra-image-list)
+      require_value "$1" $#
+      [[ -f "$2" ]] || die "$1: file not found: $2"
+      resolved_dir="$(cd -- "$(dirname -- "$2")" && pwd)"
+      mount_paths+=("${resolved_dir}")
+      passthrough_args+=("$1" "${resolved_dir}/$(basename -- "$2")")
+      shift 2
+      ;;
+    *)
+      passthrough_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${output_dir}" ]]; then
+  OUTPUT_CHOICE=''
+  choose_output_dir
+  mkdir -p "${OUTPUT_CHOICE}" || die "Could not create output directory: ${OUTPUT_CHOICE}"
+  output_dir="$(cd -- "${OUTPUT_CHOICE}" && pwd)"
+fi
+
+mount_paths+=("${output_dir}")
+passthrough_args+=(--output "${output_dir}")
+
+available_kb="$(space_of "${output_dir}" 'kb')"
+if [[ -n "${available_kb}" && "${available_kb}" -lt "${REQUIRED_SPACE_KB}" ]]; then
+  log "Warning: only $(space_of "${output_dir}" 'human') free at ${output_dir}; a bundle needs roughly 1 GB plus working room."
+fi
+
+###################################################################################################################################################################################################
+#                                                                                                                                                                                                 #
+#                                                                                        Run the Build                                                                                            #
+#                                                                                                                                                                                                 #
+###################################################################################################################################################################################################
+
+# Sort shortest-first so an ancestor is always seen before anything nested
+# inside it, then skip paths an existing mount already covers.
+mount_args=()
+mounted=()
+while IFS= read -r path; do
+  [[ -n "${path}" ]] || continue
+  covered='false'
+  for existing in ${mounted[@]+"${mounted[@]}"}; do
+    if [[ "${path}" == "${existing}" || "${path}" == "${existing}"/* ]]; then
+      covered='true'
+      break
+    fi
+  done
+  [[ "${covered}" == 'false' ]] || continue
+  mounted+=("${path}")
+  mount_args+=(-v "${path}:${path}")
+done < <(printf '%s\n' "${mount_paths[@]}" | awk '{ print length, $0 }' | sort -n | cut -d' ' -f2-)
+
+log "Building in ${BUILDER_IMAGE} (host needs only Docker)..."
+log "Bundle will be written to ${output_dir}"
+
+# git safe.directory is set because the checkout is owned by the host user, not
+# by root inside the container.
+docker run --rm \
+  -v "${DOCKER_SOCKET}:/var/run/docker.sock" \
+  "${mount_args[@]}" \
+  -w "${REPO_ROOT}" \
+  "${BUILDER_IMAGE}" \
+  sh -c '
+    set -e
+    apk add --no-cache bash git coreutils findutils tar gzip > /dev/null
+    git config --global --add safe.directory "*"
+    exec bash install/build_offline_bundle.sh "$@"
+  ' sh "${passthrough_args[@]}"
+
+echo ''
+echo -e "${GREEN}#${RESET} Done. The bundle is in ${output_dir}"

--- a/install/capture_installed_images.sh
+++ b/install/capture_installed_images.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# Project NOMAD Installed Image Capture Helper
+
+###################################################################################################################################################################################################
+#
+# Exports the Docker images present on an already-populated Project NOMAD host so
+# they can be added to an offline artifact bundle with:
+#
+#   ./build_offline_bundle.sh --extra-image-archive <archive>
+#
+# This transports images only. It does NOT prove that the corresponding Supply
+# Depot apps install offline — their install logic and catalog metadata may have
+# their own network dependencies. See admin/docs/offline-install.md.
+#
+###################################################################################################################################################################################################
+
+set -Eeuo pipefail
+
+RESET='\033[0m'
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+
+OUTPUT_DIR="${PWD}/nomad-image-export"
+INCLUDE_ALL='0'
+
+die() {
+  echo -e "${RED}#${RESET} $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./capture_installed_images.sh [--output DIR] [--all-local-images]
+
+Discovers, by default:
+  * images referenced by /opt/project-nomad/compose.yml
+  * images used by containers whose names start with "nomad_"
+
+Options:
+  --output DIR          Where to write the archive (default: ./nomad-image-export)
+  --all-local-images    Also export every tagged image present on this host
+  -h, --help            Show this help text and exit
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      [[ $# -ge 2 ]] || die "--output requires a directory."
+      OUTPUT_DIR="$2"
+      shift
+      ;;
+    --all-local-images)
+      INCLUDE_ALL='1'
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      die "Unknown option: $1"
+      ;;
+  esac
+  shift
+done
+
+command -v docker > /dev/null 2>&1 || die "docker is required."
+mkdir -p "${OUTPUT_DIR}"
+
+declare -A seen=()
+images=()
+
+add_image() {
+  local image="$1"
+  [[ -n "${image}" && "${image}" != '<none>:<none>' ]] || return 0
+  if [[ -z "${seen[${image}]+set}" ]]; then
+    seen["${image}"]='1'
+    images+=("${image}")
+  fi
+}
+
+if [[ -f /opt/project-nomad/compose.yml ]]; then
+  while IFS= read -r image; do
+    add_image "${image}"
+  done < <(docker compose -f /opt/project-nomad/compose.yml config --images 2>/dev/null || true)
+fi
+
+while IFS= read -r image; do
+  add_image "${image}"
+done < <(docker ps -a --filter 'name=^nomad_' --format '{{.Image}}')
+
+if [[ "${INCLUDE_ALL}" == '1' ]]; then
+  while IFS= read -r image; do
+    add_image "${image}"
+  done < <(docker image ls --format '{{.Repository}}:{{.Tag}}')
+fi
+
+[[ ${#images[@]} -gt 0 ]] || die "No images were discovered on this host."
+
+missing='0'
+for image in "${images[@]}"; do
+  if ! docker image inspect "${image}" > /dev/null 2>&1; then
+    echo "Image referenced but not present locally: ${image}" >&2
+    missing='1'
+  fi
+done
+[[ "${missing}" == '0' ]] || die "Every discovered image must exist locally before export."
+
+printf '%s\n' "${images[@]}" | sort -u > "${OUTPUT_DIR}/optional-images.txt"
+
+docker save -o "${OUTPUT_DIR}/optional-images.tar" "${images[@]}" || die "docker save failed."
+
+(cd "${OUTPUT_DIR}" && sha256sum optional-images.txt optional-images.tar > SHA256SUMS)
+
+echo ''
+echo -e "${GREEN}#${RESET} Exported ${#images[@]} image(s) to ${OUTPUT_DIR}/optional-images.tar"
+echo ''
+echo "Add to a bundle with:"
+printf '  ./build_offline_bundle.sh --extra-image-archive %q\n' "${OUTPUT_DIR}/optional-images.tar"

--- a/install/install_nomad.sh
+++ b/install/install_nomad.sh
@@ -37,12 +37,232 @@ UPDATE_SCRIPT_URL="https://raw.githubusercontent.com/Crosstalk-Solutions/project
 script_option_debug='true'
 accepted_terms='false'
 local_ip_address=''
+has_lan_address='false'
+
+# Offline artifact mode. When an artifact bundle is selected (--artifacts or
+# NOMAD_ARTIFACT_PATH) every dependency — host packages, Docker images, helper
+# scripts and the management compose file — is taken from that bundle, and the
+# installer never falls back to the network. See admin/docs/offline-install.md.
+SUPPORTED_BUNDLE_FORMAT_VERSION='1'
+NOMAD_ARTIFACT_PATH="${NOMAD_ARTIFACT_PATH:-}"
+artifact_mode='false'
+existing_install='false'
+existing_app_key=''
+existing_db_password=''
+existing_db_root_password=''
+existing_url=''
+artifact_manifest_file=''
+artifact_apt_repo_dir=''
+artifact_image_dir=''
+artifact_payload_dir=''
 
 ###################################################################################################################################################################################################
 #                                                                                                                                                                                                 #
 #                                                                                           Functions                                                                                             #
 #                                                                                                                                                                                                 #
 ###################################################################################################################################################################################################
+
+usage() {
+  cat <<EOF
+Project NOMAD Installation Script
+
+Usage:
+  sudo bash $(basename "$0") [options]
+
+Options:
+  --artifacts PATH   Install from a local offline artifact bundle instead of
+                     downloading dependencies from the internet. Bundles are
+                     produced on a connected machine by
+                     install/build_offline_bundle.sh and are specific to one
+                     OS / version / architecture.
+  -h, --help         Show this help text and exit.
+
+Environment:
+  NOMAD_ARTIFACT_PATH   Equivalent to --artifacts. The command line option wins
+                        when both are supplied.
+
+With no artifact path the installer behaves exactly as before and downloads its
+dependencies from the internet.
+EOF
+}
+
+parse_installer_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --artifacts)
+        if [[ $# -lt 2 || -z "$2" ]]; then
+          echo -e "${RED}#${RESET} --artifacts requires the path to an offline artifact bundle."
+          exit 1
+        fi
+        NOMAD_ARTIFACT_PATH="$2"
+        shift
+        ;;
+      --artifacts=*)
+        NOMAD_ARTIFACT_PATH="${1#*=}"
+        if [[ -z "${NOMAD_ARTIFACT_PATH}" ]]; then
+          echo -e "${RED}#${RESET} --artifacts requires the path to an offline artifact bundle."
+          exit 1
+        fi
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo -e "${RED}#${RESET} Unknown option: $1"
+        usage
+        exit 1
+        ;;
+    esac
+    shift
+  done
+
+  if [[ -n "${NOMAD_ARTIFACT_PATH}" ]]; then
+    local resolved_path
+    if ! resolved_path="$(cd -- "${NOMAD_ARTIFACT_PATH}" 2>/dev/null && pwd)"; then
+      echo -e "${RED}#${RESET} Offline artifact bundle directory not found: ${NOMAD_ARTIFACT_PATH}"
+      exit 1
+    fi
+    NOMAD_ARTIFACT_PATH="${resolved_path}"
+    artifact_mode='true'
+    artifact_manifest_file="${NOMAD_ARTIFACT_PATH}/manifest"
+    artifact_apt_repo_dir="${NOMAD_ARTIFACT_PATH}/packages/apt"
+    artifact_image_dir="${NOMAD_ARTIFACT_PATH}/images"
+    artifact_payload_dir="${NOMAD_ARTIFACT_PATH}/payload/nomad"
+  fi
+}
+
+artifact_mode_enabled() {
+  [[ "${artifact_mode}" == 'true' ]]
+}
+
+artifact_manifest_get() {
+  # The manifest is data, not shell. Read individual keys instead of sourcing it
+  # so a malformed or hostile bundle cannot execute code on the target.
+  local key="$1"
+  awk -F= -v wanted="${key}" '$1 == wanted { sub(/^[^=]*=/, "", $0); print; exit }' "${artifact_manifest_file}"
+}
+
+normalize_arch() {
+  case "$1" in
+    x86_64|amd64) echo 'amd64' ;;
+    aarch64|arm64) echo 'arm64' ;;
+    *) echo "$1" ;;
+  esac
+}
+
+os_release_get() {
+  local key="$1"
+  [[ -r /etc/os-release ]] || return 0
+  awk -F= -v wanted="${key}" '$1 == wanted { gsub(/^"|"$/, "", $2); print $2; exit }' /etc/os-release
+}
+
+validate_artifact_bundle() {
+  echo -e "${YELLOW}#${RESET} Offline artifact mode selected: ${NOMAD_ARTIFACT_PATH}\\n"
+
+  if ! command -v sha256sum &> /dev/null; then
+    header_red
+    echo -e "${RED}#${RESET} sha256sum is required to verify an offline artifact bundle but was not found."
+    exit 1
+  fi
+
+  # Distinguish "not a bundle at all" from "a damaged bundle". Pointing
+  # --artifacts at a source checkout instead of a built bundle is an easy
+  # mistake to make, and deserves a better answer than a missing-file list.
+  if [[ ! -f "${artifact_manifest_file}" ]]; then
+    header_red
+    echo -e "${RED}#${RESET} ${NOMAD_ARTIFACT_PATH} is not an offline artifact bundle (it has no 'manifest' file).\\n"
+    echo -e "${RED}#${RESET} --artifacts must point at a bundle directory, not at a Project NOMAD source"
+    echo -e "${RED}#${RESET} checkout. Bundles are named project-nomad-offline-<os>-<version>-<arch>-<commit>"
+    echo -e "${RED}#${RESET} and contain a manifest, SHA256SUMS, packages/, images/ and payload/.\\n"
+    echo -e "${RED}#${RESET} Build one on an internet-connected machine:"
+    echo -e "${RED}#${RESET}   ./install/build_offline_bundle.sh --target ubuntu:26.04 --output <output-dir>\\n"
+    echo -e "${RED}#${RESET} Then copy the resulting directory to this machine, cd into it, and run:"
+    echo -e "${RED}#${RESET}   sudo bash ./install_nomad.sh --artifacts ."
+    exit 1
+  fi
+
+  # Every one of these is required for a complete offline install. A bundle that
+  # is missing any of them must fail here rather than part-way through, because
+  # artifact mode has no network fallback to fill the gap.
+  local required_files=(
+    "${NOMAD_ARTIFACT_PATH}/SHA256SUMS"
+    "${artifact_apt_repo_dir}/Packages"
+    "${artifact_apt_repo_dir}/Packages.gz"
+    "${artifact_image_dir}/core-images.txt"
+    "${artifact_image_dir}/core-images.tar"
+    "${artifact_payload_dir}/management_compose.yaml"
+    "${artifact_payload_dir}/compose.artifact.yml"
+    "${artifact_payload_dir}/start_nomad.sh"
+    "${artifact_payload_dir}/stop_nomad.sh"
+    "${artifact_payload_dir}/update_nomad.sh"
+  )
+  local required_file
+  for required_file in "${required_files[@]}"; do
+    if [[ ! -f "${required_file}" ]]; then
+      header_red
+      echo -e "${RED}#${RESET} The offline artifact bundle is incomplete. Missing: ${required_file}"
+      echo -e "${RED}#${RESET} Rebuild the bundle with install/build_offline_bundle.sh on a connected machine and try again."
+      exit 1
+    fi
+  done
+
+  # Transfer integrity only. These checksums prove the bundle arrived intact;
+  # they are not a publisher signature and do not prove who produced it.
+  echo -e "${YELLOW}#${RESET} Verifying artifact bundle checksums...\\n"
+  if ! (cd "${NOMAD_ARTIFACT_PATH}" && sha256sum -c SHA256SUMS > /dev/null); then
+    header_red
+    echo -e "${RED}#${RESET} The offline artifact bundle failed checksum verification."
+    echo -e "${RED}#${RESET} It is corrupt or incomplete — copy it again from the build machine and retry."
+    exit 1
+  fi
+
+  local bundle_format target_os target_version target_arch
+  bundle_format="$(artifact_manifest_get BUNDLE_FORMAT_VERSION)"
+  target_os="$(artifact_manifest_get TARGET_OS)"
+  target_version="$(artifact_manifest_get TARGET_VERSION)"
+  target_arch="$(artifact_manifest_get TARGET_ARCH)"
+
+  if [[ "${bundle_format}" != "${SUPPORTED_BUNDLE_FORMAT_VERSION}" ]]; then
+    header_red
+    echo -e "${RED}#${RESET} Unsupported artifact bundle format '${bundle_format:-unknown}'."
+    echo -e "${RED}#${RESET} This installer supports bundle format ${SUPPORTED_BUNDLE_FORMAT_VERSION}."
+    exit 1
+  fi
+
+  if [[ -z "${target_os}" || -z "${target_version}" || -z "${target_arch}" ]]; then
+    header_red
+    echo -e "${RED}#${RESET} The artifact manifest is incomplete — TARGET_OS, TARGET_VERSION and TARGET_ARCH are all required."
+    exit 1
+  fi
+
+  # Bundles carry a dependency closure resolved for one exact distribution and
+  # architecture, so a mismatch is an error rather than a warning.
+  local host_os host_version host_arch
+  host_os="$(os_release_get ID)"
+  host_version="$(os_release_get VERSION_ID)"
+  host_arch="$(normalize_arch "$(dpkg --print-architecture 2>/dev/null || uname -m)")"
+
+  if [[ "${host_os}" != "${target_os}" ]]; then
+    header_red
+    echo -e "${RED}#${RESET} This bundle targets ${target_os}, but this host is ${host_os:-unknown}."
+    echo -e "${RED}#${RESET} Build a bundle for ${host_os:-this host} and try again."
+    exit 1
+  fi
+  if [[ "${host_version}" != "${target_version}" ]]; then
+    header_red
+    echo -e "${RED}#${RESET} This bundle targets ${target_os} ${target_version}, but this host runs ${host_version:-unknown}."
+    echo -e "${RED}#${RESET} Bundles are specific to one OS version because they carry a resolved package set."
+    exit 1
+  fi
+  if [[ "${host_arch}" != "${target_arch}" ]]; then
+    header_red
+    echo -e "${RED}#${RESET} This bundle targets ${target_arch}, but this host is ${host_arch:-unknown}."
+    exit 1
+  fi
+
+  echo -e "${GREEN}#${RESET} Artifact bundle validated (NOMAD commit $(artifact_manifest_get NOMAD_COMMIT), built $(artifact_manifest_get CREATED_AT_UTC)).\\n"
+}
 
 header() {
   if [[ "${script_option_debug}" != 'true' ]]; then clear; clear; fi
@@ -217,6 +437,98 @@ ensure_docker_installed() {
   fi
 }
 
+install_packages_from_artifacts() {
+  # Artifact-mode replacement for ensure_dependencies_installed + ensure_docker_installed.
+  # Everything comes from the bundle's flat APT repository; the host's configured
+  # remote repositories take no part in dependency resolution.
+  echo -e "${YELLOW}#${RESET} Installing host dependencies from the offline artifact bundle...\\n"
+
+  local apt_root
+  if ! apt_root="$(mktemp -d /tmp/nomad-artifact-apt.XXXXXX)"; then
+    header_red
+    echo -e "${RED}#${RESET} Failed to create a temporary directory for the local APT repository."
+    exit 1
+  fi
+
+  # Removable media is routinely mounted under a path containing spaces, which
+  # the APT "file:" source syntax cannot express. Reach the bundle repository
+  # through a whitespace-free symlink instead.
+  if ! ln -s "${artifact_apt_repo_dir}" "${apt_root}/repo"; then
+    header_red
+    echo -e "${RED}#${RESET} Failed to link the local APT repository at ${artifact_apt_repo_dir}."
+    exit 1
+  fi
+  mkdir -p "${apt_root}/lists/partial"
+  echo "deb [trusted=yes] file:${apt_root}/repo ./" > "${apt_root}/sources.list"
+
+  # Isolation: only the bundle repository is visible (sourcelist), /etc/apt/sources.list.d
+  # is excluded (sourceparts=-), list state is kept out of the host's (Dir::State::Lists),
+  # and APT is told not to retry fetches. A dependency that is missing from the
+  # bundle therefore fails the install instead of being pulled from the internet.
+  local apt_opts=(
+    -o "Dir::Etc::sourcelist=${apt_root}/sources.list"
+    -o "Dir::Etc::sourceparts=-"
+    -o "Dir::State::Lists=${apt_root}/lists"
+    -o "APT::Get::List-Cleanup=0"
+    -o "Acquire::Languages=none"
+    -o "Acquire::Retries=0"
+  )
+
+  # Mirrors what the online path installs: the dependencies checked by
+  # ensure_dependencies_installed, the Docker packages the convenience script
+  # would install, and the host utilities used later by verify_gpu_setup.
+  local packages=(
+    ca-certificates
+    curl
+    gnupg
+    jq
+    pciutils
+    docker-ce
+    docker-ce-cli
+    containerd.io
+    docker-buildx-plugin
+    docker-compose-plugin
+  )
+  if [[ "$(artifact_manifest_get WITH_NVIDIA_TOOLKIT)" == '1' ]]; then
+    packages+=(nvidia-container-toolkit)
+  fi
+
+  if ! sudo apt-get "${apt_opts[@]}" update; then
+    header_red
+    echo -e "${RED}#${RESET} Failed to read the offline APT repository at ${artifact_apt_repo_dir}."
+    rm -rf "${apt_root}"
+    exit 1
+  fi
+
+  if ! sudo DEBIAN_FRONTEND=noninteractive apt-get "${apt_opts[@]}" install -y --no-install-recommends "${packages[@]}"; then
+    header_red
+    echo -e "${RED}#${RESET} Failed to install host dependencies from the offline artifact bundle."
+    echo -e "${RED}#${RESET} The bundle is missing one or more packages required by this system. Rebuild it"
+    echo -e "${RED}#${RESET} on a connected machine for $(artifact_manifest_get TARGET_OS) $(artifact_manifest_get TARGET_VERSION) and try again."
+    rm -rf "${apt_root}"
+    exit 1
+  fi
+
+  rm -rf "${apt_root}"
+
+  if ! command -v docker &> /dev/null; then
+    header_red
+    echo -e "${RED}#${RESET} Docker is still not available after installing packages from the bundle."
+    exit 1
+  fi
+
+  if ! systemctl is-active --quiet docker; then
+    echo -e "${YELLOW}#${RESET} Docker is installed but not running. Attempting to start Docker...\\n"
+    sudo systemctl enable --now docker
+    if ! systemctl is-active --quiet docker; then
+      echo -e "${RED}#${RESET} Failed to start Docker. Please check the Docker service status and try again."
+      exit 1
+    fi
+  fi
+
+  echo -e "${GREEN}#${RESET} Host dependencies installed from the offline artifact bundle.\\n"
+}
+
 check_docker_compose() {
   # Check if 'docker compose' (v2 plugin) is available
   if ! docker compose version &>/dev/null; then
@@ -227,12 +539,10 @@ check_docker_compose() {
   fi
 }
 
-setup_nvidia_container_toolkit() {
-  # This function attempts to set up NVIDIA GPU support but is non-blocking
-  # Any failures will result in warnings but will NOT stop the installation process
-  
-  echo -e "${YELLOW}#${RESET} Checking for NVIDIA GPU...\\n"
-  
+detect_nvidia_gpu() {
+  # Shared hardware detection for the online and artifact toolkit paths.
+  # Returns 0 when an NVIDIA GPU is present.
+
   # Safely detect NVIDIA GPU
   local has_nvidia_gpu=false
   if command -v lspci &> /dev/null; then
@@ -241,7 +551,7 @@ setup_nvidia_container_toolkit() {
       echo -e "${GREEN}#${RESET} NVIDIA GPU detected.\\n"
     fi
   fi
-  
+
   # Also check for nvidia-smi
   if ! $has_nvidia_gpu && command -v nvidia-smi &> /dev/null; then
     if nvidia-smi &> /dev/null; then
@@ -249,12 +559,63 @@ setup_nvidia_container_toolkit() {
       echo -e "${GREEN}#${RESET} NVIDIA GPU detected via nvidia-smi.\\n"
     fi
   fi
-  
-  if ! $has_nvidia_gpu; then
+
+  $has_nvidia_gpu
+}
+
+setup_nvidia_container_toolkit_from_artifacts() {
+  # Artifact-mode counterpart of setup_nvidia_container_toolkit. Same non-blocking
+  # philosophy: warn and continue rather than fail the install. The toolkit, when
+  # present, was installed from the bundle by install_packages_from_artifacts —
+  # the NVIDIA package repository is never contacted.
+
+  echo -e "${YELLOW}#${RESET} Checking for NVIDIA GPU...\\n"
+
+  if ! detect_nvidia_gpu; then
+    echo -e "${YELLOW}#${RESET} No NVIDIA GPU detected. Skipping NVIDIA container toolkit configuration.\\n"
+    return 0
+  fi
+
+  if ! command -v nvidia-ctk &> /dev/null; then
+    echo -e "${YELLOW}#${RESET} Warning: an NVIDIA GPU is present but this bundle does not include the NVIDIA"
+    echo -e "${YELLOW}#${RESET} Container Toolkit. Rebuild the bundle without --without-nvidia-toolkit to add it.\\n"
+    echo -e "${YELLOW}#${RESET} Continuing without NVIDIA container acceleration.\\n"
+    return 0
+  fi
+
+  if ! command -v nvidia-smi &> /dev/null || ! nvidia-smi &> /dev/null; then
+    echo -e "${YELLOW}#${RESET} Warning: the NVIDIA Container Toolkit is installed but no working host NVIDIA"
+    echo -e "${YELLOW}#${RESET} driver was detected. Host GPU drivers are outside the scope of offline bundles"
+    echo -e "${YELLOW}#${RESET} and must be installed separately. Continuing without GPU acceleration.\\n"
+    return 0
+  fi
+
+  echo -e "${YELLOW}#${RESET} Configuring Docker to use NVIDIA runtime...\\n"
+  if ! sudo nvidia-ctk runtime configure --runtime=docker 2>/dev/null; then
+    echo -e "${YELLOW}#${RESET} Warning: nvidia-ctk runtime configuration failed. GPU support may require manual setup.\\n"
+    return 0
+  fi
+
+  echo -e "${YELLOW}#${RESET} Restarting Docker service...\\n"
+  if ! sudo systemctl restart docker 2>/dev/null; then
+    echo -e "${YELLOW}#${RESET} Warning: Failed to restart Docker service. You may need to restart it manually.\\n"
+    return 0
+  fi
+
+  echo -e "${GREEN}#${RESET} NVIDIA container toolkit configuration completed.\\n"
+}
+
+setup_nvidia_container_toolkit() {
+  # This function attempts to set up NVIDIA GPU support but is non-blocking
+  # Any failures will result in warnings but will NOT stop the installation process
+
+  echo -e "${YELLOW}#${RESET} Checking for NVIDIA GPU...\\n"
+
+  if ! detect_nvidia_gpu; then
     echo -e "${YELLOW}#${RESET} No NVIDIA GPU detected. Skipping NVIDIA container toolkit installation.\\n"
     return 0
   fi
-  
+
   # Check if nvidia-container-toolkit is already installed
   if command -v nvidia-ctk &> /dev/null; then
     echo -e "${GREEN}#${RESET} NVIDIA container toolkit is already installed.\\n"
@@ -353,6 +714,25 @@ setup_nvidia_container_toolkit() {
 }
 
 get_install_confirmation(){
+  if artifact_mode_enabled && [[ "${existing_install}" == 'true' ]]; then
+    # Re-running artifact mode over an existing install is the supported offline
+    # update path: new images and helper scripts are applied, data is kept.
+    echo -e "${YELLOW}#${RESET} An existing Project NOMAD installation was found at ${NOMAD_DIR}."
+    echo -e "${YELLOW}#${RESET} This will update it from the artifact bundle, keeping your database, installed apps and content."
+    echo -e "${YELLOW}#${RESET} Backing up ${NOMAD_DIR} first is still recommended."
+    read -p "Are you sure you want to continue? (y/N): " choice
+    case "$choice" in
+      y|Y )
+        echo -e "${GREEN}#${RESET} User chose to continue with the update."
+        return 0
+        ;;
+      * )
+        echo "User chose not to continue with the update."
+        exit 0
+        ;;
+    esac
+  fi
+
   echo -e "${YELLOW}#${RESET} This script will install Project NOMAD and its dependencies on your machine."
   echo -e "${YELLOW}#${RESET} If you already have Project NOMAD installed with customized config or data, please be aware that running this installation script may overwrite existing files and configurations. It is highly recommended to back up any important data/configs before proceeding."
   read -p "Are you sure you want to continue? (y/N): " choice
@@ -407,6 +787,23 @@ create_nomad_directory(){
   sudo touch "${NOMAD_DIR}/storage/logs/admin.log"
 }
 
+copy_artifact_payload_file() {
+  local source_name="$1"
+  local destination="$2"
+
+  if [[ ! -f "${artifact_payload_dir}/${source_name}" ]]; then
+    header_red
+    echo -e "${RED}#${RESET} Required file missing from the artifact bundle payload: ${source_name}"
+    exit 1
+  fi
+
+  if ! cp "${artifact_payload_dir}/${source_name}" "${destination}"; then
+    header_red
+    echo -e "${RED}#${RESET} Failed to copy ${source_name} from the artifact bundle to ${destination}."
+    exit 1
+  fi
+}
+
 download_management_compose_file() {
   local compose_file_path="${NOMAD_DIR}/compose.yml"
 
@@ -416,23 +813,89 @@ download_management_compose_file() {
     exit 1
   fi
   echo -e "${GREEN}#${RESET} Docker compose file downloaded successfully to $compose_file_path.\\n"
+}
 
-  local app_key=$(generateRandomPass)
-  local db_root_password=$(generateRandomPass)
-  local db_user_password=$(generateRandomPass)
+copy_management_compose_file_from_artifacts() {
+  local compose_file_path="${NOMAD_DIR}/compose.yml"
 
-  # If MySQL data directory exists from a previous install attempt, remove it.
-  # MySQL only initializes credentials on first startup when the data dir is empty.
-  # If stale data exists, MySQL ignores the new passwords above and uses the old ones,
-  # causing "Access denied" errors when the admin container tries to connect.
-  if [[ -d "${NOMAD_DIR}/mysql" ]]; then
-    echo -e "${YELLOW}#${RESET} Removing existing MySQL data directory to ensure credentials match...\\n"
-    sudo rm -rf "${NOMAD_DIR}/mysql"
+  echo -e "${YELLOW}#${RESET} Installing docker-compose file for management from the artifact bundle...\\n"
+  copy_artifact_payload_file management_compose.yaml "$compose_file_path"
+  # Layered at startup to force pull_policy: never for every service, so the
+  # canonical compose file keeps its normal pull_policy: always.
+  copy_artifact_payload_file compose.artifact.yml "${NOMAD_DIR}/compose.artifact.yml"
+  echo -e "${GREEN}#${RESET} Docker compose file installed successfully to $compose_file_path.\\n"
+}
+
+compose_env_value() {
+  # Reads a "- KEY=value" entry from a compose file. Prints nothing when the key
+  # is absent or still holds the placeholder.
+  local key="$1" file="$2" value
+  [[ -f "$file" ]] || return 0
+  value="$(awk -v key="${key}" '
+    $0 ~ "^[[:space:]]*-[[:space:]]*" key "=" {
+      sub("^[[:space:]]*-[[:space:]]*" key "=", "", $0)
+      print
+      exit
+    }
+  ' "$file")"
+  [[ "$value" != 'replaceme' ]] || return 0
+  echo "$value"
+}
+
+detect_existing_installation() {
+  # Must run before the compose file is replaced, so an update can carry the
+  # generated credentials forward instead of orphaning the existing database.
+  local compose_file_path="${NOMAD_DIR}/compose.yml"
+  [[ -f "$compose_file_path" ]] || return 0
+
+  existing_app_key="$(compose_env_value APP_KEY "$compose_file_path")"
+  existing_db_password="$(compose_env_value MYSQL_PASSWORD "$compose_file_path")"
+  existing_db_root_password="$(compose_env_value MYSQL_ROOT_PASSWORD "$compose_file_path")"
+  existing_url="$(compose_env_value URL "$compose_file_path")"
+
+  if [[ -n "$existing_app_key" && -n "$existing_db_password" && -n "$existing_db_root_password" ]]; then
+    existing_install='true'
+  fi
+}
+
+configure_management_compose_file() {
+  local compose_file_path="${NOMAD_DIR}/compose.yml"
+  local app_key db_root_password db_user_password
+
+  # Re-running artifact mode over an existing install is an update, not a fresh
+  # install: keep the credentials the database was initialised with so its data,
+  # installed apps and settings survive. MySQL only applies these passwords on
+  # first startup, so regenerating them here is what would force wiping the data
+  # directory.
+  if artifact_mode_enabled && [[ "${existing_install}" == 'true' ]]; then
+    echo -e "${YELLOW}#${RESET} Existing Project NOMAD installation detected — updating in place and keeping your data.\\n"
+    app_key="${existing_app_key}"
+    db_root_password="${existing_db_root_password}"
+    db_user_password="${existing_db_password}"
+  else
+    app_key=$(generateRandomPass)
+    db_root_password=$(generateRandomPass)
+    db_user_password=$(generateRandomPass)
+
+    # If MySQL data directory exists from a previous install attempt, remove it.
+    # MySQL only initializes credentials on first startup when the data dir is empty.
+    # If stale data exists, MySQL ignores the new passwords above and uses the old ones,
+    # causing "Access denied" errors when the admin container tries to connect.
+    if [[ -d "${NOMAD_DIR}/mysql" ]]; then
+      echo -e "${YELLOW}#${RESET} Removing existing MySQL data directory to ensure credentials match...\\n"
+      sudo rm -rf "${NOMAD_DIR}/mysql"
+    fi
   fi
 
   # Inject dynamic env values into the compose file
   echo -e "${YELLOW}#${RESET} Configuring docker-compose file env variables...\\n"
-  sed -i "s|URL=replaceme|URL=http://${local_ip_address}:8080|g" "$compose_file_path"
+  if artifact_mode_enabled && [[ -n "${existing_url}" ]]; then
+    # Keep the address the instance is already reachable at rather than silently
+    # repointing it during an update.
+    sed -i "s|URL=replaceme|URL=${existing_url}|g" "$compose_file_path"
+  else
+    sed -i "s|URL=replaceme|URL=http://${local_ip_address}:8080|g" "$compose_file_path"
+  fi
   sed -i "s|APP_KEY=replaceme|APP_KEY=${app_key}|g" "$compose_file_path"
   
   sed -i "s|DB_PASSWORD=replaceme|DB_PASSWORD=${db_user_password}|g" "$compose_file_path"
@@ -440,6 +903,18 @@ download_management_compose_file() {
   sed -i "s|MYSQL_PASSWORD=replaceme|MYSQL_PASSWORD=${db_user_password}|g" "$compose_file_path"
   
   echo -e "${GREEN}#${RESET} Docker compose file configured successfully.\\n"
+}
+
+setup_management_compose_file() {
+  # Read the outgoing compose file before it is overwritten.
+  detect_existing_installation
+
+  if artifact_mode_enabled; then
+    copy_management_compose_file_from_artifacts
+  else
+    download_management_compose_file
+  fi
+  configure_management_compose_file
 }
 
 download_helper_scripts() {
@@ -469,9 +944,113 @@ download_helper_scripts() {
   echo -e "${GREEN}#${RESET} Helper scripts downloaded successfully to $start_script_path, $stop_script_path, and $update_script_path.\\n"
 }
 
+copy_helper_scripts_from_artifacts() {
+  local start_script_path="${NOMAD_DIR}/start_nomad.sh"
+  local stop_script_path="${NOMAD_DIR}/stop_nomad.sh"
+  local update_script_path="${NOMAD_DIR}/update_nomad.sh"
+
+  echo -e "${YELLOW}#${RESET} Installing helper scripts from the artifact bundle...\\n"
+  copy_artifact_payload_file start_nomad.sh "$start_script_path"
+  chmod +x "$start_script_path"
+
+  copy_artifact_payload_file stop_nomad.sh "$stop_script_path"
+  chmod +x "$stop_script_path"
+
+  copy_artifact_payload_file update_nomad.sh "$update_script_path"
+  chmod +x "$update_script_path"
+
+  # The uninstall script is normally fetched from GitHub on demand, which a
+  # disconnected host cannot do. Ship it alongside the others when the bundle
+  # carries it.
+  if [[ -f "${artifact_payload_dir}/uninstall_nomad.sh" ]]; then
+    copy_artifact_payload_file uninstall_nomad.sh "${NOMAD_DIR}/uninstall_nomad.sh"
+    chmod +x "${NOMAD_DIR}/uninstall_nomad.sh"
+  fi
+
+  echo -e "${GREEN}#${RESET} Helper scripts installed successfully to $start_script_path, $stop_script_path, and $update_script_path.\\n"
+}
+
+setup_helper_scripts() {
+  if artifact_mode_enabled; then
+    copy_helper_scripts_from_artifacts
+  else
+    download_helper_scripts
+  fi
+}
+
+load_artifact_images() {
+  echo -e "${YELLOW}#${RESET} Loading Docker images from the artifact bundle...\\n"
+
+  local archive
+  local archives_loaded=0
+  for archive in "${artifact_image_dir}"/*.tar; do
+    [[ -f "$archive" ]] || continue
+    # Skip AppleDouble sidecars ("._core-images.tar"), which macOS leaves on
+    # FAT/exFAT media next to real files. They match *.tar but are metadata.
+    [[ "$(basename "$archive")" != ._* ]] || continue
+    echo -e "${YELLOW}#${RESET} Loading $(basename "$archive")...\\n"
+    if ! sudo docker load -i "$archive"; then
+      header_red
+      echo -e "${RED}#${RESET} Failed to load Docker images from $(basename "$archive")."
+      exit 1
+    fi
+    archives_loaded=$((archives_loaded + 1))
+  done
+
+  if [[ "$archives_loaded" -eq 0 ]]; then
+    header_red
+    echo -e "${RED}#${RESET} No Docker image archives were found in ${artifact_image_dir}."
+    exit 1
+  fi
+
+  # Fail closed: the stack starts with --pull never, so a management image that
+  # did not make it into the archive must be caught here with a clear message
+  # rather than as an opaque Compose failure.
+  local image
+  while IFS= read -r image; do
+    [[ -n "$image" ]] || continue
+    if ! sudo docker image inspect "$image" &> /dev/null; then
+      header_red
+      echo -e "${RED}#${RESET} The bundle lists image ${image} but it is not present after loading."
+      echo -e "${RED}#${RESET} Rebuild the bundle on a connected machine and try again."
+      exit 1
+    fi
+  done < "${artifact_image_dir}/core-images.txt"
+
+  echo -e "${GREEN}#${RESET} Docker images loaded successfully from the artifact bundle.\\n"
+}
+
+seed_artifact_content() {
+  # Optional extension point: a bundle may carry pre-staged NOMAD storage
+  # content. Transporting files here does not make every optional app or content
+  # type installable offline — see admin/docs/offline-install.md.
+  [[ -d "${NOMAD_ARTIFACT_PATH}/content" ]] || return 0
+
+  echo -e "${YELLOW}#${RESET} Seeding pre-staged content into ${NOMAD_DIR}/storage...\\n"
+  sudo mkdir -p "${NOMAD_DIR}/storage"
+  # -n so re-running never overwrites content the user has changed or replaced;
+  # new files in a later bundle are still added.
+  if ! sudo cp -a -n "${NOMAD_ARTIFACT_PATH}/content/." "${NOMAD_DIR}/storage/"; then
+    header_red
+    echo -e "${RED}#${RESET} Failed to seed pre-staged content from the artifact bundle."
+    exit 1
+  fi
+  echo -e "${GREEN}#${RESET} Pre-staged content seeded successfully.\\n"
+}
+
 start_management_containers() {
   echo -e "${YELLOW}#${RESET} Starting management containers using docker compose...\\n"
-  if ! sudo docker compose -p project-nomad -f "${NOMAD_DIR}/compose.yml" up -d; then
+
+  local compose_args=(-p project-nomad -f "${NOMAD_DIR}/compose.yml")
+  if artifact_mode_enabled; then
+    # Layer the bundle's override (pull_policy: never for every service) and
+    # forbid pulls outright, so startup uses only the images loaded above.
+    compose_args+=(-f "${NOMAD_DIR}/compose.artifact.yml" up -d --pull never)
+  else
+    compose_args+=(up -d)
+  fi
+
+  if ! sudo docker compose "${compose_args[@]}"; then
     echo -e "${RED}#${RESET} Failed to start management containers. Please check the logs and try again."
     exit 1
   fi
@@ -479,11 +1058,23 @@ start_management_containers() {
 }
 
 get_local_ip() {
-  local_ip_address=$(hostname -I | awk '{print $1}')
-  if [[ -z "$local_ip_address" ]]; then
-    echo -e "${RED}#${RESET} Unable to determine local IP address. Please check your network configuration."
-    exit 1
+  local_ip_address=$(hostname -I 2>/dev/null | awk '{print $1}')
+  if [[ -n "$local_ip_address" ]]; then
+    has_lan_address='true'
+    return 0
   fi
+
+  if artifact_mode_enabled; then
+    # A genuinely disconnected target may have no LAN address at all. That must
+    # not block an offline install, so fall back to localhost and simply don't
+    # advertise a LAN URL.
+    echo -e "${YELLOW}#${RESET} No LAN address detected. Project NOMAD will be reachable at http://localhost:8080.\\n"
+    local_ip_address='localhost'
+    return 0
+  fi
+
+  echo -e "${RED}#${RESET} Unable to determine local IP address. Please check your network configuration."
+  exit 1
 }
 verify_gpu_setup() {
   # This function only displays GPU setup status and is completely non-blocking
@@ -604,7 +1195,12 @@ success_message() {
   echo -e "${GREEN}#${RESET} Project NOMAD installation completed successfully!\\n"
   echo -e "${GREEN}#${RESET} Installation files are located at /opt/project-nomad\\n\n"
   echo -e "${GREEN}#${RESET} Project NOMAD's Command Center should automatically start whenever your device reboots. However, if you need to start it manually, you can always do so by running: ${WHITE_R}${NOMAD_DIR}/start_nomad.sh${RESET}\\n"
-  echo -e "${GREEN}#${RESET} You can now access the management interface at http://localhost:8080 or http://${local_ip_address}:8080\\n"
+  if [[ "${has_lan_address}" == 'true' ]]; then
+    echo -e "${GREEN}#${RESET} You can now access the management interface at http://localhost:8080 or http://${local_ip_address}:8080\\n"
+  else
+    # No LAN address was available (offline install on a host with no network).
+    echo -e "${GREEN}#${RESET} You can now access the management interface at http://localhost:8080\\n"
+  fi
   echo -e "${GREEN}#${RESET} Thank you for supporting Project NOMAD!\\n"
 }
 
@@ -614,24 +1210,51 @@ success_message() {
 #                                                                                                                                                                                                 #
 ###################################################################################################################################################################################################
 
+# The test suite sources this script to exercise individual functions. Every
+# other invocation runs the installer normally.
+if [[ "${NOMAD_INSTALLER_LIB_ONLY:-}" == '1' ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+parse_installer_args "$@"
+
 # Pre-flight checks
 check_is_debian_based
 check_is_x86_64
 check_is_bash
 check_has_sudo
-ensure_dependencies_installed
+if artifact_mode_enabled; then
+  # Artifact mode is fail-closed from here on: no dependency is acquired over
+  # the network, so the bundle is validated up front instead.
+  validate_artifact_bundle
+  # Read before anything is written, so the confirmation prompt can tell the
+  # user whether this is a fresh install or an in-place update.
+  detect_existing_installation
+else
+  ensure_dependencies_installed
+fi
 check_is_debug_mode
 
 # Main install
 get_install_confirmation
 accept_terms
-ensure_docker_installed
-check_docker_compose
-setup_nvidia_container_toolkit
+if artifact_mode_enabled; then
+  install_packages_from_artifacts
+  check_docker_compose
+  setup_nvidia_container_toolkit_from_artifacts
+else
+  ensure_docker_installed
+  check_docker_compose
+  setup_nvidia_container_toolkit
+fi
 get_local_ip
 create_nomad_directory
-download_helper_scripts
-download_management_compose_file
+setup_helper_scripts
+setup_management_compose_file
+if artifact_mode_enabled; then
+  load_artifact_images
+  seed_artifact_content
+fi
 start_management_containers
 verify_gpu_setup
 success_message

--- a/install/tests/offline_artifact_tests.sh
+++ b/install/tests/offline_artifact_tests.sh
@@ -610,7 +610,22 @@ if [[ -f "${DOCKER_WRAPPER}" ]]; then
 
   assert_contains "${wrapper_src}" '${DOCKER_SOCKET}:/var/run/docker.sock' \
     'wrapper mounts the Docker socket so nested builds reach the host daemon'
-  assert_contains "${wrapper_src}" '-v "${path}:${path}"' \
+  # The invariant is that a path means the same thing to the build container and
+  # to the host daemon, since the build starts further containers whose bind
+  # mounts the daemon resolves. On Linux that is literally the same string; on
+  # Docker Desktop the container side becomes /run/desktop/mnt/host/<drive>/…,
+  # which the daemon resolves to the same directory. Assert the behaviour of the
+  # two helpers rather than a fixed mount line, so the Windows support does not
+  # have to look like the Linux case to be correct.
+  assert_contains "${wrapper_src}" 'host_mount_source "${path}"):$(daemon_identity_path "${path}")' \
+    'wrapper builds mounts from the daemon-source and container-path helpers'
+
+  wrapper_helpers="$(sed -n '/^host_mount_source() {/,/^}/p;/^daemon_identity_path() {/,/^}/p' "${DOCKER_WRAPPER}")"
+  identity_probe="$(HOST_IS_WINDOWS='0' bash -c "
+    ${wrapper_helpers}
+    printf '%s|%s' \"\$(host_mount_source /srv/nomad)\" \"\$(daemon_identity_path /srv/nomad)\"
+  ")"
+  assert_eq "${identity_probe}" '/srv/nomad|/srv/nomad' \
     'wrapper mounts host paths at identical locations inside the container'
   assert_contains "${wrapper_src}" 'exec bash install/build_offline_bundle.sh "$@"' \
     'wrapper delegates to the real builder with arguments passed through'

--- a/install/tests/offline_artifact_tests.sh
+++ b/install/tests/offline_artifact_tests.sh
@@ -1,0 +1,700 @@
+#!/bin/bash
+
+# Project NOMAD Offline Artifact Mode Regression Tests
+
+###################################################################################################################################################################################################
+#
+# Guards the fail-closed behaviour of install_nomad.sh --artifacts and the bundle
+# builder. Runs offline and needs no Docker daemon.
+#
+# Requires a Linux host (the installer reads /etc/os-release and dpkg). Run it
+# from anywhere:
+#
+#   bash install/tests/offline_artifact_tests.sh
+#
+# Or in a container from the repository root:
+#
+#   docker run --rm --network none -v "$PWD:/repo" -w /repo ubuntu:26.04 \
+#     bash install/tests/offline_artifact_tests.sh
+#
+###################################################################################################################################################################################################
+
+set -uo pipefail
+
+TESTS_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR="$(cd -- "${TESTS_DIR}/.." && pwd)"
+INSTALLER="${INSTALL_DIR}/install_nomad.sh"
+BUILDER="${INSTALL_DIR}/build_offline_bundle.sh"
+COMPOSE_FILE="${INSTALL_DIR}/management_compose.yaml"
+
+pass_count=0
+fail_count=0
+
+pass() {
+  pass_count=$((pass_count + 1))
+  echo "  ok   - $1"
+}
+
+fail() {
+  fail_count=$((fail_count + 1))
+  echo "  FAIL - $1"
+  [[ $# -lt 2 ]] || echo "         $2"
+}
+
+assert_eq() {
+  local expected="$1" actual="$2" name="$3"
+  if [[ "${expected}" == "${actual}" ]]; then
+    pass "${name}"
+  else
+    fail "${name}" "expected '${expected}', got '${actual}'"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    pass "${name}"
+  else
+    fail "${name}" "expected to find '${needle}'"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    pass "${name}"
+  else
+    fail "${name}" "did not expect to find '${needle}'"
+  fi
+}
+
+# Run a snippet against the installer's functions without running the installer.
+installer_eval() {
+  NOMAD_INSTALLER_LIB_ONLY='1' bash -c "source '${INSTALLER}'; $1"
+}
+
+# Same, capturing the exit status of a snippet expected to fail.
+installer_status() {
+  installer_eval "$1" > /dev/null 2>&1
+  echo "$?"
+}
+
+# Print the body of a shell function, relying on the closing brace being in
+# column 0 as it is throughout these scripts.
+extract_function() {
+  awk -v fn="$1" '
+    $0 ~ "^" fn "\\(\\) \\{" { inside = 1; next }
+    inside && /^\}/ { exit }
+    inside { print }
+  ' "$2"
+}
+
+# Service names declared in the management compose file, parsed without Docker.
+compose_services() {
+  awk '
+    /^services:[[:space:]]*$/ { in_services = 1; next }
+    /^[^[:space:]#]/ { in_services = 0 }
+    in_services && /^  [A-Za-z0-9._-]+:[[:space:]]*$/ {
+      gsub(/^  |:[[:space:]]*$/, "", $0)
+      print
+    }
+  ' "$1"
+}
+
+###################################################################################################################################################################################################
+#                                                                                                                                                                                                 #
+#                                                                                       Test Fixtures                                                                                             #
+#                                                                                                                                                                                                 #
+###################################################################################################################################################################################################
+
+FIXTURE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/nomad-artifact-tests.XXXXXX")"
+trap 'rm -rf "${FIXTURE_ROOT}"' EXIT
+
+host_os="$(awk -F= '$1 == "ID" { gsub(/^"|"$/, "", $2); print $2; exit }' /etc/os-release 2>/dev/null || true)"
+host_version="$(awk -F= '$1 == "VERSION_ID" { gsub(/^"|"$/, "", $2); print $2; exit }' /etc/os-release 2>/dev/null || true)"
+host_arch="$(dpkg --print-architecture 2>/dev/null || uname -m)"
+case "${host_arch}" in
+  x86_64|amd64) host_arch='amd64' ;;
+  aarch64|arm64) host_arch='arm64' ;;
+esac
+
+if [[ -z "${host_os}" || -z "${host_version}" ]]; then
+  echo "These tests need a Linux host with /etc/os-release." >&2
+  echo "Run them in a container, for example:" >&2
+  echo "  docker run --rm --network none -v \"\$PWD:/repo\" -w /repo ubuntu:26.04 \\" >&2
+  echo "    bash install/tests/offline_artifact_tests.sh" >&2
+  exit 2
+fi
+
+# Build a structurally complete bundle. Contents are placeholders — validation
+# checks presence, checksums and the manifest, not package internals.
+make_fixture_bundle() {
+  local bundle="$1"
+  local os="${2:-${host_os}}"
+  local version="${3:-${host_version}}"
+  local arch="${4:-${host_arch}}"
+  local format="${5:-1}"
+
+  mkdir -p "${bundle}/packages/apt" "${bundle}/images" "${bundle}/payload/nomad"
+
+  echo 'placeholder' > "${bundle}/install_nomad.sh"
+  printf 'Package: docker-ce\n' > "${bundle}/packages/apt/Packages"
+  gzip -9c "${bundle}/packages/apt/Packages" > "${bundle}/packages/apt/Packages.gz"
+  echo 'placeholder' > "${bundle}/packages/apt/docker-ce.deb"
+  printf 'mysql:8.0\nredis:7-alpine\n' > "${bundle}/images/core-images.txt"
+  echo 'placeholder' > "${bundle}/images/core-images.tar"
+
+  cp "${COMPOSE_FILE}" "${bundle}/payload/nomad/management_compose.yaml"
+  local service
+  {
+    echo 'services:'
+    while IFS= read -r service; do
+      echo "  ${service}:"
+      echo '    pull_policy: never'
+    done < <(compose_services "${COMPOSE_FILE}")
+  } > "${bundle}/payload/nomad/compose.artifact.yml"
+
+  local name
+  for name in start_nomad.sh stop_nomad.sh update_nomad.sh; do
+    echo 'placeholder' > "${bundle}/payload/nomad/${name}"
+  done
+
+  cat > "${bundle}/manifest" <<EOF
+BUNDLE_FORMAT_VERSION=${format}
+NOMAD_COMMIT=0123456789abcdef0123456789abcdef01234567
+TARGET_OS=${os}
+TARGET_VERSION=${version}
+TARGET_ARCH=${arch}
+WITH_NVIDIA_TOOLKIT=1
+CREATED_AT_UTC=2026-08-14T00:00:00Z
+EOF
+
+  (
+    cd "${bundle}" || exit 1
+    find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  )
+}
+
+VALID_BUNDLE="${FIXTURE_ROOT}/valid"
+make_fixture_bundle "${VALID_BUNDLE}"
+
+###################################################################################################################################################################################################
+#                                                                                                                                                                                                 #
+#                                                                                            Tests                                                                                                #
+#                                                                                                                                                                                                 #
+###################################################################################################################################################################################################
+
+echo ''
+echo '# Argument and environment parsing'
+
+assert_eq 'true' \
+  "$(installer_eval "parse_installer_args --artifacts '${VALID_BUNDLE}'; echo \"\${artifact_mode}\"")" \
+  '--artifacts PATH enables artifact mode'
+
+assert_eq 'true' \
+  "$(installer_eval "parse_installer_args --artifacts='${VALID_BUNDLE}'; echo \"\${artifact_mode}\"")" \
+  '--artifacts=PATH enables artifact mode'
+
+assert_eq 'true' \
+  "$(NOMAD_ARTIFACT_PATH="${VALID_BUNDLE}" installer_eval 'parse_installer_args; echo "${artifact_mode}"')" \
+  'NOMAD_ARTIFACT_PATH enables artifact mode'
+
+mkdir -p "${FIXTURE_ROOT}/from-env"
+assert_eq "${VALID_BUNDLE}" \
+  "$(NOMAD_ARTIFACT_PATH="${FIXTURE_ROOT}/from-env" installer_eval \
+    "parse_installer_args --artifacts '${VALID_BUNDLE}'; echo \"\${NOMAD_ARTIFACT_PATH}\"")" \
+  'command line argument wins over NOMAD_ARTIFACT_PATH'
+
+assert_eq 'false' \
+  "$(installer_eval 'parse_installer_args; echo "${artifact_mode}"')" \
+  'no artifact path leaves artifact mode disabled (online install unchanged)'
+
+assert_eq "${VALID_BUNDLE}/payload/nomad" \
+  "$(installer_eval "parse_installer_args --artifacts '${VALID_BUNDLE}'; echo \"\${artifact_payload_dir}\"")" \
+  'artifact sub-paths are derived from the bundle root'
+
+assert_eq '1' "$(installer_status 'parse_installer_args --artifacts')" \
+  '--artifacts without a value fails'
+
+assert_eq '1' "$(installer_status 'parse_installer_args --artifacts=')" \
+  '--artifacts= with an empty value fails'
+
+assert_eq '1' "$(installer_status 'parse_installer_args --not-a-real-flag')" \
+  'unknown option fails'
+
+assert_eq '1' "$(installer_status "parse_installer_args --artifacts '${FIXTURE_ROOT}/does-not-exist'")" \
+  'missing artifact directory fails'
+
+assert_eq '0' "$(installer_status 'parse_installer_args --help')" \
+  '--help exits successfully'
+
+echo ''
+echo '# Bundle validation'
+
+assert_eq '0' \
+  "$(installer_status "parse_installer_args --artifacts '${VALID_BUNDLE}'; validate_artifact_bundle")" \
+  'a complete, matching bundle validates'
+
+corrupt_bundle="${FIXTURE_ROOT}/corrupt"
+make_fixture_bundle "${corrupt_bundle}"
+echo 'tampered' >> "${corrupt_bundle}/images/core-images.tar"
+assert_eq '1' \
+  "$(installer_status "parse_installer_args --artifacts '${corrupt_bundle}'; validate_artifact_bundle")" \
+  'a bundle failing checksum verification is rejected'
+
+# Pointing --artifacts at a source checkout instead of a bundle is a common
+# mistake and must produce a specific, actionable message.
+not_a_bundle="${FIXTURE_ROOT}/not-a-bundle"
+mkdir -p "${not_a_bundle}"
+cp "${INSTALLER}" "${not_a_bundle}/install_nomad.sh"
+cp "${COMPOSE_FILE}" "${not_a_bundle}/management_compose.yaml"
+not_a_bundle_output="$(installer_eval "parse_installer_args --artifacts '${not_a_bundle}'; validate_artifact_bundle" 2>&1)"
+assert_eq '1' \
+  "$(installer_status "parse_installer_args --artifacts '${not_a_bundle}'; validate_artifact_bundle")" \
+  'a directory that is not a bundle is rejected'
+assert_contains "${not_a_bundle_output}" 'is not an offline artifact bundle' \
+  'a non-bundle directory gets a specific error, not a missing-file list'
+assert_contains "${not_a_bundle_output}" 'build_offline_bundle.sh' \
+  'the non-bundle error tells the user how to build one'
+
+no_sums_bundle="${FIXTURE_ROOT}/no-sums"
+make_fixture_bundle "${no_sums_bundle}"
+rm -f "${no_sums_bundle}/SHA256SUMS"
+assert_eq '1' \
+  "$(installer_status "parse_installer_args --artifacts '${no_sums_bundle}'; validate_artifact_bundle")" \
+  'a bundle without SHA256SUMS is rejected'
+
+for missing in payload/nomad/compose.artifact.yml images/core-images.tar packages/apt/Packages.gz payload/nomad/update_nomad.sh; do
+  incomplete="${FIXTURE_ROOT}/incomplete-$(echo "${missing}" | tr '/.' '--')"
+  make_fixture_bundle "${incomplete}"
+  rm -f "${incomplete}/${missing}"
+  assert_eq '1' \
+    "$(installer_status "parse_installer_args --artifacts '${incomplete}'; validate_artifact_bundle")" \
+    "a bundle missing ${missing} is rejected"
+done
+
+incomplete_manifest="${FIXTURE_ROOT}/manifest-incomplete"
+make_fixture_bundle "${incomplete_manifest}"
+grep -v '^TARGET_ARCH=' "${incomplete_manifest}/manifest" > "${incomplete_manifest}/manifest.tmp"
+mv "${incomplete_manifest}/manifest.tmp" "${incomplete_manifest}/manifest"
+(cd "${incomplete_manifest}" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
+assert_eq '1' \
+  "$(installer_status "parse_installer_args --artifacts '${incomplete_manifest}'; validate_artifact_bundle")" \
+  'a manifest missing TARGET_ARCH is rejected'
+
+wrong_format="${FIXTURE_ROOT}/wrong-format"
+make_fixture_bundle "${wrong_format}" "${host_os}" "${host_version}" "${host_arch}" '99'
+assert_eq '1' \
+  "$(installer_status "parse_installer_args --artifacts '${wrong_format}'; validate_artifact_bundle")" \
+  'an unsupported bundle format version is rejected'
+
+wrong_os="${FIXTURE_ROOT}/wrong-os"
+make_fixture_bundle "${wrong_os}" 'definitely-not-this-os'
+assert_eq '1' \
+  "$(installer_status "parse_installer_args --artifacts '${wrong_os}'; validate_artifact_bundle")" \
+  'an OS mismatch is rejected'
+
+wrong_version="${FIXTURE_ROOT}/wrong-version"
+make_fixture_bundle "${wrong_version}" "${host_os}" '0.00'
+assert_eq '1' \
+  "$(installer_status "parse_installer_args --artifacts '${wrong_version}'; validate_artifact_bundle")" \
+  'an OS version mismatch is rejected'
+
+wrong_arch="${FIXTURE_ROOT}/wrong-arch"
+make_fixture_bundle "${wrong_arch}" "${host_os}" "${host_version}" 'sparc64'
+assert_eq '1' \
+  "$(installer_status "parse_installer_args --artifacts '${wrong_arch}'; validate_artifact_bundle")" \
+  'an architecture mismatch is rejected'
+
+assert_eq 'amd64' "$(installer_eval 'normalize_arch x86_64')" 'x86_64 normalizes to amd64'
+assert_eq 'arm64' "$(installer_eval 'normalize_arch aarch64')" 'aarch64 normalizes to arm64'
+
+# The manifest must be read as data. Proving it is never sourced: a manifest
+# holding shell syntax must not execute it.
+hostile="${FIXTURE_ROOT}/hostile-manifest"
+make_fixture_bundle "${hostile}"
+printf 'EVIL=$(touch %s/pwned)\n' "${FIXTURE_ROOT}" >> "${hostile}/manifest"
+(cd "${hostile}" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
+installer_eval "parse_installer_args --artifacts '${hostile}'; validate_artifact_bundle" > /dev/null 2>&1
+if [[ -e "${FIXTURE_ROOT}/pwned" ]]; then
+  fail 'manifest is parsed as data, never sourced' 'manifest contents were executed'
+else
+  pass 'manifest is parsed as data, never sourced'
+fi
+
+echo ''
+echo '# Local APT repository isolation'
+
+apt_body="$(extract_function install_packages_from_artifacts "${INSTALLER}")"
+
+for opt in \
+  'Dir::Etc::sourcelist=' \
+  'Dir::Etc::sourceparts=-' \
+  'APT::Get::List-Cleanup=0' \
+  'Acquire::Retries=0'
+do
+  assert_contains "${apt_body}" "${opt}" "artifact APT invocation sets ${opt}"
+done
+
+assert_contains "${apt_body}" 'deb [trusted=yes] file:' \
+  'artifact APT source points at a local file: repository'
+
+apt_invocations="$(echo "${apt_body}" | grep -c 'apt-get' || true)"
+isolated_invocations="$(echo "${apt_body}" | grep 'apt-get' | grep -c '"${apt_opts\[@\]}"' || true)"
+assert_eq "${apt_invocations}" "${isolated_invocations}" \
+  'every apt-get invocation in artifact mode uses the isolation options'
+
+echo ''
+echo '# Fail-closed: no network acquisition in artifact code paths'
+
+artifact_functions=(
+  validate_artifact_bundle
+  install_packages_from_artifacts
+  setup_nvidia_container_toolkit_from_artifacts
+  copy_artifact_payload_file
+  copy_helper_scripts_from_artifacts
+  copy_management_compose_file_from_artifacts
+  load_artifact_images
+  seed_artifact_content
+  start_management_containers
+)
+
+for fn in "${artifact_functions[@]}"; do
+  body="$(extract_function "${fn}" "${INSTALLER}")"
+  if [[ -z "${body}" ]]; then
+    fail "${fn} exists in the installer" 'function not found'
+    continue
+  fi
+  # Comments may legitimately describe the online path, so only executable
+  # lines are scanned.
+  offenders="$(echo "${body}" | grep -v '^[[:space:]]*#' \
+    | grep -nE 'https?://|\bwget\b|curl[[:space:]]+-|docker[[:space:]]+(compose[[:space:]]+)?pull|get\.docker\.com' || true)"
+  if [[ -z "${offenders}" ]]; then
+    pass "${fn} performs no network acquisition"
+  else
+    fail "${fn} performs no network acquisition" "${offenders}"
+  fi
+done
+
+echo ''
+echo '# Compose startup behaviour'
+
+# Intercept the privileged call so the compose command line can be inspected.
+compose_stub='sudo() { echo "SUDO $*"; }; NOMAD_DIR=/opt/project-nomad'
+
+artifact_start="$(installer_eval "${compose_stub}; parse_installer_args --artifacts '${VALID_BUNDLE}'; start_management_containers" 2>&1)"
+assert_contains "${artifact_start}" '--pull never' 'artifact startup passes --pull never'
+assert_contains "${artifact_start}" '-f /opt/project-nomad/compose.artifact.yml' \
+  'artifact startup layers the generated compose override'
+assert_not_contains "${artifact_start}" 'docker compose pull' 'artifact startup never pulls'
+
+online_start="$(installer_eval "${compose_stub}; start_management_containers" 2>&1)"
+assert_not_contains "${online_start}" '--pull never' 'online startup is unchanged (no --pull never)'
+assert_not_contains "${online_start}" 'compose.artifact.yml' 'online startup does not reference the override'
+assert_contains "${online_start}" 'SUDO docker compose -p project-nomad -f /opt/project-nomad/compose.yml up -d' \
+  'online startup keeps its original compose command'
+
+echo ''
+echo '# Acquisition dispatch'
+
+dispatch_stub='download_helper_scripts() { echo ONLINE_HELPERS; }; copy_helper_scripts_from_artifacts() { echo ARTIFACT_HELPERS; }; download_management_compose_file() { echo ONLINE_COMPOSE; }; copy_management_compose_file_from_artifacts() { echo ARTIFACT_COMPOSE; }; configure_management_compose_file() { echo CONFIGURED; }'
+
+assert_eq 'ONLINE_HELPERS' \
+  "$(installer_eval "${dispatch_stub}; setup_helper_scripts")" \
+  'helper scripts are downloaded in online mode'
+
+assert_eq 'ARTIFACT_HELPERS' \
+  "$(installer_eval "${dispatch_stub}; parse_installer_args --artifacts '${VALID_BUNDLE}'; setup_helper_scripts")" \
+  'helper scripts are copied from the bundle in artifact mode'
+
+assert_eq 'ONLINE_COMPOSE
+CONFIGURED' \
+  "$(installer_eval "${dispatch_stub}; setup_management_compose_file")" \
+  'online compose acquisition still runs the shared configuration step'
+
+assert_eq 'ARTIFACT_COMPOSE
+CONFIGURED' \
+  "$(installer_eval "${dispatch_stub}; parse_installer_args --artifacts '${VALID_BUNDLE}'; setup_management_compose_file")" \
+  'artifact compose acquisition runs the same shared configuration step'
+
+echo ''
+echo '# Host without a LAN address'
+
+no_ip_stub='hostname() { :; }'
+
+assert_eq 'localhost' \
+  "$(installer_eval "${no_ip_stub}; parse_installer_args --artifacts '${VALID_BUNDLE}'; get_local_ip > /dev/null; echo \"\${local_ip_address}\"")" \
+  'artifact mode falls back to localhost when there is no LAN address'
+
+assert_eq 'false' \
+  "$(installer_eval "${no_ip_stub}; parse_installer_args --artifacts '${VALID_BUNDLE}'; get_local_ip > /dev/null; echo \"\${has_lan_address}\"")" \
+  'no LAN address is recorded when none exists'
+
+assert_eq '1' "$(installer_status "${no_ip_stub}; get_local_ip")" \
+  'online mode still fails when no LAN address can be determined'
+
+assert_eq 'true' \
+  "$(installer_eval 'hostname() { echo "192.168.1.50 10.0.0.1"; }; get_local_ip > /dev/null; echo "${local_ip_address} ${has_lan_address}"' | awk '{print $2}')" \
+  'a real LAN address is still detected normally'
+
+success_no_lan="$(installer_eval "${no_ip_stub}; parse_installer_args --artifacts '${VALID_BUNDLE}'; get_local_ip > /dev/null; success_message")"
+assert_not_contains "${success_no_lan}" ' or http://' \
+  'no LAN URL is advertised when the host has no LAN address'
+
+success_with_lan="$(installer_eval 'hostname() { echo 192.168.1.50; }; get_local_ip > /dev/null; success_message')"
+assert_contains "${success_with_lan}" 'http://192.168.1.50:8080' \
+  'the LAN URL is still advertised when a LAN address exists'
+
+echo ''
+echo '# Bundle builder'
+
+builder_eval() {
+  NOMAD_BUNDLE_LIB_ONLY='1' bash -c "source '${BUILDER}'; $1"
+}
+
+override_out="${FIXTURE_ROOT}/override.yml"
+builder_eval "write_pull_never_override '${override_out}' admin mysql redis" > /dev/null 2>&1
+override_content="$(cat "${override_out}" 2>/dev/null || true)"
+assert_contains "${override_content}" 'pull_policy: never' 'builder writes pull_policy: never'
+for service in admin mysql redis; do
+  assert_contains "${override_content}" "  ${service}:" "builder override includes service ${service}"
+done
+
+builder_eval "write_pull_never_override '${FIXTURE_ROOT}/empty.yml'" > /dev/null 2>&1
+assert_eq '1' "$?" 'builder refuses to write an override with no services'
+
+# Every service in the canonical compose file must end up in the override, or
+# that service would still contact a registry on the target.
+mapfile -t all_services < <(compose_services "${COMPOSE_FILE}")
+if [[ ${#all_services[@]} -eq 0 ]]; then
+  fail 'management compose services were discovered' 'no services parsed'
+else
+  pass "management compose services were discovered (${#all_services[@]})"
+  full_override="${FIXTURE_ROOT}/full-override.yml"
+  builder_eval "write_pull_never_override '${full_override}' ${all_services[*]}" > /dev/null 2>&1
+  override_service_count="$(grep -c 'pull_policy: never' "${full_override}" || true)"
+  assert_eq "${#all_services[@]}" "${override_service_count}" \
+    'generated override covers every management service'
+  for service in "${all_services[@]}"; do
+    assert_contains "$(cat "${full_override}")" "  ${service}:" \
+      "generated override covers ${service}"
+  done
+fi
+
+# The builder's package set must stay in step with the installer's, or the
+# bundle will be missing something artifact mode then tries to install.
+builder_packages="$(awk '/^ARTIFACT_PACKAGES=\(/{p=1;next} p&&/^\)/{exit} p{gsub(/[[:space:]]/,"");print}' "${BUILDER}")"
+installer_packages="$(echo "${apt_body}" | awk '/local packages=\(/{p=1;next} p&&/^[[:space:]]*\)/{exit} p{gsub(/[[:space:]]/,"");print}')"
+assert_eq "${builder_packages}" "${installer_packages}" \
+  'builder and installer agree on the host package list'
+
+# Docker must be acquired from the bundle, never from the network, or an
+# offline target has no container runtime at all.
+for docker_package in docker-ce docker-ce-cli containerd.io docker-compose-plugin; do
+  assert_contains "${builder_packages}" "${docker_package}" \
+    "bundle includes ${docker_package} for offline Docker installation"
+done
+
+echo ''
+echo '# Re-running over an existing install (offline update)'
+
+existing_dir="${FIXTURE_ROOT}/existing-install"
+mkdir -p "${existing_dir}"
+cat > "${existing_dir}/compose.yml" <<'EOF'
+services:
+  admin:
+    environment:
+      - APP_KEY=EXISTINGAPPKEY123456
+      - URL=http://192.168.1.77:8080
+      - DB_PASSWORD=EXISTINGDBPASS
+  mysql:
+    environment:
+      - MYSQL_ROOT_PASSWORD=EXISTINGROOTPASS
+      - MYSQL_PASSWORD=EXISTINGDBPASS
+EOF
+
+detect_snippet="NOMAD_DIR='${existing_dir}'; parse_installer_args --artifacts '${VALID_BUNDLE}'; detect_existing_installation"
+
+assert_eq 'true' \
+  "$(installer_eval "${detect_snippet}; echo \"\${existing_install}\"")" \
+  'an existing installation is detected from its compose file'
+
+assert_eq 'EXISTINGAPPKEY123456' \
+  "$(installer_eval "${detect_snippet}; echo \"\${existing_app_key}\"")" \
+  'the existing APP_KEY is recovered'
+
+assert_eq 'EXISTINGDBPASS' \
+  "$(installer_eval "${detect_snippet}; echo \"\${existing_db_password}\"")" \
+  'the existing database password is recovered'
+
+assert_eq 'EXISTINGROOTPASS' \
+  "$(installer_eval "${detect_snippet}; echo \"\${existing_db_root_password}\"")" \
+  'the existing database root password is recovered'
+
+assert_eq 'http://192.168.1.77:8080' \
+  "$(installer_eval "${detect_snippet}; echo \"\${existing_url}\"")" \
+  'the existing access URL is recovered'
+
+# A fresh install must not be mistaken for an update.
+fresh_dir="${FIXTURE_ROOT}/fresh-install"
+mkdir -p "${fresh_dir}"
+assert_eq 'false' \
+  "$(installer_eval "NOMAD_DIR='${fresh_dir}'; parse_installer_args --artifacts '${VALID_BUNDLE}'; detect_existing_installation; echo \"\${existing_install}\"")" \
+  'a directory with no compose file is treated as a fresh install'
+
+placeholder_dir="${FIXTURE_ROOT}/placeholder-install"
+mkdir -p "${placeholder_dir}"
+printf 'services:\n  admin:\n    environment:\n      - APP_KEY=replaceme\n' > "${placeholder_dir}/compose.yml"
+assert_eq 'false' \
+  "$(installer_eval "NOMAD_DIR='${placeholder_dir}'; parse_installer_args --artifacts '${VALID_BUNDLE}'; detect_existing_installation; echo \"\${existing_install}\"")" \
+  'an unconfigured compose file is not treated as an existing install'
+
+# The critical guarantee: updating must not wipe the database directory.
+update_dir="${FIXTURE_ROOT}/update-preserves"
+mkdir -p "${update_dir}/mysql"
+cp "${existing_dir}/compose.yml" "${update_dir}/compose.yml"
+echo 'user data' > "${update_dir}/mysql/ibdata1"
+installer_eval "NOMAD_DIR='${update_dir}'; parse_installer_args --artifacts '${VALID_BUNDLE}'; sudo() { :; }; detect_existing_installation; configure_management_compose_file" > /dev/null 2>&1
+if [[ -f "${update_dir}/mysql/ibdata1" ]]; then
+  pass 'updating an existing install does not delete the MySQL data directory'
+else
+  fail 'updating an existing install does not delete the MySQL data directory' 'data directory was removed'
+fi
+
+updated_compose="$(cat "${update_dir}/compose.yml")"
+assert_contains "${updated_compose}" 'APP_KEY=EXISTINGAPPKEY123456' \
+  'the existing APP_KEY is carried into the updated compose file'
+assert_contains "${updated_compose}" 'MYSQL_PASSWORD=EXISTINGDBPASS' \
+  'the existing database password is carried into the updated compose file'
+
+# Online mode keeps its original behaviour, including the deliberate wipe.
+online_dir="${FIXTURE_ROOT}/online-install"
+mkdir -p "${online_dir}/mysql"
+cp "${existing_dir}/compose.yml" "${online_dir}/compose.yml"
+online_configure="$(installer_eval "NOMAD_DIR='${online_dir}'; detect_existing_installation; configure_management_compose_file" 2>&1)"
+assert_contains "${online_configure}" 'Removing existing MySQL data directory' \
+  'online mode still resets the database directory as before'
+
+echo ''
+echo '# Removable media metadata (FAT/exFAT AppleDouble sidecars)'
+
+# A bundle carried on FAT/exFAT collects "._name" sidecars from macOS. They must
+# never be treated as bundle content, or checksums fail and ._core-images.tar
+# gets fed to docker load.
+appledouble_bundle="${FIXTURE_ROOT}/appledouble"
+make_fixture_bundle "${appledouble_bundle}"
+printf 'mac metadata\n' > "${appledouble_bundle}/images/._core-images.tar"
+printf 'mac metadata\n' > "${appledouble_bundle}/._install_nomad.sh"
+printf 'mac metadata\n' > "${appledouble_bundle}/packages/apt/._docker-ce.deb"
+assert_eq '0' \
+  "$(installer_status "parse_installer_args --artifacts '${appledouble_bundle}'; validate_artifact_bundle")" \
+  'a bundle still validates when the OS adds AppleDouble sidecars'
+
+assert_contains "$(extract_function load_artifact_images "${INSTALLER}")" '._*' \
+  'image loading skips AppleDouble sidecars that match *.tar'
+
+checksum_body="$(extract_function write_checksums "${BUILDER}")"
+assert_contains "${checksum_body}" "! -name '._*'" \
+  'checksum generation excludes AppleDouble sidecars'
+assert_contains "${checksum_body}" "-name '.DS_Store'" \
+  'checksum generation excludes .DS_Store'
+
+echo ''
+echo '# Docker-only build entry point'
+
+DOCKER_WRAPPER="${INSTALL_DIR}/build_offline_bundle_docker.sh"
+
+if [[ -f "${DOCKER_WRAPPER}" ]]; then
+  pass 'the Docker build entry point exists'
+  wrapper_src="$(cat "${DOCKER_WRAPPER}")"
+
+  assert_contains "${wrapper_src}" '${DOCKER_SOCKET}:/var/run/docker.sock' \
+    'wrapper mounts the Docker socket so nested builds reach the host daemon'
+  assert_contains "${wrapper_src}" '-v "${path}:${path}"' \
+    'wrapper mounts host paths at identical locations inside the container'
+  assert_contains "${wrapper_src}" 'exec bash install/build_offline_bundle.sh "$@"' \
+    'wrapper delegates to the real builder with arguments passed through'
+
+  # The whole point is that the host needs nothing but Docker, so the wrapper
+  # must not depend on host tooling the builder needs.
+  wrapper_code="$(echo "${wrapper_src}" | grep -v '^[[:space:]]*#')"
+  for host_tool in sha256sum dpkg-scanpackages; do
+    assert_not_contains "${wrapper_code}" "${host_tool}" \
+      "wrapper does not require ${host_tool} on the host"
+  done
+
+  # Options that name a path must be resolved and mounted, or the nested
+  # containers cannot see them.
+  for path_option in '--output' '--repo' '--content-dir' '--extra-image-archive' '--extra-image-list'; do
+    assert_contains "${wrapper_code}" "${path_option}" \
+      "wrapper resolves and mounts ${path_option}"
+  done
+
+  wrapper_eval() {
+    NOMAD_BUILDER_LIB_ONLY='1' bash -c "source '${DOCKER_WRAPPER}'; $1"
+  }
+
+  # Output location selection. The menu offers the current location first, then
+  # connected removable drives, then home.
+  assert_eq "${PWD}/dist" \
+    "$(printf '1\n' | wrapper_eval 'OUTPUT_CHOICE=""; prompt_for_output_dir >/dev/null 2>&1; echo "${OUTPUT_CHOICE}"')" \
+    'choosing 1 writes the bundle where the build is running from'
+
+  assert_eq "${PWD}/dist" \
+    "$(printf '\n' | wrapper_eval 'OUTPUT_CHOICE=""; prompt_for_output_dir >/dev/null 2>&1; echo "${OUTPUT_CHOICE}"')" \
+    'pressing enter accepts the default location'
+
+  assert_eq '/tmp/nomad-custom-target' \
+    "$(printf 'c\n/tmp/nomad-custom-target\n' | wrapper_eval 'OUTPUT_CHOICE=""; prompt_for_output_dir >/dev/null 2>&1; echo "${OUTPUT_CHOICE}"')" \
+    'a custom path can be entered'
+
+  assert_eq "${PWD}/dist" \
+    "$(printf '99\nnonsense\n1\n' | wrapper_eval 'OUTPUT_CHOICE=""; prompt_for_output_dir >/dev/null 2>&1; echo "${OUTPUT_CHOICE}"')" \
+    'invalid input re-prompts rather than picking something arbitrary'
+
+  menu_output="$(printf '1\n' | wrapper_eval 'prompt_for_output_dir 2>&1' || true)"
+  assert_contains "${menu_output}" 'enter a custom path' 'the menu offers a custom path'
+  assert_contains "${menu_output}" '[default]' 'the menu marks a default choice'
+
+  # Unattended runs must never block on stdin.
+  assert_eq "${PWD}/dist" \
+    "$(printf '' | wrapper_eval 'OUTPUT_CHOICE=""; choose_output_dir >/dev/null 2>&1; echo "${OUTPUT_CHOICE}"')" \
+    'a non-interactive stdin uses the default without prompting'
+
+  assert_eq "${PWD}/dist" \
+    "$(NOMAD_NO_PROMPT=1 wrapper_eval 'OUTPUT_CHOICE=""; choose_output_dir >/dev/null 2>&1; echo "${OUTPUT_CHOICE}"' < /dev/null)" \
+    'NOMAD_NO_PROMPT skips the prompt'
+
+  assert_contains "${wrapper_code}" '--no-prompt' 'wrapper accepts --no-prompt'
+  assert_contains "${wrapper_code}" '! -t 0' 'wrapper treats a non-TTY as non-interactive'
+else
+  fail 'the Docker build entry point exists' "${DOCKER_WRAPPER} not found"
+fi
+
+echo ''
+echo '# Online installation path is untouched'
+
+for fn in ensure_dependencies_installed ensure_docker_installed download_helper_scripts download_management_compose_file setup_nvidia_container_toolkit; do
+  if [[ -n "$(extract_function "${fn}" "${INSTALLER}")" ]]; then
+    pass "online function ${fn} is still present"
+  else
+    fail "online function ${fn} is still present" 'function not found'
+  fi
+done
+
+assert_contains "$(extract_function download_management_compose_file "${INSTALLER}")" \
+  'curl -fsSL "$MANAGEMENT_COMPOSE_FILE_URL"' \
+  'online compose download still uses the original curl call'
+
+assert_contains "$(extract_function ensure_docker_installed "${INSTALLER}")" \
+  'https://get.docker.com' \
+  'online Docker installation still uses the convenience script'
+
+###################################################################################################################################################################################################
+
+echo ''
+echo "-------------------------------------------------"
+echo "  passed: ${pass_count}   failed: ${fail_count}"
+echo "-------------------------------------------------"
+
+[[ "${fail_count}" -eq 0 ]] || exit 1

--- a/install/verify_offline_bundle.sh
+++ b/install/verify_offline_bundle.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Project NOMAD Offline Artifact Bundle Verifier
+
+###################################################################################################################################################################################################
+#
+# Inspects and verifies an offline artifact bundle without installing anything.
+#
+# Useful before transferring a bundle to removable media, and on the target
+# before running the installer. Runs entirely offline.
+#
+# Usage:
+#   ./verify_offline_bundle.sh [/path/to/bundle]
+#
+###################################################################################################################################################################################################
+
+set -Eeuo pipefail
+
+RESET='\033[0m'
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+
+die() {
+  echo -e "${RED}#${RESET} $*" >&2
+  exit 1
+}
+
+BUNDLE="${1:-.}"
+BUNDLE="$(cd -- "${BUNDLE}" 2>/dev/null && pwd)" || die "Bundle directory not found: ${1:-.}"
+
+command -v sha256sum > /dev/null 2>&1 || die "sha256sum is required."
+
+manifest_get() {
+  local key="$1"
+  awk -F= -v wanted="${key}" '$1 == wanted { sub(/^[^=]*=/, "", $0); print; exit }' "${BUNDLE}/manifest"
+}
+
+# Same required set the installer enforces, so a bundle that passes here will
+# not fail validation on the target for a missing file.
+required_files=(
+  manifest
+  SHA256SUMS
+  install_nomad.sh
+  packages/apt/Packages
+  packages/apt/Packages.gz
+  images/core-images.txt
+  images/core-images.tar
+  payload/nomad/management_compose.yaml
+  payload/nomad/compose.artifact.yml
+  payload/nomad/start_nomad.sh
+  payload/nomad/stop_nomad.sh
+  payload/nomad/update_nomad.sh
+)
+
+for required_file in "${required_files[@]}"; do
+  [[ -f "${BUNDLE}/${required_file}" ]] || die "Bundle is incomplete. Missing: ${required_file}"
+done
+
+echo "Verifying checksums..."
+(cd "${BUNDLE}" && sha256sum -c SHA256SUMS > /dev/null) ||
+  die "Checksum verification failed — the bundle is corrupt or incomplete."
+
+# ! -name '._*' skips macOS AppleDouble sidecars left on FAT/exFAT media.
+deb_count="$(find "${BUNDLE}/packages/apt" -maxdepth 1 -name '*.deb' ! -name '._*' | wc -l | tr -d ' ')"
+[[ "${deb_count}" -gt 0 ]] || die "Bundle contains no .deb packages."
+
+image_count="$(grep -c '[^[:space:]]' "${BUNDLE}/images/core-images.txt" || true)"
+[[ "${image_count}" -gt 0 ]] || die "Bundle lists no management images."
+
+# Every service in the bundled compose file must appear in the pull-never
+# override, or that service would still try to reach a registry on the target.
+missing_overrides=''
+while IFS= read -r service; do
+  grep -qE "^[[:space:]]+${service}:[[:space:]]*$" "${BUNDLE}/payload/nomad/compose.artifact.yml" ||
+    missing_overrides="${missing_overrides} ${service}"
+done < <(awk '
+  /^services:[[:space:]]*$/ { in_services = 1; next }
+  /^[^[:space:]#]/ { in_services = 0 }
+  in_services && /^  [A-Za-z0-9._-]+:[[:space:]]*$/ {
+    gsub(/^  |:[[:space:]]*$/, "", $0)
+    print
+  }
+' "${BUNDLE}/payload/nomad/management_compose.yaml")
+
+[[ -z "${missing_overrides}" ]] ||
+  die "compose.artifact.yml is missing pull_policy overrides for:${missing_overrides}"
+
+echo ''
+printf 'Bundle format : %s\n' "$(manifest_get BUNDLE_FORMAT_VERSION)"
+printf 'NOMAD commit  : %s\n' "$(manifest_get NOMAD_COMMIT)"
+printf 'Target        : %s %s (%s)\n' \
+  "$(manifest_get TARGET_OS)" "$(manifest_get TARGET_VERSION)" "$(manifest_get TARGET_ARCH)"
+printf 'NVIDIA toolkit: %s\n' "$(manifest_get WITH_NVIDIA_TOOLKIT)"
+printf 'Created (UTC) : %s\n' "$(manifest_get CREATED_AT_UTC)"
+printf 'Packages      : %s .deb files\n' "${deb_count}"
+printf 'Images        : %s\n' "${image_count}"
+echo ''
+echo -e "${GREEN}#${RESET} Bundle verified. Checksums confirm transfer integrity, not publisher identity."


### PR DESCRIPTION
## Offline (air-gapped) installation

NOMAD is built to *run* without an internet connection, but installing one still
needed a connection: the installer downloads Docker, host packages, container
images and its own helper scripts. This adds **offline artifact mode** — build a
bundle once on a connected machine, carry it to the target on a USB drive, and
run the ordinary installer against it.

```bash
# On a connected build machine (needs only Docker):
./install/build_offline_bundle_docker.sh --target ubuntu:26.04 --output /media/usb/NOMAD

# On the disconnected target, from inside the bundle directory:
sudo bash ./install_nomad.sh --artifacts .
```

There is still only one installer. `install_nomad.sh` with no `--artifacts`
argument behaves exactly as it always has.

Full documentation: `admin/docs/offline-install.md`.

### What's in the bundle

Docker Engine/CLI/containerd/Buildx/Compose as `.deb` packages with their
dependency closure, every image referenced by `management_compose.yaml`, the
payload scripts, and the exact `install_nomad.sh` from the source commit.
Supply Depot app images can be added with `--with-apps`.

### Design notes for reviewers

- **Fail-closed.** Once an artifact path is given the installer never falls back
  to the network to fill a gap. A missing package, image, payload file, manifest
  field or checksum stops the install with an actionable error rather than
  producing a half-configured machine.
- **Host packages** install from a flat APT repo in the bundle through a
  temporary source that excludes the machine's own config (`Dir::Etc::sourceparts=-`,
  private `Dir::State::Lists`, `Acquire::Retries=0`), so the host's configured
  remotes take no part in dependency resolution — a missing dependency fails
  instead of quietly downloading.
- **Images** load with `docker load`. Because `management_compose.yaml`
  legitimately uses `pull_policy: always` for online installs, the builder
  generates a `compose.artifact.yml` overlay setting `pull_policy: never`. The
  canonical compose file is never rewritten just to make an offline install work.
- **Bundles are specific** to one OS, one version, one architecture. The builder
  resolves the closure inside a *pristine* container of the target release and
  then re-runs the install in a clean container with `--network none`; if the
  bundle can't satisfy its own package list offline, the build fails rather than
  handing you a bundle that breaks in the field.
- **Checksums are integrity, not provenance.** `SHA256SUMS` proves the bundle
  transferred intact; it is not a publisher signature.

---

## Making the Command Center usable air-gapped

Bundling the images was necessary but not sufficient — Easy Setup was unusable
on a disconnected host, which defeated the point, since the bundle had already
put the app images on disk. Two independent faults, fixed in the last commit.

### `GET /api/zim/wikipedia` returned 500 offline

The Wikipedia catalog was the only one of the wizard's four catalogs that threw
on a failed fetch instead of degrading — the curated categories, maps and
creator packs all go through `CollectionManifestService.getSpecWithFallback`
(refresh when reachable, cached copy when not). `ZimService` fetched the same
remote file directly and re-threw, so offline the wizard showed *"An internal
error occurred. Request failed with status 500"*.

Wikipedia now uses the same path. An air-gapped host that has never cached the
manifest gets an empty list and simply renders no Wikipedia selector.

The second, laxer schema for the same remote file (`wikipediaOptionsFileSchema`
alongside `wikipediaSpecSchema`) is deleted — having two schemas for one file is
what let the offline path diverge, and nothing else consumed it.

### Next and Complete Setup were dead offline

`canProceedToNextStep()` opened with `if (!isOnline) return false`, and Complete
Setup carried the same blanket gate. Stepping through a wizard needs nothing
from the network, and installing an app whose image is already in the local
Docker daemon works air-gapped because `createContainerPreflight` skips the pull
when the image is present.

The gate is now per-selection:

- `EasySetupController` reports which services have a local image (one
  `docker.listImages()` call via a new public `DockerService.listLocalImageTags()`).
  Offline, the capability cards offer exactly those and badge the rest *"Needs
  internet"* rather than queuing an install that would fail mid-pull.
- Map regions, content tiers, creator packs, AI models and Wikipedia are
  genuinely remote, so those steps stay unselectable — but they now explain why
  instead of leaving dead cards.
- Complete Setup is blocked offline only when a selection actually needs a
  download, and the message names which ones.

The offline decision logic is a pure module (`admin/inertia/lib/offline_setup.ts`)
with unit tests, rather than more conditionals threaded through the component.

---

## Known gaps (documented, not fixed here)

- **AMD hosts can't install Ollama offline.** The install path swaps to
  `ollama/ollama:rocm`, which `--with-apps` doesn't bundle — it carries the
  catalog's pinned tag. Workaround is `--extra-image-list`, or setting
  `ai.amdGpuAcceleration=false` to use the bundled CPU image. Fixing it properly
  means either widening the bundler or adding a CPU fallback to the GPU install
  path, which is a change to GPU install semantics.
- **Remote Ollama can't be configured from the wizard offline** — its checkbox
  lives behind the AI capability card, which is disabled without a local image.
  Settings → AI Assistant still covers it.
- **`update_nomad.sh` still needs the internet.** Update an air-gapped install
  by building a new bundle and re-running the installer against it.
- **Host NVIDIA drivers are not bundled** (kernel/DKMS matching is a materially
  larger problem).
- **Content is not covered.** ZIMs beyond the bundled Wikipedia sample, maps,
  Kolibri channels and AI models are fetched from remote catalogs at runtime.

---

## Testing

**Installer / bundle.** Covered by `install/tests/offline_artifact_tests.sh`, run
in CI by the new `.github/workflows/install-scripts.yml` (syntax check,
shellcheck, artifact-mode behaviour). The manual matrix exercised on a
disconnected Ubuntu 26.04 host with all egress denied is recorded under
[Verified offline behaviour](admin/docs/offline-install.md) — fresh install,
reboot with egress denied, re-running with a newer bundle, and installing
CyberChef / IT-Tools offline all work.

**Easy Setup offline logic.** 8 unit tests in
`admin/tests/unit/offline_setup.spec.ts`, all passing.

**Not yet run in this branch:** `tsc --noEmit` and the full `node ace test` suite
— the dependency install on the machine this was written on hadn't finished. The
admin changes are small and reviewed, but CI is the authority here; happy to
follow up on anything it flags.

The two Easy Setup faults were diagnosed by reading the offline code paths rather
than reproducing on hardware, so a sanity check on a real air-gapped host before
merge is worthwhile — specifically that the wizard now advances past step 1 and
that no 500 toast appears on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
