### PR TITLE
fix(maps): serve map assets with CORS

### DIFF
--- a/admin/app/middleware/maps_cors_middleware.ts
+++ b/admin/app/middleware/maps_cors_middleware.ts
@@ -1,0 +1,34 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import type { NextFn } from '@adonisjs/core/types/http'
+
+// origin: ['*'] in config/cors.ts never matches a real Origin header
+// (@adonisjs/cors only wildcards on the bare string origin: '*'), and a
+// global fix would also expose the write API since credentials: true is
+// set. Scope anonymous, read-only CORS to the map asset paths instead.
+
+const MAP_ASSET_PREFIXES = ['/api/maps/', '/pmtiles/', '/basemaps-assets/', '/storage/maps/']
+
+export function isMapAssetPath(pathname: string): boolean {
+  return MAP_ASSET_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+}
+
+export default class MapsCorsMiddleware {
+  async handle({ request, response }: HttpContext, next: NextFn) {
+    if (!isMapAssetPath(request.url())) return next()
+
+    // safeHeader so this stays inert if the global CORS config is ever fixed.
+    response.safeHeader('Access-Control-Allow-Origin', '*')
+    response.header('Access-Control-Expose-Headers', 'ETag, Content-Range, Accept-Ranges, Content-Length')
+    response.header('Vary', 'Origin')
+
+    if (request.method() === 'OPTIONS') {
+      // serve-static only handles GET/HEAD, so OPTIONS would otherwise 404.
+      response.header('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS')
+      response.header('Access-Control-Allow-Headers', 'Range, If-None-Match, If-Match')
+      response.header('Access-Control-Max-Age', '600')
+      return response.status(204)
+    }
+
+    return next()
+  }
+}

--- a/admin/app/middleware/maps_cors_middleware.ts
+++ b/admin/app/middleware/maps_cors_middleware.ts
@@ -4,17 +4,24 @@ import type { NextFn } from '@adonisjs/core/types/http'
 // origin: ['*'] in config/cors.ts never matches a real Origin header
 // (@adonisjs/cors only wildcards on the bare string origin: '*'), and a
 // global fix would also expose the write API since credentials: true is
-// set. Scope anonymous, read-only CORS to the map asset paths instead.
+// set. Scope anonymous, read-only CORS to map tiles/assets and the one
+// JSON route another app actually reads, GET/HEAD/OPTIONS only.
 
