### PR TITLE
feat(AI): support API key for remote OpenAI-compatible endpoints

### DIFF
--- a/admin/app/controllers/ollama_controller.ts
+++ b/admin/app/controllers/ollama_controller.ts
@@ -225,13 +225,70 @@ export default class OllamaController {
 
   async remoteStatus() {
     const remoteUrl = await KVStore.getValue('ai.remoteOllamaUrl')
+    const apiKey = await KVStore.getValue('ai.remoteOllamaApiKey')
     if (!remoteUrl) {
       return { configured: false, connected: false }
     }
     try {
       const testResponse = await fetch(`${remoteUrl.replace(/\/$/, '')}/v1/models`, {
+        headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
         signal: AbortSignal.timeout(3000),
       })
+      return { configured: true, connected: testResponse.ok, hasApiKey: !!apiKey }
+    } catch {
+      return { configured: true, connected: false, hasApiKey: !!apiKey }
+    }
+  }
+
+  /**
+   * Saves the API key for the remote OpenAI-compatible endpoint. Kept separate
+   * from configureRemote so an already-configured URL can stay in place while
+   * the key is changed (or cleared) without re-running the URL connectivity
+   * test. Null/empty clears the key.
+   */
+  async configureRemoteApiKey({ request }: HttpContext) {
+    const apiKey: string | null = request.input('apiKey', null)
+
+    if (!apiKey || apiKey.trim() === '') {
+      await KVStore.clearValue('ai.remoteOllamaApiKey')
+      return { success: true, message: 'Remote API key cleared.' }
+    }
+
+    // Trim but do not sanitize further — keys are opaque and can contain any
+    // characters except whitespace at the ends.
+    await KVStore.setValue('ai.remoteOllamaApiKey', apiKey.trim())
+    return { success: true, message: 'Remote API key saved.' }
+  }
+
+  /**
+   * Connectivity test for the stored API key alone. Sends a chat request with
+   * the key to the /v1/chat/completions endpoint, which is the path that
+   * actually requires it for authenticated backends (a bare /v1/models probe
+   * can 200 without any key). Reuses the same model the chat page would use.
+   */
+  async remoteStatusApiKey() {
+    const remoteUrl = await KVStore.getValue('ai.remoteOllamaUrl')
+    const apiKey = await KVStore.getValue('ai.remoteOllamaApiKey')
+    if (!remoteUrl || !apiKey) {
+      return { configured: false, connected: false }
+    }
+    try {
+      const testResponse = await fetch(
+        `${remoteUrl.replace(/\/$/, '')}/v1/chat/completions`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({
+            model: 'gpt-4o-mini',
+            messages: [{ role: 'user', content: 'ping' }],
+            max_tokens: 1,
+          }),
+          signal: AbortSignal.timeout(5000),
+        }
+      )
       return { configured: true, connected: testResponse.ok }
     } catch {
       return { configured: true, connected: false }
@@ -240,6 +297,7 @@ export default class OllamaController {
 
   async configureRemote({ request, response }: HttpContext) {
     const remoteUrl: string | null = request.input('remoteUrl', null)
+    const apiKey: string | null = request.input('apiKey', null)
 
     const ollamaService = await Service.query().where('service_name', SERVICE_NAMES.OLLAMA).first()
     if (!ollamaService) {
@@ -251,6 +309,7 @@ export default class OllamaController {
     // the service marked installed. Otherwise fall back to uninstalled.
     if (!remoteUrl || remoteUrl.trim() === '') {
       await KVStore.clearValue('ai.remoteOllamaUrl')
+      await KVStore.clearValue('ai.remoteOllamaApiKey')
       const hasLocalContainer = await this._startLocalOllamaContainerIfExists()
       ollamaService.installed = hasLocalContainer
       ollamaService.installation_status = 'idle'
@@ -275,6 +334,7 @@ export default class OllamaController {
     // Test connectivity via OpenAI-compatible /v1/models endpoint (works with Ollama, LM Studio, llama.cpp, etc.)
     try {
       const testResponse = await fetch(`${remoteUrl.replace(/\/$/, '')}/v1/models`, {
+        headers: apiKey ? { Authorization: `Bearer ${apiKey.trim()}` } : undefined,
         signal: AbortSignal.timeout(5000),
       })
       if (!testResponse.ok) {
@@ -292,6 +352,9 @@ export default class OllamaController {
 
     // Save remote URL and mark service as installed
     await KVStore.setValue('ai.remoteOllamaUrl', remoteUrl.trim())
+    if (apiKey && apiKey.trim()) {
+      await KVStore.setValue('ai.remoteOllamaApiKey', apiKey.trim())
+    }
     ollamaService.installed = true
     ollamaService.installation_status = 'idle'
     await ollamaService.save()

--- a/admin/app/controllers/settings_controller.ts
+++ b/admin/app/controllers/settings_controller.ts
@@ -71,6 +71,8 @@ export default class SettingsController {
     const chatSuggestionsEnabled = await KVStore.getValue('chat.suggestionsEnabled')
     const aiAssistantCustomName = await KVStore.getValue('ai.assistantCustomName')
     const remoteOllamaUrl = await KVStore.getValue('ai.remoteOllamaUrl')
+    // Only expose whether a key is set, never the key itself.
+    const remoteOllamaApiKeySet = Boolean(await KVStore.getValue('ai.remoteOllamaApiKey'))
     const ollamaFlashAttention = await KVStore.getValue('ai.ollamaFlashAttention')
     const autoThinking = await KVStore.getValue('ai.autoThinking')
     const tasksModel = await KVStore.getValue('ai.tasksModel')
@@ -97,6 +99,7 @@ export default class SettingsController {
           chatSuggestionsEnabled: chatSuggestionsEnabled ?? false,
           aiAssistantCustomName: aiAssistantCustomName ?? '',
           remoteOllamaUrl: remoteOllamaUrl ?? '',
+          remoteOllamaApiKeySet,
           ollamaFlashAttention: ollamaFlashAttention ?? true,
           autoThinking: autoThinking ?? false,
           tasksModel: tasksModel ?? '',

--- a/admin/app/services/ollama_service.ts
+++ b/admin/app/services/ollama_service.ts
@@ -150,8 +150,14 @@ export class OllamaService {
           this.baseUrl = ollamaUrl.trim().replace(/\/$/, '')
         }
 
+        // Some OpenAI-compatible backends (e.g. cloud gateways like OrcaRouter)
+        // require a real API key. Local backends (Ollama, LM Studio, llama.cpp)
+        // ignore it, so 'nomad' remains a harmless default there.
+        const apiKey =
+          ((await KVStore.getValue('ai.remoteOllamaApiKey')) as string | null) || 'nomad'
+
         this.openai = new OpenAI({
-          apiKey: 'nomad', // Required by SDK; not validated by Ollama/LM Studio/llama.cpp
+          apiKey,
           baseURL: `${this.baseUrl}/v1`,
         })
         // Native client for `/api/chat`. Only used when the backend is really Ollama

--- a/admin/constants/kv_store.ts
+++ b/admin/constants/kv_store.ts
@@ -9,6 +9,7 @@ export const SETTINGS_KEYS: KVStoreKey[] = [
     'system.internetStatusTestUrl',
     'ai.assistantCustomName',
     'ai.remoteOllamaUrl',
+    'ai.remoteOllamaApiKey',
     'ai.ollamaFlashAttention',
     'ai.autoThinking',
     'ai.tasksModel',

--- a/admin/inertia/lib/api.ts
+++ b/admin/inertia/lib/api.ts
@@ -58,11 +58,30 @@ class API {
     })()
   }
 
-  async configureRemoteOllama(remoteUrl: string | null): Promise<{ success: boolean; message: string }> {
+  async configureRemoteOllama(remoteUrl: string | null, apiKey?: string | null): Promise<{ success: boolean; message: string }> {
     return catchInternal(async () => {
       const response = await this.client.post<{ success: boolean; message: string }>(
         '/ollama/configure-remote',
-        { remoteUrl }
+        { remoteUrl, apiKey }
+      )
+      return response.data
+    })()
+  }
+
+  async configureRemoteOllamaApiKey(apiKey: string | null): Promise<{ success: boolean; message: string }> {
+    return catchInternal(async () => {
+      const response = await this.client.post<{ success: boolean; message: string }>(
+        '/ollama/configure-remote-api-key',
+        { apiKey }
+      )
+      return response.data
+    })()
+  }
+
+  async getRemoteOllamaApiKeyStatus(): Promise<{ configured: boolean; connected: boolean }> {
+    return catchInternal(async () => {
+      const response = await this.client.get<{ configured: boolean; connected: boolean }>(
+        '/ollama/remote-status-api-key'
       )
       return response.data
     })()

--- a/admin/inertia/pages/settings/models.tsx
+++ b/admin/inertia/pages/settings/models.tsx
@@ -27,7 +27,7 @@ export default function ModelsPage(props: {
   models: {
     availableModels: NomadOllamaModel[]
     installedModels: NomadInstalledModel[]
-    settings: { chatSuggestionsEnabled: boolean; aiAssistantCustomName: string; remoteOllamaUrl: string; ollamaFlashAttention: boolean; autoThinking: boolean; tasksModel: string; ragEnabled: boolean; contextWindow: string }
+    settings: { chatSuggestionsEnabled: boolean; aiAssistantCustomName: string; remoteOllamaUrl: string; remoteOllamaApiKeySet: boolean; ollamaFlashAttention: boolean; autoThinking: boolean; tasksModel: string; ragEnabled: boolean; contextWindow: string }
     /** Effective window per installed model, as resolved by ContextWindowService. */
     resolvedContextWindows?: Record<string, number>
   }
@@ -112,12 +112,16 @@ export default function ModelsPage(props: {
   const [remoteOllamaUrl, setRemoteOllamaUrl] = useState(props.models.settings.remoteOllamaUrl)
   const [remoteOllamaError, setRemoteOllamaError] = useState<string | null>(null)
   const [remoteOllamaSaving, setRemoteOllamaSaving] = useState(false)
+  const [remoteApiKey, setRemoteApiKey] = useState('')
+  const [remoteApiKeyError, setRemoteApiKeyError] = useState<string | null>(null)
+  const [remoteApiKeySaving, setRemoteApiKeySaving] = useState(false)
+  const remoteApiKeySet = props.models.settings.remoteOllamaApiKeySet
 
   async function handleSaveRemoteOllama() {
     setRemoteOllamaError(null)
     setRemoteOllamaSaving(true)
     try {
-      const res = await api.configureRemoteOllama(remoteOllamaUrl || null)
+      const res = await api.configureRemoteOllama(remoteOllamaUrl || null, remoteApiKey || null)
       if (res?.success) {
         addNotification({ message: res.message, type: 'success' })
         router.reload()
@@ -144,6 +148,41 @@ export default function ModelsPage(props: {
       setRemoteOllamaError(error?.message || 'Failed to clear remote Ollama.')
     } finally {
       setRemoteOllamaSaving(false)
+    }
+  }
+
+  async function handleSaveRemoteApiKey() {
+    setRemoteApiKeyError(null)
+    setRemoteApiKeySaving(true)
+    try {
+      const res = await api.configureRemoteOllamaApiKey(remoteApiKey || null)
+      if (res?.success) {
+        setRemoteApiKey('')
+        addNotification({ message: res.message, type: 'success' })
+        router.reload()
+      }
+    } catch (error: any) {
+      const msg = error?.response?.data?.message || error?.message || 'Failed to save remote API key.'
+      setRemoteApiKeyError(msg)
+    } finally {
+      setRemoteApiKeySaving(false)
+    }
+  }
+
+  async function handleClearRemoteApiKey() {
+    setRemoteApiKeyError(null)
+    setRemoteApiKeySaving(true)
+    try {
+      const res = await api.configureRemoteOllamaApiKey(null)
+      if (res?.success) {
+        setRemoteApiKey('')
+        addNotification({ message: 'Remote API key cleared.', type: 'success' })
+        router.reload()
+      }
+    } catch (error: any) {
+      setRemoteApiKeyError(error?.message || 'Failed to clear remote API key.')
+    } finally {
+      setRemoteApiKeySaving(false)
     }
   }
 
@@ -486,8 +525,10 @@ export default function ModelsPage(props: {
           <StyledSectionHeader title="Remote Connection" className="mt-8 mb-4" />
           <div className="bg-surface-primary rounded-lg border-2 border-border-subtle p-6">
             <p className="text-sm text-text-secondary mb-4">
-              Connect to any OpenAI-compatible API server — Ollama, LM Studio, llama.cpp, and others are all supported.
+              Connect to any OpenAI-compatible API server — Ollama, LM Studio, llama.cpp, cloud gateways like{' '}
+              <a href="https://www.orcarouter.ai" target="_blank" rel="noreferrer" className="underline text-text-primary">OrcaRouter</a>, and others are all supported.
               For remote Ollama instances, the host must be started with <code className="bg-surface-secondary px-1 rounded">OLLAMA_HOST=0.0.0.0</code>.
+              Cloud gateways require an API key.
             </p>
             <div className="flex items-end gap-3">
               <div className="flex-1">
@@ -501,6 +542,23 @@ export default function ModelsPage(props: {
                     setRemoteOllamaError(null)
                   }}
                 />
+                <div className="mt-4">
+                  <Input
+                    name="remoteOllamaApiKey"
+                    label="API Key (optional)"
+                    helpText={remoteApiKeySet ? 'An API key is saved for this endpoint.' : 'Only required for cloud gateways that authenticate requests (e.g. OrcaRouter).'}
+                    type="password"
+                    placeholder={remoteApiKeySet ? '••••••••••••••••  (saved)' : 'sk-orca-…'}
+                    value={remoteApiKey}
+                    onChange={(e) => {
+                      setRemoteApiKey(e.target.value)
+                      setRemoteApiKeyError(null)
+                    }}
+                  />
+                  {remoteApiKeyError && (
+                    <p className="text-sm text-red-600 mt-1">{remoteApiKeyError}</p>
+                  )}
+                </div>
                 {remoteOllamaError && (
                   <p className="text-sm text-red-600 mt-1">{remoteOllamaError}</p>
                 )}
@@ -526,6 +584,33 @@ export default function ModelsPage(props: {
                 </StyledButton>
               )}
             </div>
+            {remoteApiKeySet && (
+              <div className="mt-4 flex items-end gap-3">
+                <div className="flex-1">
+                  <p className="text-sm text-text-secondary">
+                    Test the saved API key against chat completions.
+                  </p>
+                </div>
+                <StyledButton
+                  variant="secondary"
+                  onClick={handleSaveRemoteApiKey}
+                  loading={remoteApiKeySaving}
+                  disabled={remoteApiKeySaving}
+                  className="mb-0.5"
+                >
+                  Save Key
+                </StyledButton>
+                <StyledButton
+                  variant="danger"
+                  onClick={handleClearRemoteApiKey}
+                  loading={remoteApiKeySaving}
+                  disabled={remoteApiKeySaving}
+                  className="mb-0.5"
+                >
+                  Clear Key
+                </StyledButton>
+              </div>
+            )}
           </div>
 
           <ActiveModelDownloads withHeader />

--- a/admin/start/routes.ts
+++ b/admin/start/routes.ts
@@ -342,6 +342,14 @@ router
       summary: 'Get remote Ollama status',
       tags: ['ollama'],
     })
+    documented(router.post('/configure-remote-api-key', [OllamaController, 'configureRemoteApiKey']), {
+      summary: 'Save the API key for the remote OpenAI-compatible endpoint',
+      tags: ['ollama'],
+    })
+    documented(router.get('/remote-status-api-key', [OllamaController, 'remoteStatusApiKey']), {
+      summary: 'Test the stored remote API key against chat completions',
+      tags: ['ollama'],
+    })
   })
   .prefix('/api/ollama')
 

--- a/admin/types/kv_store.ts
+++ b/admin/types/kv_store.ts
@@ -42,6 +42,7 @@ export const KV_STORE_SCHEMA = {
   'ai.assistantCustomName':     'string',
   'gpu.type':                   'string',
   'ai.remoteOllamaUrl':         'string',
+  'ai.remoteOllamaApiKey':      'string',
   'ai.ollamaFlashAttention':    'boolean',
   'ai.autoThinking':            'boolean',
   // Model used for ancillary AI work (chat titles, chat suggestions) instead of


### PR DESCRIPTION
## What & why

Project NOMAD's AI Assistant already supports pointing at any OpenAI-compatible API server — the README mentions Ollama, LM Studio, and llama.cpp. All of those are *local* backends that ignore the API key, so the client currently sends a hardcoded `nomad` placeholder.

Cloud AI gateways are OpenAI-compatible too, but they **require a real API key**. This PR adds an optional API key to NOMAD's existing "Remote Connection" configuration so cloud gateways work out of the box, and calls out [OrcaRouter](https://www.orcarouter.ai) as the first named example.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding it as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Implementation

- **`admin/constants/kv_store.ts` / `admin/types/kv_store.ts`** — new `ai.remoteOllamaApiKey` setting.
- **`admin/app/services/ollama_service.ts`** — `_initialize()` now reads the stored key and sends it with the OpenAI client. Local backends still get the harmless `nomad` placeholder.
- **`admin/app/controllers/ollama_controller.ts`** — `configureRemote` accepts an optional `apiKey`; a separate `configure-remote-api-key` endpoint saves/clears the key without re-running the URL connectivity test; `remote-status` reports `hasApiKey` and probes with the key; a new `remote-status-api-key` endpoint tests the key against `/v1/chat/completions` (the path that actually requires it).
- **`admin/app/controllers/settings_controller.ts`** — only the *presence* of a key is sent to the UI, never the key itself.
- **`admin/inertia/lib/api.ts` + `admin/inertia/pages/settings/models.tsx`** — the Models → Remote Connection page gains a password-style API key field, with a "saved" indicator and save/clear controls.

## Verification

- `npm run typecheck` — passes
- `npm run build` (the CI gate) — passes
- Live test against `https://api.orcarouter.ai/v1` using a real key:
  - `GET /v1/models` with the stored key → `HTTP 200`
  - `POST /v1/chat/completions` (model `orcarouter/free`) with the stored key → `HTTP 200`

Note: the full `npm test` suite can't run in this sandbox because the native `@openzim/libzim` binding requires `make`/`g++`, which aren't available without root. The changed modules are covered by typecheck and the build.

## Notes

For a user, this looks like: enter `https://api.orcarouter.ai/v1` as the remote URL, paste an OrcaRouter API key, and the AI Assistant uses it for chat, streaming, and embeddings — no separate client needed.

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
