### PR TITLE
fix(benchmark): WSL2 submits "Microsoft Basic Render Driver" as the GPU model

### DIFF
--- a/admin/app/services/benchmark_service.ts
+++ b/admin/app/services/benchmark_service.ts
@@ -203,6 +203,16 @@ function isUnresolvedGpuModel(model: string): boolean {
   if (s === '') return true
   if (/^device\s+[0-9a-f]{4}$/i.test(s)) return true
   if (/^unknown$/i.test(s)) return true
+  // WSL2 exposes the GPU through /dev/dxg rather than the real adapter, so
+  // si.graphics() reports Microsoft's generic placeholder even while CUDA work
+  // is running on a physical card. Left unhandled, an RTX 3090 reaches the
+  // public leaderboard labelled "Microsoft Basic Render Driver", which is worse
+  // than no label: it is wrong, and it fragments per-hardware grouping (#1218).
+  //
+  // These are Microsoft's own placeholder adapter names and appear nowhere
+  // outside a Windows/WSL graphics stack, so this cannot reject a real product
+  // name on a native Linux host.
+  if (/^microsoft basic (render driver|display adapter)$/i.test(s)) return true
   return false
 }
 


### PR DESCRIPTION
Refs #1218.

## The bug

Under WSL2 the GPU is reached through `/dev/dxg` rather than the real adapter, so `si.graphics()` returns Microsoft's generic placeholder even while CUDA work is running on a physical card. `isUnresolvedGpuModel()` caught blanks, `Device <hex>` and `Unknown`, but not this, so the placeholder passed as a legitimate model name and the authoritative detection path was skipped.

The reporter has an RTX 3090 doing real work (92% utilisation, 11.6 GB VRAM, 352 W, 127.9 tok/s) reaching the **public leaderboard** labelled `Microsoft Basic Render Driver`. A wrong label is worse than no label: it fragments per-hardware grouping, which is the same failure #1165 fixed for raw PCI ids. This is one more entry in that same list.

## Scoped so it cannot affect non-WSL machines

These are Microsoft's own placeholder adapter names and appear nowhere outside a Windows/WSL graphics stack. On a native Linux host the function returns exactly what it returns today.

Verified against real product names from all four vendors, plus an adversarial near-miss to confirm the anchored pattern cannot swallow a real name:

```
true   "Microsoft Basic Render Driver"
true   "Microsoft Basic Display Adapter"
false  "NVIDIA GeForce RTX 3090"
false  "AMD Radeon RX 6800"
false  "Apple M4 Max 40-Core GPU (Metal 4)"
false  "Intel Arc A770 Graphics"
false  "NVIDIA RTX A3000 Laptop GPU"
false  "Microsoft Basic Renderer Pro 9000"   <- near-miss, correctly not matched
true   "Device 2d05" / "Unknown" / ""        <- existing behaviour unchanged
```

## What this does and does not achieve

It makes the model resolve to **unknown** rather than to "RTX 3090". The fallback path queries `nvidia-smi`, and under WSL2 with native Docker Engine the admin container does not have it: WSL's copy lives at `/usr/lib/wsl/lib/nvidia-smi`, outside the container.

Honest-unknown is the right outcome for the leaderboard, since a wrong name actively corrupts grouping while an absent one does not. Actually naming the card under WSL is a separate and larger problem, and is not attempted here.

`npx tsc --noEmit` clean.