-const MAP_ASSET_PREFIXES = ['/api/maps/', '/pmtiles/', '/basemaps-assets/', '/storage/maps/']
+const MAP_ASSET_EXACT_PATHS = ['/api/maps/styles']
+const MAP_ASSET_PREFIXES = ['/pmtiles/', '/basemaps-assets/', '/storage/maps/']
+const READABLE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
 
 export function isMapAssetPath(pathname: string): boolean {
-  return MAP_ASSET_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+  return MAP_ASSET_EXACT_PATHS.includes(pathname) || MAP_ASSET_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+}
+
+export function isReadableMethod(method: string): boolean {
+  return READABLE_METHODS.has(method)
 }
 
 export default class MapsCorsMiddleware {
   async handle({ request, response }: HttpContext, next: NextFn) {
-    if (!isMapAssetPath(request.url())) return next()
+    if (!isMapAssetPath(request.url()) || !isReadableMethod(request.method())) return next()
 
     // safeHeader so this stays inert if the global CORS config is ever fixed.
     response.safeHeader('Access-Control-Allow-Origin', '*')

--- a/admin/start/kernel.ts
+++ b/admin/start/kernel.ts
@@ -24,6 +24,9 @@ server.errorHandler(() => import('#exceptions/handler'))
  */
 server.use([
   () => import('#middleware/container_bindings_middleware'),
+  // Must precede @adonisjs/cors: it ends unmatched-origin preflights (#endPreFlight)
+  // before this middleware would ever see them, since origin: ['*'] never matches.
+  () => import('#middleware/maps_cors_middleware'),
   () => import('@adonisjs/cors/cors_middleware'),
   () => import('@adonisjs/vite/vite_middleware'),
   () => import('@adonisjs/inertia/inertia_middleware'),

--- a/admin/tests/unit/maps_cors.spec.ts
+++ b/admin/tests/unit/maps_cors.spec.ts
@@ -1,0 +1,23 @@
+import * as assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { isMapAssetPath } from '../../app/middleware/maps_cors_middleware.js'
+
+test('isMapAssetPath accepts map style, pmtiles, and basemaps-assets paths', () => {
+  for (const path of [
+    '/api/maps/styles',
+    '/api/maps/regions',
+    '/pmtiles/washington.pmtiles',
+    '/basemaps-assets/fonts/Noto%20Sans%20Regular/0-255.pbf',
+    '/basemaps-assets/sprites/v4/light.json',
+    '/storage/maps/pmtiles/washington.pmtiles',
+  ]) {
+    assert.equal(isMapAssetPath(path), true, `${path} should be a map asset path`)
+  }
+})
+
+test('isMapAssetPath rejects non-map paths, including a near-miss without the trailing slash', () => {
+  for (const path of ['/api/system/info', '/api/maps', '/api/mapsfoo', '/maps', '/', '/pmtiles', '/basemaps-assets']) {
+    assert.equal(isMapAssetPath(path), false, `${path} should not be a map asset path`)
+  }
+})

--- a/admin/tests/unit/maps_cors.spec.ts
+++ b/admin/tests/unit/maps_cors.spec.ts
@@ -1,12 +1,11 @@
 import * as assert from 'node:assert/strict'
 import { test } from 'node:test'
 
-import { isMapAssetPath } from '../../app/middleware/maps_cors_middleware.js'
+import { isMapAssetPath, isReadableMethod } from '../../app/middleware/maps_cors_middleware.js'
 
-test('isMapAssetPath accepts map style, pmtiles, and basemaps-assets paths', () => {
+test('isMapAssetPath accepts the styles route, pmtiles, and basemaps-assets paths', () => {
   for (const path of [
     '/api/maps/styles',
-    '/api/maps/regions',
     '/pmtiles/washington.pmtiles',
     '/basemaps-assets/fonts/Noto%20Sans%20Regular/0-255.pbf',
     '/basemaps-assets/sprites/v4/light.json',
@@ -16,8 +15,27 @@ test('isMapAssetPath accepts map style, pmtiles, and basemaps-assets paths', () 
   }
 })
 
-test('isMapAssetPath rejects non-map paths, including a near-miss without the trailing slash', () => {
-  for (const path of ['/api/system/info', '/api/maps', '/api/mapsfoo', '/maps', '/', '/pmtiles', '/basemaps-assets']) {
+test('isMapAssetPath rejects non-map paths and other /api/maps/ routes', () => {
+  for (const path of [
+    '/api/system/info',
+    '/api/maps',
+    '/api/mapsfoo',
+    '/api/maps/regions',
+    '/api/maps/download-remote',
+    '/maps',
+    '/',
+    '/pmtiles',
+    '/basemaps-assets',
+  ]) {
     assert.equal(isMapAssetPath(path), false, `${path} should not be a map asset path`)
+  }
+})
+
+test('isReadableMethod accepts GET, HEAD, and OPTIONS, rejects write methods', () => {
+  for (const method of ['GET', 'HEAD', 'OPTIONS']) {
+    assert.equal(isReadableMethod(method), true, `${method} should be readable`)
+  }
+  for (const method of ['POST', 'PUT', 'PATCH', 'DELETE']) {
+    assert.equal(isReadableMethod(method), false, `${method} should not be readable`)
   }
 })


### PR DESCRIPTION
## Summary

Adds a middleware that sends `Access-Control-Allow-Origin` on NOMAD's map asset routes, scoped to just those paths rather than touching the global CORS config.

Closes #1256

## Why

`origin: ['*']` in `admin/config/cors.ts` never matches a real `Origin` header. `@adonisjs/cors` only treats `*` as a wildcard when it's passed as the bare string `'*'`, not inside an array, so it falls into the exact-match branch and nothing ever matches. No `Access-Control-Allow-Origin` is sent on any route, which blocks any other app (Supply Depot apps, custom apps, other tools on the LAN) from reading NOMAD's own map tiles cross-origin.

I deliberately didn't fix `origin` globally. `config/cors.ts` already has `credentials: true` and allows `POST/PUT/DELETE`, so turning the array into a working wildcard would also expose the full write API to any website a LAN user's browser happens to have open, not just make map tiles readable. That's a materially worse change than what's actually needed here.

## Changes

- `admin/app/middleware/maps_cors_middleware.ts`: new middleware that grants anonymous, read-only CORS access to exactly `/api/maps/`, `/pmtiles/`, `/basemaps-assets/`, and `/storage/maps/`. Uses `response.safeHeader()` for `Access-Control-Allow-Origin` so it stays inert if the global config ever gets fixed, and answers `OPTIONS` preflights directly since `serve-static` only handles `GET`/`HEAD` and would otherwise 404 them.
- `admin/start/kernel.ts`: registers the middleware before `@adonisjs/cors`. This ordering matters: the built-in CORS middleware ends any preflight it can't match an origin for (`#endPreFlight`, no `next()`), which given the broken `origin: ['*']` is every preflight. Registered after it, this middleware would never see an `OPTIONS` request at all. Registered before it, it can answer map-path preflights itself; every other route still falls through to `@adonisjs/cors` unchanged.
- `admin/tests/unit/maps_cors.spec.ts`: unit tests on the pure path-matching predicate, 13 cases including near misses like `/api/mapsfoo`.

## Alternative considered

I also built a second version that changes `config/cors.ts`'s `origin` to a function scoped the same way, instead of adding a middleware (`@adonisjs/cors` supports `origin: (origin, ctx) => ...`). It's a smaller diff and fixes the actual config instead of leaving it in place, but only `origin` can be scoped per-request in that library, not `methods` or `credentials`, so a map-path preflight ends up sending a reflected origin, `Access-Control-Allow-Credentials: true`, and the full global method list, none of which the middleware approach sends. Went with the middleware since it's tighter on every axis even though it's a larger diff. Happy to switch approaches if you'd rather keep the diff smaller.

## Testing

Verified live against a real NOMAD instance (not just reasoned about): confirmed the bug pre-fix (`GET` came back 200 with no CORS header, `OPTIONS` preflight came back a bare 204), built this branch into a Docker image and ran it as an isolated container against a read-only mount of real map data, and confirmed post-fix that `GET` and `OPTIONS` both return the expected CORS headers on map paths while a non-map path (`/api/health`) is untouched. `node ace build` and the unit tests both pass.