### PR TITLE
fix: let admin tests boot without native ZIM loading

### DIFF
--- a/admin/app/services/kiwix_library_service.ts
+++ b/admin/app/services/kiwix_library_service.ts
@@ -1,8 +1,12 @@
 import { XMLBuilder, XMLParser } from 'fast-xml-parser'
-import { readFile, writeFile, rename, readdir } from 'fs/promises'
-import { join } from 'path'
-import { Archive } from '@openzim/libzim'
-import { KIWIX_LIBRARY_XML_PATH, ZIM_STORAGE_PATH, ensureDirectoryExists, isValidZimFile } from '../utils/fs.js'
+import { readFile, writeFile, rename, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  KIWIX_LIBRARY_XML_PATH,
+  ZIM_STORAGE_PATH,
+  ensureDirectoryExists,
+  isValidZimFile,
+} from '../utils/fs.js'
 import logger from '@adonisjs/core/services/logger'
 import { randomUUID } from 'node:crypto'
 
@@ -60,6 +64,7 @@ export class KiwixLibraryService {
         logger.warn(`[KiwixLibraryService] Skipping invalid/corrupted ZIM file: ${zimFilePath}`)
         return null
       }
+      const { Archive } = await import('@openzim/libzim')
       const archive = new Archive(zimFilePath)
 
       const getMeta = (key: string): string | undefined => {
@@ -179,8 +184,7 @@ export class KiwixLibraryService {
         faviconMimeType: b['@_faviconMimeType'],
         favicon: b['@_favicon'],
         date: b['@_date'],
-        articleCount:
-          b['@_articleCount'] !== undefined ? Number(b['@_articleCount']) : undefined,
+        articleCount: b['@_articleCount'] !== undefined ? Number(b['@_articleCount']) : undefined,
         mediaCount: b['@_mediaCount'] !== undefined ? Number(b['@_mediaCount']) : undefined,
         size: b['@_size'] !== undefined ? Number(b['@_size']) : undefined,
       }))

--- a/admin/app/services/zim_extraction_service.ts
+++ b/admin/app/services/zim_extraction_service.ts
@@ -1,4 +1,4 @@
-import { Archive, Entry } from '@openzim/libzim'
+import type { Archive, Entry } from '@openzim/libzim'
 import * as cheerio from 'cheerio'
 import { HTML_SELECTORS_TO_REMOVE, NON_CONTENT_HEADING_PATTERNS } from '../../constants/zim_extraction.js'
 import { extractStructuredContent } from '../utils/zim_html.js'
@@ -63,6 +63,7 @@ export class ZIMExtractionService {
                 throw new Error(`ZIM file is invalid or corrupted: ${filePath}`)
             }
 
+            const { Archive } = await import('@openzim/libzim')
             const archive = new Archive(filePath)
 
             // Extract archive-level metadata once

--- a/admin/bin/test.ts
+++ b/admin/bin/test.ts
@@ -12,6 +12,27 @@
 
 process.env.NODE_ENV = 'test'
 
+// Keep a clean checkout able to boot the test runner without requiring a
+// developer's database/Redis credentials. A checked-in .env.test still wins
+// through Adonis' normal environment loading; these values only fill gaps.
+const testDefaults: Record<string, string> = {
+  PORT: '3333',
+  APP_KEY: 'test-only-app-key-not-for-production',
+  HOST: '127.0.0.1',
+  URL: 'http://127.0.0.1:3333',
+  LOG_LEVEL: 'error',
+  DB_HOST: '127.0.0.1',
+  DB_PORT: '3306',
+  DB_USER: 'root',
+  DB_DATABASE: 'nomad_test',
+  REDIS_HOST: '127.0.0.1',
+  REDIS_PORT: '6379',
+}
+
+for (const [key, value] of Object.entries(testDefaults)) {
+  process.env[key] ??= value
+}
+
 import 'reflect-metadata'
 import { Ignitor, prettyPrintError } from '@adonisjs/core'
 import { configure, processCLIArgs, run } from '@japa/runner'


### PR DESCRIPTION
## Problem
A clean checkout cannot start the admin test runner because required test environment variables are absent. The application also imports `@openzim/libzim` at module load time through ZIM services, so tests that do not exercise ZIM code can still require the native binding during boot.

## What changed
- Provide safe test-only defaults for the required environment variables in `admin/bin/test.ts`, while preserving any explicitly supplied values.
- Make the `@openzim/libzim` runtime imports lazy in the two ZIM services; retain type-only imports where needed.
- Preserve the existing ZIM runtime behavior once an extraction/library operation is actually invoked.

## Validation
- `npm run typecheck` (admin)
- `npm test -- --files=tests/unit/zim_html.spec.ts`: all 6 assertions passed; the runner then remained retrying because no Redis service is running locally.
- Targeted ESLint with the repository's existing Prettier-format baseline disabled for the legacy ZIM file
- `git diff --check`
