### PR TITLE
docs: state how much disk NOMAD needs before any content

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Project NOMAD is a self-contained, offline-first knowledge and education server 
 ## Installation & Quickstart
 Project NOMAD can be installed on any Debian-based operating system (we recommend Ubuntu 26.04 LTS; 24.04 LTS and Debian 12 are also supported). Installation is completely terminal-based, and all tools and resources are designed to be accessed through the browser, so there's no need for a desktop environment if you'd rather setup NOMAD as a "server" and access it through other clients.
 
-**Disk space:** NOMAD itself needs about **5 GB**, so plan for **10 GB free** to install comfortably. Adding the AI Assistant needs roughly **25 GB** in total, since Ollama and a general-purpose model are large. Offline content is downloaded separately and is what actually fills a drive: a full Wikipedia or a regional map set runs to tens or hundreds of gigabytes, so an SSD of 500 GB or more is the practical recommendation once you start adding libraries. See the [FAQ](https://www.projectnomad.us/docs/faq) for content sizes.
+**Before you start:** NOMAD itself needs about **5 GB of disk and under 1 GB of RAM**. The offline content you add afterwards is what actually fills a drive, and the AI Assistant is what drives the memory requirement up. See [Device Requirements](#device-requirements) for both, and the [FAQ](https://www.projectnomad.us/docs/faq) for individual content sizes.
 
 *Note: sudo/root privileges are required to run the install script*
 
@@ -78,9 +78,11 @@ At its core, however, NOMAD is still very lightweight. For a barebones installat
 #### Minimum Specs
 - Processor: 2 GHz dual-core processor or better
 - RAM: 4GB system memory (the whole stack without AI runs in under 1 GB)
-- Storage: At least 5 GB free disk space
+- Storage: At least 5 GB free disk space (plan for 10 GB to install comfortably)
 - OS: Debian-based (Ubuntu 26.04 LTS recommended)
 - Stable internet connection (required during install only)
+
+Adding the AI Assistant brings the install to roughly **25 GB**, because Ollama and a general-purpose model are both large, and a model needs about its download size in memory while it answers. That memory comes from VRAM if you have a discrete GPU and from system RAM if you do not, which is the single biggest reason the figures below are so much higher.
 
 To run LLMs and other included AI tools:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Project NOMAD is a self-contained, offline-first knowledge and education server 
 ## Installation & Quickstart
 Project NOMAD can be installed on any Debian-based operating system (we recommend Ubuntu 26.04 LTS; 24.04 LTS and Debian 12 are also supported). Installation is completely terminal-based, and all tools and resources are designed to be accessed through the browser, so there's no need for a desktop environment if you'd rather setup NOMAD as a "server" and access it through other clients.
 
+**Disk space:** NOMAD itself needs about **5 GB**, so plan for **10 GB free** to install comfortably. Adding the AI Assistant needs roughly **25 GB** in total, since Ollama and a general-purpose model are large. Offline content is downloaded separately and is what actually fills a drive: a full Wikipedia or a regional map set runs to tens or hundreds of gigabytes, so an SSD of 500 GB or more is the practical recommendation once you start adding libraries. See the [FAQ](https://www.projectnomad.us/docs/faq) for content sizes.
+
 *Note: sudo/root privileges are required to run the install script*
 
 ### Quick Install (Debian-based OS Only)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ At its core, however, NOMAD is still very lightweight. For a barebones installat
 
 #### Minimum Specs
 - Processor: 2 GHz dual-core processor or better
-- RAM: 4GB system memory
+- RAM: 4GB system memory (the whole stack without AI runs in under 1 GB)
 - Storage: At least 5 GB free disk space
 - OS: Debian-based (Ubuntu 26.04 LTS recommended)
 - Stable internet connection (required during install only)

--- a/admin/docs/faq.md
+++ b/admin/docs/faq.md
@@ -30,7 +30,13 @@ NOMAD is designed for capable hardware, especially if you want to use the AI fea
 **For detailed build recommendations at three price points ($150–$1,000+), see the [Hardware Guide](https://www.projectnomad.us/hardware).**
 
 ### How much storage do I need?
-It depends on what you download:
+
+**To install NOMAD itself: about 5GB, so leave 10GB free.** That covers the
+Command Center and its database, before any content. Adding the AI Assistant
+brings the total to roughly 25GB, because Ollama and a general-purpose model are
+both large.
+
+After that it depends entirely on what you download:
 - Full Wikipedia: ~95GB
 - Khan Academy courses: ~50GB
 - Medical references: ~500MB

--- a/admin/docs/faq.md
+++ b/admin/docs/faq.md
@@ -29,6 +29,24 @@ NOMAD is designed for capable hardware, especially if you want to use the AI fea
 
 **For detailed build recommendations at three price points ($150–$1,000+), see the [Hardware Guide](https://www.projectnomad.us/hardware).**
 
+### How much RAM do I need?
+
+**Without the AI Assistant, the whole stack sits under 1GB.** Measured on a running
+install: the Command Center 241MB, MySQL 444MB, Redis 9MB, Kiwix 101MB, and the
+knowledge base index 155MB. That is why 4GB is a real minimum rather than a
+defensive one.
+
+**The AI is the variable, and it is the model rather than NOMAD.** Ollama idles at
+roughly 1.2GB, and a model needs about its download size resident while it answers,
+so an 8B model at ~4.6GB wants about that much on top. **8GB is workable for a small
+model, 16GB is comfortable, and 32GB is the recommendation if you want to run larger
+ones.**
+
+Where that memory comes from depends on your hardware. With a discrete GPU the model
+loads into VRAM and never touches system RAM, so VRAM is the number that limits which
+models you can run. With an integrated GPU or no GPU at all, it comes out of system
+RAM, which is why a CPU-only box needs more of it.
+
 ### How much storage do I need?
 
 **To install NOMAD itself: about 5GB, so leave 10GB free.** That covers the


### PR DESCRIPTION
Closes #1271.

The quickstart never said how much free space is needed to install. That is the first thing anyone plans around on a project whose whole purpose is downloading large offline libraries, and the reporter proposed the exact sentence with the number left blank for us to fill in.

The FAQ's `How much storage do I need?` question only covered content sizes, so it answered "how big is Wikipedia" but never "can I install this at all". Both are updated.

## Measured, not estimated

On a v1.34.0 install:

| Image | Size |
|---|---|
| admin (`project-nomad:v1.34.0`) | 2.81 GB |
| MySQL 8.0 | 1.1 GB |
| sidecar-updater | 137 MB |
| dozzle | 76.5 MB |
| redis 7-alpine | 57.8 MB |
| disk-collector | 25.1 MB |
| **core total** | **~4.2 GB** |

So ~5 GB installed, and 10 GB free to install comfortably.

The AI Assistant is the big optional add: `ollama/ollama` is **10.6 GB** on its own, and a general-purpose model is several more (llama3.1:8b is ~4.9 GB). That is where the ~25 GB figure comes from.

## Noted, not changed

The FAQ lists "Full Wikipedia: ~95GB". The `wikipedia_en_all_maxi_2026-02` archive is actually **124 GB** on disk. I left it alone because per-build ZIM sizes move and PR #1189 already re-measured the catalog, so that number should be corrected from the catalog rather than from my one sample.