### PR TITLE
fix(ai): a failed Ollama model pull is reported to the user as a success

### DIFF
--- a/admin/app/services/ollama_service.ts
+++ b/admin/app/services/ollama_service.ts
@@ -321,6 +321,20 @@ export class OllamaService {
             if (!line.trim()) continue
             try {
               const parsed = JSON.parse(line)
+              // Ollama reports pull failures IN-BAND: the HTTP request returns 200 and the
+              // failure arrives as a line in the NDJSON body, e.g.
+              //   {"error":"pull model manifest: file does not exist"}
+              // The 'error' event below only fires for transport failures (a destroyed
+              // socket), so without this the line is dropped, the stream ends cleanly, and
+              // a pull that transferred nothing is reported to the user as a success.
+              if (parsed.error) {
+                const message =
+                  typeof parsed.error === 'string' ? parsed.error : JSON.stringify(parsed.error)
+                const err: any = new Error(message)
+                err.code = 'ERR_OLLAMA_PULL'
+                pullResponse.data.destroy(err)
+                return
+              }
               if (parsed.completed && parsed.total && parsed.digest) {
                 // Update this digest's progress — take the max seen value so transient
                 // out-of-order updates don't make the aggregate jump backwards.
@@ -374,6 +388,22 @@ export class OllamaService {
         })
       })
 
+      // A clean stream end is not proof the model landed. Ollama can end the stream without
+      // an error line, and historically any such case was reported to the user as a
+      // successful download. Confirm against the installed list before claiming success.
+      //
+      // includeEmbeddings must be true: getModels() filters out anything with "embed" in the
+      // name by default, so nomic-embed-text would otherwise fail verification after a
+      // perfectly good pull. Names are normalised because Ollama resolves a bare name to
+      // ":latest", so a pull of "llama3.1" comes back as "llama3.1:latest".
+      const tag = (n: string) => (n.includes(':') ? n : `${n}:latest`)
+      const installedAfter = await this.getModels(true)
+      if (!installedAfter.some((m) => tag(m.name) === tag(model))) {
+        throw new Error(
+          'Ollama reported no error but the model is not installed. The download did not complete.'
+        )
+      }
+
       logger.info(`[OllamaService] Model "${model}" downloaded successfully.`)
       return { success: true, message: 'Model downloaded successfully.' }
     } catch (error) {
@@ -396,14 +426,28 @@ export class OllamaService {
 
       // Check for version mismatch (Ollama 412 response)
       const isVersionMismatch = errorMessage.includes('newer version of Ollama')
+
+      // An in-band pull error that says the model does not exist is permanent. Retrying it
+      // ten times on an exponential backoff just leaves the user watching a "delayed" job
+      // for hours instead of showing them the real reason, which is a bad model name.
+      const isPermanentPullError =
+        (error as any)?.code === 'ERR_OLLAMA_PULL' &&
+        /manifest|not found|does not exist|unauthorized|no such/i.test(errorMessage)
+
       const userMessage = isVersionMismatch
         ? 'This model requires a newer version of Ollama. Please update AI Assistant from the Apps page.'
-        : `Failed to download model: ${errorMessage}`
+        : isPermanentPullError
+          ? `Ollama could not find this model: ${errorMessage}`
+          : `Failed to download model: ${errorMessage}`
 
       // Broadcast failure to connected clients so UI can show the error
       this.broadcastDownloadError(model, userMessage)
 
-      return { success: false, message: userMessage, retryable: !isVersionMismatch }
+      return {
+        success: false,
+        message: userMessage,
+        retryable: !isVersionMismatch && !isPermanentPullError,
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #1273. Refs #1071.

## The bug

Ollama's `/api/pull` returns **HTTP 200** and reports failures *in-band*, as a JSON line inside the NDJSON stream body:

```
$ curl -s -o body.txt -w "HTTP_STATUS=%{http_code}\n" -X POST http://localhost:11434/api/pull \
    -d '{"model":"llama3.1:405b-instruct-fp16-nope","stream":true}'
HTTP_STATUS=200

$ cat body.txt
{"status":"pulling manifest"}
{"error":"pull model manifest: file does not exist"}
```

The stream handler only ever read `completed`/`total`/`digest` off each line and silently dropped everything else, including that error line. The stream then ended normally, `on('end')` resolved unconditionally, and we logged the model as downloaded successfully.

`pullResponse.data.on('error', ...)` never fires for this. It only sees **transport** failures (a destroyed socket). At the HTTP layer the request succeeded.

So every failed model pull, for any reason, was reported to the user as a success.

## Why it matters more than one report

On #1071 this surfaced as an ~800 GB fp16 model "downloading" in **two seconds** and nothing being installed. It had been triaged twice as disk space and then as a stale blob. Both explanations produce workarounds that cannot possibly work, because the pull is not reaching the disk at all, which is also why the remediation from #690 stopped helping that reporter.

Anything in the "download says complete, nothing installed" bucket is a candidate for this.

Distinct from #1214/#1047 (retained terminal job dedupes the dispatch, so no worker runs and there are **no** `[DownloadModelJob]` lines) and from #1194 (orphaned job 500s the queue endpoint). Here the worker runs to completion and misreports the outcome.

## The change

Three edits, all in `_doDownloadModel`:

1. **Check `parsed.error`** in the data handler and destroy the stream with it, so the existing `catch` reports a real failure. Reuses the established rejection path rather than adding a second one.
2. **Verify the model is actually installed** via `getModels()` before returning success. This is the load-bearing half: it catches silent failure modes we have *not* anticipated, not only the ones Ollama labels.
3. **Treat an in-band "model does not exist" as permanent.** It was retryable, so a bad model name spun through `attempts: 10` on exponential backoff and the user watched a `delayed` job for hours instead of being told the name was wrong.

Two traps in (2) worth calling out, both of which would have caused false *negatives* on good pulls:

- `getModels()` filters out anything with `embed` in the name unless `includeEmbeddings` is true, so `nomic-embed-text` would fail verification after a perfectly good pull.
- Ollama resolves a bare name to `:latest`, so a pull of `llama3.1` comes back as `llama3.1:latest`. Names are normalised before comparison.

`getModels()` hits `/api/tags` live and is not cached, so the post-pull read is safe. (The `Using cached available models data` log line comes from the recommended-models catalog, a different method.)

## Verification

Hot-patched onto NOMAD3 running the shipped **v1.34.0** image, which carries the same defect (`parsed.error` is absent from the compiled `ollama_service.js` there too, so this is live in GA, not just `dev`).

| Case | Before | After |
|---|---|---|
| Bogus tag | `Model "..." downloaded successfully.` | `Failed to download model "...": pull model manifest: file does not exist` |
| Bogus tag, retries | 2 attempts and climbing | **1 attempt**, no retry |
| Bogus tag, user message | `Failed to download model: ...` | `Ollama could not find this model: ...` |
| Real model `qwen2.5:0.5b` | succeeds | succeeds, passes verification, present in `ollama list` (397 MB) |

The real-model case matters as much as the failure case: it confirms the new verification does not reject good pulls.

`npx tsc --noEmit` clean.

## Not in scope

The pre-flight "is it already installed" check at the top of the same function calls `getModels()` without `includeEmbeddings` and compares names without normalising. The consequence is only a redundant re-pull of an already-present embedding model, which is harmless, so I have left it alone rather than widen this PR. Worth a follow-up.
