### PR TITLE
fix(gpu): a missing /dev/kfd blocks the AI Assistant install entirely

### DIFF
--- a/admin/app/services/docker_service.ts
+++ b/admin/app/services/docker_service.ts
@@ -850,8 +850,10 @@ export class DockerService {
         'creating',
         `Creating Docker container for service ${service.service_name}...`
       )
-      const container = await this.docker.createContainer({
-        Image: finalImage,
+      // Built once and reused, so the AMD fallback below cannot drift from the
+      // real payload as this config grows.
+      const buildCreateOptions = (image: string, hostConfig: any, env: string[]) => ({
+        Image: image,
         name: service.service_name,
         Labels: {
           ...(containerConfig?.Labels ?? {}),
@@ -859,10 +861,10 @@ export class DockerService {
           'io.project-nomad.managed': 'true',
         },
         ...(containerConfig?.User && { User: containerConfig.User }),
-        HostConfig: gpuHostConfig,
+        HostConfig: hostConfig,
         ...(containerConfig?.WorkingDir && { WorkingDir: containerConfig.WorkingDir }),
         ...(containerConfig?.ExposedPorts && { ExposedPorts: containerConfig.ExposedPorts }),
-        Env: [...(containerConfig?.Env ?? []), ...ollamaEnv, ...appEnv],
+        Env: env,
         ...(service.container_command ? { Cmd: service.container_command.split(' ') } : {}),
         // Ensure container is attached to the Nomad docker network in production
         ...(process.env.NODE_ENV === 'production' && {
@@ -874,12 +876,76 @@ export class DockerService {
         }),
       })
 
+      let container = await this.docker.createContainer(
+        buildCreateOptions(finalImage, gpuHostConfig, [
+          ...(containerConfig?.Env ?? []),
+          ...ollamaEnv,
+          ...appEnv,
+        ])
+      )
+
       this._broadcast(
         service.service_name,
         'starting',
         `Starting Docker container for service ${service.service_name}...`
       )
-      await container.start()
+      try {
+        await container.start()
+      } catch (error: any) {
+        // An AMD GPU whose ROCm device nodes are absent must not block the install
+        // outright (#1232). GPU detection reads PCI data, so "an AMD GPU is present"
+        // and "ROCm is usable" are different questions, and only the daemon can
+        // answer the second. CPU-only Ollama works fine on these machines.
+        //
+        // This has to sit on start(), not createContainer(): the daemon accepts a
+        // container whose --device path does not exist (create returns 201) and only
+        // resolves devices when the container starts. Measured on Docker 29.6.2.
+        //
+        // Retrying rather than pre-checking is also deliberate. The admin runs in its
+        // own container, so stat()ing /dev/kfd here describes the admin's namespace,
+        // not the host's. Verified on NOMAD6, a working ROCm box: /dev/kfd is present
+        // on the host and absent inside the admin container, so a pre-check would
+        // strip GPU passthrough from a machine where it works.
+        if (!amdGpuConfigured || !this._isMissingDeviceError(error)) throw error
+
+        logger.warn(
+          `[DockerService] AMD device passthrough rejected by the daemon (${error?.message}); ` +
+            `recreating ${service.service_name} CPU-only on ${service.container_image}`
+        )
+        this._broadcast(
+          service.service_name,
+          'gpu-config',
+          `AMD GPU detected, but this system has no usable ROCm device (/dev/kfd is missing, ` +
+            `which means the amdgpu/ROCm kernel driver is not loaded or does not support this GPU). ` +
+            `Installing CPU-only instead so the AI Assistant still works.`
+        )
+
+        // The created container carries the rejected device config, so it cannot be
+        // started as-is and has to go before the name can be reused.
+        await container.remove({ force: true }).catch((removeError: any) => {
+          logger.warn(`[DockerService] Could not remove the failed container: ${removeError?.message}`)
+        })
+
+        const { Devices, ...cpuHostConfig } = gpuHostConfig as any
+        // Drop the ROCm-only env along with the devices. HSA_OVERRIDE_GFX_VERSION and
+        // OLLAMA_IGPU_ENABLE mean nothing to the CPU build, and leaving them behind is
+        // misleading to anyone who later reads `docker inspect`.
+        const cpuOllamaEnv = ollamaEnv.filter(
+          (e) => !e.startsWith('HSA_OVERRIDE_GFX_VERSION=') && !e.startsWith('OLLAMA_IGPU_ENABLE=')
+        )
+        amdGpuConfigured = false
+        // service.container_image is the CPU tag, already pulled earlier in this
+        // function before the AMD branch overrode finalImage to :rocm.
+        finalImage = service.container_image
+        container = await this.docker.createContainer(
+          buildCreateOptions(finalImage, cpuHostConfig, [
+            ...(containerConfig?.Env ?? []),
+            ...cpuOllamaEnv,
+            ...appEnv,
+          ])
+        )
+        await container.start()
+      }
 
       this._broadcast(
         service.service_name,
@@ -1579,6 +1645,28 @@ export class DockerService {
       { PathOnHost: '/dev/kfd', PathInContainer: '/dev/kfd', CgroupPermissions: 'rwm' },
       { PathOnHost: '/dev/dri', PathInContainer: '/dev/dri', CgroupPermissions: 'rwm' },
     ]
+  }
+
+  /**
+   * Whether a container-create failure was the daemon refusing a `--device` path
+   * that does not exist on the host, e.g.
+   *
+   *   (HTTP code 500) server error - error gathering device information while
+   *   adding custom device "/dev/kfd": no such file or directory
+   *
+   * GPU *detection* reads PCI data, which says nothing about whether the ROCm
+   * kernel interface was ever loaded. An AMD card with no `/dev/kfd` is a
+   * perfectly normal machine — old pre-ROCm silicon, or amdgpu not loaded — and
+   * on those the create fails outright and the whole install dies (#1232).
+   *
+   * Deliberately keyed on the device-gathering phrase rather than a bare "no
+   * such file or directory", which Docker also emits for missing bind-mount
+   * sources and image layers. Falling back to CPU on one of those would hide a
+   * real failure behind a degraded install.
+   */
+  private _isMissingDeviceError(error: any): boolean {
+    const raw: string = error?.message ?? String(error)
+    return /error gathering device information while adding custom device/i.test(raw)
   }
 
   /**


### PR DESCRIPTION
Fixes #1232.

## The bug

When an AMD GPU is detected, the install switches to the ROCm image and passes `/dev/kfd` and `/dev/dri` into the container. `_discoverAMDDevices()` returns both **unconditionally**, with no check that they exist.

GPU detection reads PCI data, which says nothing about whether the ROCm kernel interface was ever loaded. On a pre-ROCm card, or a host where amdgpu is not loaded, the container is rejected:

```
(HTTP code 500) server error - error gathering device information while adding
custom device "/dev/kfd": no such file or directory
```

and the install dies outright.

**There is no way out through the UI.** The opt-out, `ai.amdGpuAcceleration`, is a backend-only KV key: no settings toggle, no API route, no frontend reference anywhere. So an affected user cannot install the AI Assistant at all, even though CPU-only would work fine on their machine. That is what makes this a hard block rather than a missing optimisation.

## The fix

Fall back to the CPU image after a device-rejection, with a message explaining why.

Two things about the shape of it, both measured rather than assumed, because both are places I initially got it wrong:

**It hooks `start()`, not `createContainer()`.** My first cut wrapped the create. The daemon actually *accepts* a container whose `--device` path does not exist and only resolves devices on start. Verified against Docker 29.6.2 over the socket:

```
create HTTP=201
start  HTTP=500
{"message":"error gathering device information while adding custom device \"/dev/kfd\": no such file or directory"}
```

So the recovery also has to remove the created-but-unstartable container before the name can be reused.

**It retries rather than pre-checking.** A `stat('/dev/kfd')` would be the obvious fix and it is wrong: the admin runs in its own container, so it describes the admin's mount namespace, not the host's. Verified on a working ROCm box (Ollama running `ollama/ollama:rocm` with both devices attached, AMD acceleration functioning):

```
host  /dev/kfd:      PRESENT
admin sees /dev/kfd: ABSENT
```

A pre-check would have stripped GPU passthrough from a machine where it works. That is a worse regression than the bug being fixed, and it would have been invisible in testing on any non-AMD box.

## Matcher precision

Keyed on the device-gathering phrase rather than a bare `no such file or directory`, which Docker also emits for missing bind-mount sources and image layers. Falling back to CPU on one of those would hide a real failure behind a silently degraded install.

Checked against every format the daemon and dockerode produce, plus a near-miss:

| Message | Matches |
|---|---|
| `(HTTP code 500) server error - error gathering device information...` | yes |
| `error gathering device information while adding custom device "/dev/kfd"...` | yes |
| `Error response from daemon: error gathering device information...` | yes |
| `no such file or directory` | **no** |
| `Bind for 0.0.0.0:11434 failed: port is already allocated` | **no** |

## Blast radius

The success path is unchanged. Both attempts build their payload through a single `buildCreateOptions` helper, so the GPU path produces exactly the object it did before, and the fallback only runs after a `start()` failure that matches the phrase above. On a healthy AMD box nothing new executes.

The fallback also strips `HSA_OVERRIDE_GFX_VERSION` and `OLLAMA_IGPU_ENABLE` along with the devices, since they mean nothing to the CPU build and are misleading to anyone later reading `docker inspect`.

`npx tsc --noEmit` clean.

## Not in scope

`updateContainer()` has its own AMD branch with the same unconditional `_discoverAMDDevices()` call, so an update on such a machine would hit the same rejection. I left it out to keep this reviewable: that path has its own rollback handling and deserves a look on its own terms rather than a copy of this patch.
