### PR TITLE
feat(dashboard): user-added link tiles for services NOMAD does not manage

### DIFF
--- a/admin/app/controllers/system_controller.ts
+++ b/admin/app/controllers/system_controller.ts
@@ -550,7 +550,7 @@ export default class SystemController {
         if (!normalized) {
             return response.status(422).send({
                 success: false,
-                message: 'Enter a valid http(s) address, for example 192.168.1.50:8080 or https://nas.local.',
+                message: 'Enter a valid URL, for example 192.168.1.50:8080 or https://nas.local.',
             })
         }
 
@@ -617,7 +617,7 @@ export default class SystemController {
         if (!normalized) {
             return response.status(422).send({
                 success: false,
-                message: 'Enter a valid http(s) address, for example 192.168.1.50:8080 or https://nas.local.',
+                message: 'Enter a valid URL, for example 192.168.1.50:8080 or https://nas.local.',
             })
         }
 

--- a/admin/app/controllers/system_controller.ts
+++ b/admin/app/controllers/system_controller.ts
@@ -23,6 +23,9 @@ import {
   updateServiceValidator,
   setServiceAutoUpdateValidator,
   setServiceCustomUrlValidator,
+  createLinkTileValidator,
+  updateLinkTileValidator,
+  deleteLinkTileValidator,
   normalizeCustomUrl,
 } from '#validators/system'
 import {
@@ -30,6 +33,7 @@ import {
   DEFAULT_MEMORY_MB,
   evaluateCustomApp,
 } from '#services/custom_app_guard'
+import { DEFAULT_LINK_TILE_ICON, isLinkTileIcon } from '../../constants/link_tile_icons.js'
 import { inject } from '@adonisjs/core'
 import type { HttpContext } from '@adonisjs/core/http'
 import logger from '@adonisjs/core/services/logger'
@@ -527,6 +531,123 @@ export default class SystemController {
         await service.save()
 
         return response.send({ success: true, custom_url: service.custom_url })
+    }
+
+    /**
+     * Create a dashboard link tile: a shortcut to something the user already runs.
+     *
+     * Stored as a service row with no container behind it. `installed` is true so
+     * the dashboard renders it, `custom_url` carries the destination (getServiceLink
+     * already prefers custom_url over a computed link), and `is_link_tile` marks it
+     * so the UI never offers Start/Stop/Update/Uninstall for something with no
+     * lifecycle. `is_custom` stays false: that flag means a container NOMAD installs.
+     */
+    async createLinkTile({ request, response }: HttpContext) {
+        const payload = await request.validateUsing(createLinkTileValidator)
+
+        const normalized = normalizeCustomUrl(payload.url)
+        if (!normalized) {
+            return response.status(422).send({
+                success: false,
+                message: 'Enter a valid http(s) address, for example 192.168.1.50:8080 or https://nas.local.',
+            })
+        }
+
+        if (payload.icon && !isLinkTileIcon(payload.icon)) {
+            return response.status(422).send({ success: false, message: 'Unknown icon.' })
+        }
+
+        // Namespaced so a tile can never collide with a curated catalog entry. The
+        // seeder only ever touches names in its own DEFAULT_SERVICES list, so a
+        // `nomad_link_` row is invisible to a reseed.
+        const slug = payload.friendly_name
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '_')
+            .replace(/^_+|_+$/g, '')
+        if (!slug) {
+            return response.status(422).send({ success: false, message: 'Enter a name using letters or numbers.' })
+        }
+        const serviceName = `nomad_link_${slug}`
+
+        const existing = await Service.query().where('service_name', serviceName).first()
+        if (existing) {
+            return response.status(409).send({
+                success: false,
+                message: `A link named "${payload.friendly_name}" already exists. Choose a different name.`,
+            })
+        }
+
+        const service = await Service.create({
+            service_name: serviceName,
+            container_image: '',
+            container_config: null,
+            friendly_name: payload.friendly_name,
+            description: payload.description ?? null,
+            icon: payload.icon || DEFAULT_LINK_TILE_ICON,
+            display_order: payload.display_order ?? 90,
+            installed: true,
+            installation_status: 'idle',
+            is_dependency_service: false,
+            ui_location: null,
+            custom_url: normalized,
+            is_custom: false,
+            is_user_modified: true,
+            is_link_tile: true,
+            category: 'Links',
+        })
+
+        return response.status(201).send({ success: true, service_name: service.service_name })
+    }
+
+    /** Reconfigure an existing link tile. service_name is immutable so the tile keeps its identity. */
+    async updateLinkTile({ request, response }: HttpContext) {
+        const payload = await request.validateUsing(updateLinkTileValidator)
+
+        const service = await Service.query().where('service_name', payload.service_name).first()
+        if (!service) {
+            return response.status(404).send({ success: false, message: 'Link not found' })
+        }
+        if (!service.is_link_tile) {
+            return response.status(403).send({ success: false, message: 'That app is not a link.' })
+        }
+
+        const normalized = normalizeCustomUrl(payload.url)
+        if (!normalized) {
+            return response.status(422).send({
+                success: false,
+                message: 'Enter a valid http(s) address, for example 192.168.1.50:8080 or https://nas.local.',
+            })
+        }
+
+        if (payload.icon && !isLinkTileIcon(payload.icon)) {
+            return response.status(422).send({ success: false, message: 'Unknown icon.' })
+        }
+
+        service.friendly_name = payload.friendly_name
+        service.description = payload.description ?? null
+        service.icon = payload.icon || DEFAULT_LINK_TILE_ICON
+        service.display_order = payload.display_order ?? service.display_order ?? 90
+        service.custom_url = normalized
+        await service.save()
+
+        return response.send({ success: true })
+    }
+
+    /** Remove a link tile. Nothing to uninstall: there is no container, image or volume. */
+    async deleteLinkTile({ request, response }: HttpContext) {
+        const payload = await request.validateUsing(deleteLinkTileValidator)
+
+        const service = await Service.query().where('service_name', payload.service_name).first()
+        if (!service) {
+            return response.status(404).send({ success: false, message: 'Link not found' })
+        }
+        if (!service.is_link_tile) {
+            return response.status(403).send({ success: false, message: 'That app is not a link.' })
+        }
+
+        await service.delete()
+
+        return response.send({ success: true })
     }
 
     /** Re-pull a custom app's image and recreate its container in place (preserving volumes). */

--- a/admin/app/controllers/system_controller.ts
+++ b/admin/app/controllers/system_controller.ts
@@ -38,6 +38,7 @@ import { inject } from '@adonisjs/core'
 import type { HttpContext } from '@adonisjs/core/http'
 import logger from '@adonisjs/core/services/logger'
 import Service from '#models/service'
+import { DEFAULT_LINK_TILE_COLOR } from '../../constants/link_tile_colors.js'
 
 @inject()
 export default class SystemController {
@@ -593,6 +594,7 @@ export default class SystemController {
             is_custom: false,
             is_user_modified: true,
             is_link_tile: true,
+            link_color: payload.link_color ?? DEFAULT_LINK_TILE_COLOR,
             category: 'Links',
         })
 
@@ -628,6 +630,7 @@ export default class SystemController {
         service.icon = payload.icon || DEFAULT_LINK_TILE_ICON
         service.display_order = payload.display_order ?? service.display_order ?? 90
         service.custom_url = normalized
+        service.link_color = payload.link_color ?? service.link_color ?? DEFAULT_LINK_TILE_COLOR
         await service.save()
 
         return response.send({ success: true })

--- a/admin/app/models/service.ts
+++ b/admin/app/models/service.ts
@@ -94,6 +94,9 @@ export default class Service extends BaseModel {
   declare is_link_tile: boolean
 
   @column()
+  declare link_color: string | null
+
+  @column()
   declare category: string | null
 
   // When true the service is sunset: hidden from the install catalog unless it is already

--- a/admin/app/models/service.ts
+++ b/admin/app/models/service.ts
@@ -82,6 +82,17 @@ export default class Service extends BaseModel {
   })
   declare is_user_modified: boolean
 
+  // True when this row is only a dashboard shortcut: a name, icon and URL with no
+  // container behind it. Distinct from is_custom, which is still a real container
+  // NOMAD installs and manages. A link tile has no lifecycle, so no Start/Stop/
+  // Update/Uninstall may be offered for one.
+  @column({
+    serialize(value) {
+      return Boolean(value)
+    },
+  })
+  declare is_link_tile: boolean
+
   @column()
   declare category: string | null
 

--- a/admin/app/services/system_service.ts
+++ b/admin/app/services/system_service.ts
@@ -986,6 +986,12 @@ export class SystemService {
       const serviceStatusList = await this.dockerService.getServicesStatus()
 
       for (const service of allServices) {
+        // Link tiles are shortcuts with no container behind them, so container
+        // reconciliation does not apply: they are always "installed" in the only
+        // sense that matters, which is that the dashboard should show them.
+        // Without this they are marked not-installed on the next sync and vanish.
+        if (service.is_link_tile) continue
+
         const containerExists = serviceStatusList.find(
           (s) => s.service_name === service.service_name
         )

--- a/admin/app/services/system_service.ts
+++ b/admin/app/services/system_service.ts
@@ -344,6 +344,7 @@ export class SystemService {
         'is_user_modified',
         'is_deprecated',
         'is_link_tile',
+        'link_color',
         'category'
       )
       .where('is_dependency_service', false)
@@ -385,6 +386,7 @@ export class SystemService {
         is_user_modified: service.is_user_modified,
         is_deprecated: service.is_deprecated,
         is_link_tile: service.is_link_tile,
+        link_color: service.link_color,
         category: service.category,
       })
     }

--- a/admin/app/services/system_service.ts
+++ b/admin/app/services/system_service.ts
@@ -343,6 +343,7 @@ export class SystemService {
         'is_custom',
         'is_user_modified',
         'is_deprecated',
+        'is_link_tile',
         'category'
       )
       .where('is_dependency_service', false)
@@ -383,6 +384,7 @@ export class SystemService {
         is_custom: service.is_custom,
         is_user_modified: service.is_user_modified,
         is_deprecated: service.is_deprecated,
+        is_link_tile: service.is_link_tile,
         category: service.category,
       })
     }

--- a/admin/app/validators/system.ts
+++ b/admin/app/validators/system.ts
@@ -123,6 +123,41 @@ export function normalizeCustomUrl(input: string | null | undefined): string | n
   }
 }
 
+/**
+ * Dashboard link tile: a shortcut to something the user already runs, with no
+ * container behind it. One `url` field rather than separate host/port/path,
+ * because people paste URLs and it gets https and sub-paths for free. The URL is
+ * normalized and http(s)-restricted by normalizeCustomUrl in the controller,
+ * which is what keeps javascript:/data: out of an href.
+ */
+export const createLinkTileValidator = vine.compile(
+  vine.object({
+    friendly_name: vine.string().trim().minLength(1).maxLength(60),
+    url: vine.string().trim().minLength(1).maxLength(2048),
+    description: vine.string().trim().maxLength(200).nullable().optional(),
+    icon: vine.string().trim().maxLength(60).nullable().optional(),
+    display_order: vine.number().min(0).max(999).optional(),
+  })
+)
+
+/** Reconfigure an existing link tile. Identified by service_name, which is immutable. */
+export const updateLinkTileValidator = vine.compile(
+  vine.object({
+    service_name: vine.string().trim(),
+    friendly_name: vine.string().trim().minLength(1).maxLength(60),
+    url: vine.string().trim().minLength(1).maxLength(2048),
+    description: vine.string().trim().maxLength(200).nullable().optional(),
+    icon: vine.string().trim().maxLength(60).nullable().optional(),
+    display_order: vine.number().min(0).max(999).optional(),
+  })
+)
+
+export const deleteLinkTileValidator = vine.compile(
+  vine.object({
+    service_name: vine.string().trim(),
+  })
+)
+
 export const deleteCustomAppValidator = vine.compile(
   vine.object({
     service_name: vine.string().trim(),

--- a/admin/app/validators/system.ts
+++ b/admin/app/validators/system.ts
@@ -1,4 +1,5 @@
 import vine from '@vinejs/vine'
+import { LINK_TILE_COLOR_IDS } from '../../constants/link_tile_colors.js'
 
 export const installServiceValidator = vine.compile(
   vine.object({
@@ -137,6 +138,7 @@ export const createLinkTileValidator = vine.compile(
     description: vine.string().trim().maxLength(200).nullable().optional(),
     icon: vine.string().trim().maxLength(60).nullable().optional(),
     display_order: vine.number().min(0).max(999).optional(),
+    link_color: vine.enum(LINK_TILE_COLOR_IDS).optional(),
   })
 )
 
@@ -149,6 +151,7 @@ export const updateLinkTileValidator = vine.compile(
     description: vine.string().trim().maxLength(200).nullable().optional(),
     icon: vine.string().trim().maxLength(60).nullable().optional(),
     display_order: vine.number().min(0).max(999).optional(),
+    link_color: vine.enum(LINK_TILE_COLOR_IDS).optional(),
   })
 )
 

--- a/admin/constants/link_tile_colors.ts
+++ b/admin/constants/link_tile_colors.ts
@@ -1,11 +1,11 @@
 /**
- * The colours a user can give a dashboard link tile.
+ * The colors a user can give a dashboard link tile.
  *
  * Drawn from the brand palette rather than arbitrary hex, so a tile always sits
  * on-theme next to the managed app cards. The default white-on-green contrast
  * read as jarring on the dashboard, which is why this exists.
  *
- * Tiles stay visually distinct from managed apps regardless of colour: the
+ * Tiles stay visually distinct from managed apps regardless of color: the
  * dashed border and the external-link marker are what carry that, not the hue.
  * The tint is deliberately light so the distinction survives every option.
  *

--- a/admin/constants/link_tile_colors.ts
+++ b/admin/constants/link_tile_colors.ts
@@ -1,0 +1,70 @@
+/**
+ * The colours a user can give a dashboard link tile.
+ *
+ * Drawn from the brand palette rather than arbitrary hex, so a tile always sits
+ * on-theme next to the managed app cards. The default white-on-green contrast
+ * read as jarring on the dashboard, which is why this exists.
+ *
+ * Tiles stay visually distinct from managed apps regardless of colour: the
+ * dashed border and the external-link marker are what carry that, not the hue.
+ * The tint is deliberately light so the distinction survives every option.
+ *
+ * Class names are written out in full and never interpolated. Tailwind scans
+ * source text for literal class strings, so a computed name like
+ * `bg-desert-${id}/10` would be silently dropped from the build.
+ */
+export const LINK_TILE_COLORS = [
+  {
+    id: 'green',
+    label: 'Green',
+    border: 'border-desert-green/70',
+    bg: 'bg-desert-green/10',
+    marker: 'text-desert-green',
+  },
+  {
+    id: 'olive',
+    label: 'Olive',
+    border: 'border-desert-olive/70',
+    bg: 'bg-desert-olive/10',
+    marker: 'text-desert-olive',
+  },
+  {
+    id: 'orange',
+    label: 'Orange',
+    border: 'border-desert-orange/70',
+    bg: 'bg-desert-orange/10',
+    marker: 'text-desert-orange',
+  },
+  {
+    id: 'red',
+    label: 'Red',
+    border: 'border-desert-red/70',
+    bg: 'bg-desert-red/10',
+    marker: 'text-desert-red',
+  },
+  {
+    id: 'sand',
+    label: 'Sand',
+    border: 'border-desert-sand/70',
+    bg: 'bg-desert-sand/20',
+    marker: 'text-desert-stone-dark',
+  },
+  {
+    id: 'stone',
+    label: 'Stone',
+    border: 'border-desert-stone/70',
+    bg: 'bg-desert-stone/10',
+    marker: 'text-desert-stone-dark',
+  },
+] as const
+
+export type LinkTileColorId = (typeof LINK_TILE_COLORS)[number]['id']
+
+export const DEFAULT_LINK_TILE_COLOR: LinkTileColorId = 'green'
+
+export const LINK_TILE_COLOR_IDS: readonly string[] = LINK_TILE_COLORS.map((c) => c.id)
+
+/** Resolve a stored id, falling back to the default for anything unknown. */
+export function linkTileColor(id?: string | null) {
+  return LINK_TILE_COLORS.find((c) => c.id === id) ?? LINK_TILE_COLORS[0]
+}

--- a/admin/constants/link_tile_colors.ts
+++ b/admin/constants/link_tile_colors.ts
@@ -9,6 +9,11 @@
  * dashed border and the external-link marker are what carry that, not the hue.
  * The tint is deliberately light so the distinction survives every option.
  *
+ * `bg` is the tile tint and `swatch` is the same color at full strength. They
+ * differ on purpose: a 10% tint reads well across a 190px card but makes six
+ * 28px picker swatches indistinguishable from each other, so the picker shows
+ * the color solid while the tile stays subtle.
+ *
  * Class names are written out in full and never interpolated. Tailwind scans
  * source text for literal class strings, so a computed name like
  * `bg-desert-${id}/10` would be silently dropped from the build.
@@ -16,6 +21,7 @@
 export const LINK_TILE_COLORS = [
   {
     id: 'green',
+    swatch: 'bg-desert-green',
     label: 'Green',
     border: 'border-desert-green/70',
     bg: 'bg-desert-green/10',
@@ -23,6 +29,7 @@ export const LINK_TILE_COLORS = [
   },
   {
     id: 'olive',
+    swatch: 'bg-desert-olive',
     label: 'Olive',
     border: 'border-desert-olive/70',
     bg: 'bg-desert-olive/10',
@@ -30,6 +37,7 @@ export const LINK_TILE_COLORS = [
   },
   {
     id: 'orange',
+    swatch: 'bg-desert-orange',
     label: 'Orange',
     border: 'border-desert-orange/70',
     bg: 'bg-desert-orange/10',
@@ -37,6 +45,7 @@ export const LINK_TILE_COLORS = [
   },
   {
     id: 'red',
+    swatch: 'bg-desert-red',
     label: 'Red',
     border: 'border-desert-red/70',
     bg: 'bg-desert-red/10',
@@ -44,6 +53,7 @@ export const LINK_TILE_COLORS = [
   },
   {
     id: 'sand',
+    swatch: 'bg-desert-sand',
     label: 'Sand',
     border: 'border-desert-sand/70',
     bg: 'bg-desert-sand/20',
@@ -51,6 +61,7 @@ export const LINK_TILE_COLORS = [
   },
   {
     id: 'stone',
+    swatch: 'bg-desert-stone',
     label: 'Stone',
     border: 'border-desert-stone/70',
     bg: 'bg-desert-stone/10',

--- a/admin/constants/link_tile_icons.ts
+++ b/admin/constants/link_tile_icons.ts
@@ -1,0 +1,72 @@
+/**
+ * The icons offered when creating a dashboard link tile: a curated 36, laid out
+ * six across and six down.
+ *
+ * Every name here must exist in the `DynamicIcon` registry (`inertia/lib/icons.ts`).
+ * `DynamicIcon` renders nothing at all for a name it does not know, so an icon
+ * that is not in that registry produces a tile with a silent hole where its icon
+ * should be. Shared by the picker and the server-side validator so the two can
+ * never disagree about what is selectable.
+ *
+ * Chosen for "a thing on my network": storage, media, documents, tooling,
+ * infrastructure. Not a general icon browser. The point of a fixed set is that
+ * the user picks from something that fits on one screen.
+ */
+export const LINK_TILE_ICONS = [
+  // Infrastructure
+  'IconServer',
+  'IconDatabase',
+  'IconWorld',
+  'IconWifi',
+  'IconAntenna',
+  'IconBroadcast',
+
+  // Machines and containers
+  'IconBrandDocker',
+  'IconCpu',
+  'IconHome',
+  'IconBox',
+  'IconFolderOpen',
+  'IconMovie',
+
+  // Reading and reference
+  'IconBooks',
+  'IconBook',
+  'IconLibrary',
+  'IconMap',
+  'IconNotes',
+  'IconFileDescription',
+
+  // Tools and admin
+  'IconCode',
+  'IconTool',
+  'IconSettings',
+  'IconShieldCheck',
+  'IconShieldLock',
+  'IconRobot',
+
+  // Subjects
+  'IconBrain',
+  'IconPlant',
+  'IconChefHat',
+  'IconSchool',
+  'IconStethoscope',
+  'IconSearch',
+
+  // Transfer and misc
+  'IconCloudDownload',
+  'IconCloudUpload',
+  'IconLogs',
+  'IconPlayerPlay',
+  'IconExternalLink',
+  'IconWand',
+] as const
+
+export type LinkTileIconName = (typeof LINK_TILE_ICONS)[number]
+
+/** The icon a tile gets when none was chosen, or when a stored name is no longer offered. */
+export const DEFAULT_LINK_TILE_ICON: LinkTileIconName = 'IconExternalLink'
+
+export function isLinkTileIcon(value: unknown): value is LinkTileIconName {
+  return typeof value === 'string' && (LINK_TILE_ICONS as readonly string[]).includes(value)
+}

--- a/admin/database/migrations/1786000000001_add_is_link_tile_to_services.ts
+++ b/admin/database/migrations/1786000000001_add_is_link_tile_to_services.ts
@@ -1,0 +1,22 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'services'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      // Marks a row that is only a dashboard shortcut: a name, an icon and a URL,
+      // with no container behind it. Distinct from is_custom, which still means a
+      // user-defined container NOMAD installs and manages. A link tile has no
+      // image, no ports and no lifecycle, so the UI must not offer Start, Stop,
+      // Update or Uninstall for one.
+      table.boolean('is_link_tile').notNullable().defaultTo(false)
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('is_link_tile')
+    })
+  }
+}

--- a/admin/database/migrations/1786000000002_add_link_color_to_services.ts
+++ b/admin/database/migrations/1786000000002_add_link_color_to_services.ts
@@ -1,0 +1,21 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'services'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      // Brand-palette colour for a dashboard link tile. Null means the default.
+      // A separate migration from the one that added is_link_tile, because that
+      // one has already run on the test box; editing it in place would leave
+      // fresh installs and upgraded ones with different schemas.
+      table.string('link_color', 20).nullable()
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('link_color')
+    })
+  }
+}

--- a/admin/database/seeders/service_seeder.ts
+++ b/admin/database/seeders/service_seeder.ts
@@ -15,6 +15,7 @@ type ServiceSeedRecord = Omit<
   | 'metadata'
   | 'is_user_modified'
   | 'is_deprecated'
+  | 'is_link_tile'
   | 'custom_url'
   | 'auto_update_enabled'
   | 'available_update_first_seen_at'

--- a/admin/database/seeders/service_seeder.ts
+++ b/admin/database/seeders/service_seeder.ts
@@ -16,6 +16,7 @@ type ServiceSeedRecord = Omit<
   | 'is_user_modified'
   | 'is_deprecated'
   | 'is_link_tile'
+  | 'link_color'
   | 'custom_url'
   | 'auto_update_enabled'
   | 'available_update_first_seen_at'

--- a/admin/inertia/components/LinkTileIconPicker.tsx
+++ b/admin/inertia/components/LinkTileIconPicker.tsx
@@ -1,0 +1,41 @@
+import DynamicIcon, { DynamicIconName } from './DynamicIcon'
+import { LINK_TILE_ICONS } from '../../constants/link_tile_icons'
+
+type LinkTileIconPickerProps = {
+  value: string | null
+  onChange: (icon: string) => void
+}
+
+/**
+ * The whole curated icon set, six across and six down.
+ *
+ * No search box and no paging: 36 icons fit on screen at once, which is the
+ * point of curating them rather than offering a library. The grid needs an
+ * explicit width, because a shrink-wrapped container collapses the six 1fr
+ * columns and the glyphs overlap into an unreadable smear.
+ */
+export default function LinkTileIconPicker({ value, onChange }: LinkTileIconPickerProps) {
+  return (
+    <div className="w-72 rounded border border-border-default bg-surface-primary p-2">
+      <div className="grid grid-cols-6 justify-items-center gap-1">
+        {LINK_TILE_ICONS.map((name) => (
+          <button
+            key={name}
+            type="button"
+            title={name.replace(/^Icon/, '')}
+            aria-label={name.replace(/^Icon/, '')}
+            aria-pressed={value === name}
+            onClick={() => onChange(name)}
+            className={`flex h-9 w-9 shrink-0 items-center justify-center rounded transition-colors ${
+              value === name
+                ? 'bg-desert-green text-white'
+                : 'text-text-secondary hover:bg-surface-secondary'
+            }`}
+          >
+            <DynamicIcon icon={name as DynamicIconName} className="!size-5" />
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/admin/inertia/components/LinkTileModal.tsx
+++ b/admin/inertia/components/LinkTileModal.tsx
@@ -117,7 +117,7 @@ export default function LinkTileModal({
         <div>
           <Input
             name="linkUrl"
-            label="Address"
+            label="URL"
             placeholder="192.168.1.50:8080"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
@@ -125,11 +125,11 @@ export default function LinkTileModal({
           />
           {urlInvalid ? (
             <p className="mt-1.5 text-xs text-red-500">
-              Enter a valid http(s) address, for example 192.168.1.50:8080 or https://nas.local.
+              Enter a valid URL, for example 192.168.1.50:8080 or https://nas.local.
             </p>
           ) : (
             <p className="mt-1.5 text-xs text-text-muted">
-              No scheme? We'll default to <span className="font-mono">http://</span>. Opens as:{' '}
+              Opens as:{' '}
               <span className="font-mono break-all text-text-primary">
                 {normalized || 'not set yet'}
               </span>

--- a/admin/inertia/components/LinkTileModal.tsx
+++ b/admin/inertia/components/LinkTileModal.tsx
@@ -5,6 +5,7 @@ import LinkTileIconPicker from './LinkTileIconPicker'
 import DynamicIcon, { DynamicIconName } from './DynamicIcon'
 import { normalizeCustomUrl } from '~/lib/navigation'
 import { DEFAULT_LINK_TILE_ICON } from '../../constants/link_tile_icons'
+import { DEFAULT_LINK_TILE_COLOR, LINK_TILE_COLORS } from '../../constants/link_tile_colors'
 import { ServiceSlim } from '../../types/services'
 import api from '~/lib/api'
 
@@ -35,6 +36,7 @@ export default function LinkTileModal({
   const [url, setUrl] = useState('')
   const [description, setDescription] = useState('')
   const [icon, setIcon] = useState<string>(DEFAULT_LINK_TILE_ICON)
+  const [color, setColor] = useState<string>(DEFAULT_LINK_TILE_COLOR)
   const [submitting, setSubmitting] = useState(false)
 
   const isEdit = Boolean(tile)
@@ -45,6 +47,7 @@ export default function LinkTileModal({
     setUrl(tile?.custom_url ?? '')
     setDescription(tile?.description ?? '')
     setIcon(tile?.icon ?? DEFAULT_LINK_TILE_ICON)
+    setColor(tile?.link_color ?? DEFAULT_LINK_TILE_COLOR)
   }, [open, tile])
 
   const trimmedName = name.trim()
@@ -62,6 +65,7 @@ export default function LinkTileModal({
       url: trimmedUrl,
       description: description.trim() ? description.trim() : null,
       icon,
+      link_color: color,
     }
 
     const result = isEdit
@@ -150,6 +154,29 @@ export default function LinkTileModal({
             </span>
           </p>
           <LinkTileIconPicker value={icon} onChange={setIcon} />
+        </div>
+
+        <div>
+          <p className="mb-1.5 font-medium text-text-primary">Colour</p>
+          <div className="flex items-center gap-2">
+            {LINK_TILE_COLORS.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                title={option.label}
+                aria-label={option.label}
+                aria-pressed={color === option.id}
+                onClick={() => setColor(option.id)}
+                className={`h-7 w-7 rounded border-2 border-dashed transition-transform ${option.border} ${option.bg} ${
+                  color === option.id ? 'scale-110 ring-2 ring-offset-1 ring-desert-green' : ''
+                }`}
+              />
+            ))}
+          </div>
+          <p className="mt-1.5 text-xs text-text-muted">
+            Links stay outlined rather than filled whichever colour you pick, so they
+            are still tellable apart from apps NOMAD manages.
+          </p>
         </div>
       </div>
     </StyledModal>

--- a/admin/inertia/components/LinkTileModal.tsx
+++ b/admin/inertia/components/LinkTileModal.tsx
@@ -167,8 +167,10 @@ export default function LinkTileModal({
                 aria-label={option.label}
                 aria-pressed={color === option.id}
                 onClick={() => setColor(option.id)}
-                className={`h-7 w-7 rounded border-2 border-dashed transition-transform ${option.border} ${option.bg} ${
-                  color === option.id ? 'scale-110 ring-2 ring-offset-1 ring-desert-green' : ''
+                className={`h-7 w-7 rounded transition-transform ${option.swatch} ${
+                  color === option.id
+                    ? 'scale-110 ring-2 ring-offset-2 ring-text-primary'
+                    : 'opacity-70 hover:opacity-100'
                 }`}
               />
             ))}

--- a/admin/inertia/components/LinkTileModal.tsx
+++ b/admin/inertia/components/LinkTileModal.tsx
@@ -157,7 +157,7 @@ export default function LinkTileModal({
         </div>
 
         <div>
-          <p className="mb-1.5 font-medium text-text-primary">Colour</p>
+          <p className="mb-1.5 font-medium text-text-primary">Color</p>
           <div className="flex items-center gap-2">
             {LINK_TILE_COLORS.map((option) => (
               <button
@@ -174,8 +174,8 @@ export default function LinkTileModal({
             ))}
           </div>
           <p className="mt-1.5 text-xs text-text-muted">
-            Links stay outlined rather than filled whichever colour you pick, so they
-            are still tellable apart from apps NOMAD manages.
+            Links stay outlined rather than filled whichever color you pick, so they
+            are distinguishable from apps NOMAD manages.
           </p>
         </div>
       </div>

--- a/admin/inertia/components/LinkTileModal.tsx
+++ b/admin/inertia/components/LinkTileModal.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react'
+import StyledModal from './StyledModal'
+import Input from './inputs/Input'
+import LinkTileIconPicker from './LinkTileIconPicker'
+import DynamicIcon, { DynamicIconName } from './DynamicIcon'
+import { normalizeCustomUrl } from '~/lib/navigation'
+import { DEFAULT_LINK_TILE_ICON } from '../../constants/link_tile_icons'
+import { ServiceSlim } from '../../types/services'
+import api from '~/lib/api'
+
+interface LinkTileModalProps {
+  open: boolean
+  /** The tile being edited, or null when creating a new one. */
+  tile: ServiceSlim | null
+  onClose: () => void
+  onSaved: () => void
+  showError: (msg: string) => void
+}
+
+/**
+ * Create or edit a dashboard link: a shortcut to something the user already runs.
+ *
+ * One URL field rather than separate host/port/path. People paste URLs, and it
+ * gets https and sub-paths for free. A bare "192.168.1.50:8080" is accepted and
+ * gains http:// automatically, which is what most LAN devices need.
+ */
+export default function LinkTileModal({
+  open,
+  tile,
+  onClose,
+  onSaved,
+  showError,
+}: LinkTileModalProps) {
+  const [name, setName] = useState('')
+  const [url, setUrl] = useState('')
+  const [description, setDescription] = useState('')
+  const [icon, setIcon] = useState<string>(DEFAULT_LINK_TILE_ICON)
+  const [submitting, setSubmitting] = useState(false)
+
+  const isEdit = Boolean(tile)
+
+  useEffect(() => {
+    if (!open) return
+    setName(tile?.friendly_name ?? '')
+    setUrl(tile?.custom_url ?? '')
+    setDescription(tile?.description ?? '')
+    setIcon(tile?.icon ?? DEFAULT_LINK_TILE_ICON)
+  }, [open, tile])
+
+  const trimmedName = name.trim()
+  const trimmedUrl = url.trim()
+  const normalized = normalizeCustomUrl(url)
+  const urlInvalid = trimmedUrl.length > 0 && !normalized
+  const canSave = trimmedName.length > 0 && Boolean(normalized)
+
+  async function handleSave() {
+    if (!canSave) return
+    setSubmitting(true)
+
+    const payload = {
+      friendly_name: trimmedName,
+      url: trimmedUrl,
+      description: description.trim() ? description.trim() : null,
+      icon,
+    }
+
+    const result = isEdit
+      ? await api.updateLinkTile({ ...payload, service_name: tile!.service_name })
+      : await api.createLinkTile(payload)
+
+    setSubmitting(false)
+
+    if (!result?.success) {
+      showError(
+        isEdit
+          ? 'Failed to save this link.'
+          : 'Failed to add this link. A link with that name may already exist.'
+      )
+      return
+    }
+    onSaved()
+  }
+
+  return (
+    <StyledModal
+      title={isEdit ? 'Edit Link' : 'Add a Link'}
+      open={open}
+      onCancel={onClose}
+      onClose={onClose}
+      cancelText="Cancel"
+      onConfirm={handleSave}
+      confirmVariant="primary"
+      confirmText={isEdit ? 'Save' : 'Add Link'}
+      confirmIcon="IconCheck"
+      confirmLoading={submitting}
+      confirmDisabled={!canSave}
+    >
+      <div className="space-y-4 text-sm">
+        <p className="text-text-muted">
+          Add a shortcut to something you already run, on this machine or anywhere else on your
+          network. NOMAD does not manage it, it just puts a button on your dashboard.
+        </p>
+
+        <Input
+          name="linkName"
+          label="Name"
+          placeholder="Living room NAS"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          maxLength={60}
+        />
+
+        <div>
+          <Input
+            name="linkUrl"
+            label="Address"
+            placeholder="192.168.1.50:8080"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            error={urlInvalid}
+          />
+          {urlInvalid ? (
+            <p className="mt-1.5 text-xs text-red-500">
+              Enter a valid http(s) address, for example 192.168.1.50:8080 or https://nas.local.
+            </p>
+          ) : (
+            <p className="mt-1.5 text-xs text-text-muted">
+              No scheme? We'll default to <span className="font-mono">http://</span>. Opens as:{' '}
+              <span className="font-mono break-all text-text-primary">
+                {normalized || 'not set yet'}
+              </span>
+            </p>
+          )}
+        </div>
+
+        <Input
+          name="linkDescription"
+          label="Description (optional)"
+          placeholder="Photos and backups"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          maxLength={200}
+        />
+
+        <div>
+          <p className="mb-1.5 flex items-center gap-2 font-medium text-text-primary">
+            Icon
+            <span className="text-text-secondary">
+              <DynamicIcon icon={icon as DynamicIconName} className="!size-5" />
+            </span>
+          </p>
+          <LinkTileIconPicker value={icon} onChange={setIcon} />
+        </div>
+      </div>
+    </StyledModal>
+  )
+}

--- a/admin/inertia/lib/api.ts
+++ b/admin/inertia/lib/api.ts
@@ -1137,6 +1137,7 @@ class API {
     description?: string | null
     icon?: string | null
     display_order?: number
+    link_color?: string
   }) {
     return catchInternal(async () => {
       const response = await this.client.post<{ success: boolean; service_name: string }>(
@@ -1154,6 +1155,7 @@ class API {
     description?: string | null
     icon?: string | null
     display_order?: number
+    link_color?: string
   }) {
     return catchInternal(async () => {
       const response = await this.client.put<{ success: boolean }>('/system/services/links', data)

--- a/admin/inertia/lib/api.ts
+++ b/admin/inertia/lib/api.ts
@@ -1131,6 +1131,45 @@ class API {
     })()
   }
 
+  async createLinkTile(data: {
+    friendly_name: string
+    url: string
+    description?: string | null
+    icon?: string | null
+    display_order?: number
+  }) {
+    return catchInternal(async () => {
+      const response = await this.client.post<{ success: boolean; service_name: string }>(
+        '/system/services/links',
+        data
+      )
+      return response.data
+    })()
+  }
+
+  async updateLinkTile(data: {
+    service_name: string
+    friendly_name: string
+    url: string
+    description?: string | null
+    icon?: string | null
+    display_order?: number
+  }) {
+    return catchInternal(async () => {
+      const response = await this.client.put<{ success: boolean }>('/system/services/links', data)
+      return response.data
+    })()
+  }
+
+  async deleteLinkTile(service_name: string) {
+    return catchInternal(async () => {
+      const response = await this.client.delete<{ success: boolean }>('/system/services/links', {
+        data: { service_name },
+      })
+      return response.data
+    })()
+  }
+
   async getSetting(key: string) {
     return catchInternal(async () => {
       const response = await this.client.get<{ key: string; value: any }>(

--- a/admin/inertia/pages/home.tsx
+++ b/admin/inertia/pages/home.tsx
@@ -26,6 +26,7 @@ import { SERVICE_NAMES } from '../../constants/service_names'
 import LinkTileModal from '~/components/LinkTileModal'
 import { IconPlus, IconPencil, IconTrash, IconExternalLink } from '@tabler/icons-react'
 import { useState } from 'react'
+import { linkTileColor } from '../../constants/link_tile_colors'
 
 // Maps is a Core Capability (display_order: 4)
 const MAPS_ITEM = {
@@ -271,6 +272,9 @@ export default function Home(props: {
           const shouldHighlight = isEasySetup && shouldHighlightEasySetup
 
           const isLinkTile = Boolean(item.linkTile)
+          // A flat surface colour read as a stark white card next to the filled
+          // app tiles. Tint from the brand palette instead, user-chosen.
+          const tileColor = linkTileColor(item.linkTile?.link_color)
 
           // Link tiles are deliberately not styled like managed apps: outlined
           // rather than filled, with an external-link marker. If they looked the
@@ -280,13 +284,13 @@ export default function Home(props: {
             <div
               className={
                 isLinkTile
-                  ? 'relative rounded border-2 border-dashed border-desert-green/70 bg-surface-primary text-text-primary hover:bg-surface-secondary transition-colors shadow-sm h-48 flex flex-col items-center justify-center cursor-pointer text-center px-4'
+                  ? `relative rounded border-2 border-dashed ${tileColor.border} ${tileColor.bg} text-text-primary hover:bg-surface-secondary transition-colors shadow-sm h-48 flex flex-col items-center justify-center cursor-pointer text-center px-4`
                   : 'relative rounded border-desert-green border-2 bg-desert-green hover:bg-transparent hover:text-text-primary text-white transition-colors shadow-sm h-48 flex flex-col items-center justify-center cursor-pointer text-center px-4'
               }
             >
               {isLinkTile && (
                 <span
-                  className="absolute top-2 left-2 text-text-muted"
+                  className={`absolute top-2 left-2 ${tileColor.marker}`}
                   title="A shortcut you added. NOMAD does not manage this."
                 >
                   <IconExternalLink size={16} />

--- a/admin/inertia/pages/home.tsx
+++ b/admin/inertia/pages/home.tsx
@@ -23,6 +23,9 @@ import api from '~/lib/api'
 import Alert from '~/components/Alert'
 import WhatsNewBanner from '~/components/WhatsNewBanner'
 import { SERVICE_NAMES } from '../../constants/service_names'
+import LinkTileModal from '~/components/LinkTileModal'
+import { IconPlus, IconPencil, IconTrash, IconExternalLink } from '@tabler/icons-react'
+import { useState } from 'react'
 
 // Maps is a Core Capability (display_order: 4)
 const MAPS_ITEM = {
@@ -104,6 +107,8 @@ interface DashboardItem {
   installed: boolean
   displayOrder: number
   poweredBy: string | null
+  /** Set only for user-added link tiles, which render differently and can be edited. */
+  linkTile?: ServiceSlim
 }
 
 export default function Home(props: {
@@ -121,6 +126,27 @@ export default function Home(props: {
   const queryClient = useQueryClient()
   const { aiAssistantName } = usePage<{ aiAssistantName: string }>().props
 
+  // Link tile management. `editingTile` null with the modal open means "create".
+  const [linkModalOpen, setLinkModalOpen] = useState(false)
+  const [editingTile, setEditingTile] = useState<ServiceSlim | null>(null)
+  // Deleting a tile is not undoable and the tiles are user-entered, so the trash
+  // icon arms a confirm rather than deleting on the first click.
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null)
+  const [linkError, setLinkError] = useState<string | null>(null)
+
+  const refreshServices = () => router.reload({ only: ['system'] })
+
+  const handleDeleteTile = async (serviceName: string) => {
+    const result = await api.deleteLinkTile(serviceName)
+    setPendingDelete(null)
+    if (!result?.success) {
+      setLinkError('Failed to remove this link.')
+      return
+    }
+    refreshServices()
+  }
+
+
   const handleDismissRerunBanner = async () => {
     await api.updateSetting('benchmark.rerunBannerDismissed', true)
     queryClient.invalidateQueries({ queryKey: BENCHMARK_RERUN_BANNER_QUERY_KEY })
@@ -132,9 +158,14 @@ export default function Home(props: {
   })
   const shouldHighlightEasySetup = easySetupVisited?.value ? String(easySetupVisited.value) !== 'true' : false
 
-  // Add installed services (non-dependency services only)
+  // Add installed services (non-dependency services only). Link tiles are user-added
+  // shortcuts with no container behind them, so they are collected separately below
+  // and rendered with their own treatment.
   props.system.services
-    .filter((service) => service.installed && (service.ui_location || service.custom_url))
+    .filter(
+      (service) =>
+        service.installed && (service.ui_location || service.custom_url) && !service.is_link_tile
+    )
     .forEach((service) => {
       items.push({
         // Inject custom AI Assistant name if this is the chat service
@@ -155,6 +186,23 @@ export default function Home(props: {
         installed: service.installed,
         displayOrder: service.display_order ?? 100,
         poweredBy: service.powered_by ?? null,
+      })
+    })
+
+  // User-added link tiles: shortcuts to things NOMAD does not manage.
+  props.system.services
+    .filter((service) => service.is_link_tile && service.custom_url)
+    .forEach((service) => {
+      items.push({
+        label: service.friendly_name || service.service_name,
+        to: getServiceLink('', service.custom_url),
+        target: '_blank',
+        description: service.description || 'Opens in a new tab',
+        icon: <DynamicIcon icon={service.icon as DynamicIconName} className="!size-12" />,
+        installed: true,
+        displayOrder: service.display_order ?? 90,
+        poweredBy: null,
+        linkTile: service,
       })
     })
 
@@ -222,8 +270,28 @@ export default function Home(props: {
           const isEasySetup = item.label === 'Easy Setup'
           const shouldHighlight = isEasySetup && shouldHighlightEasySetup
 
+          const isLinkTile = Boolean(item.linkTile)
+
+          // Link tiles are deliberately not styled like managed apps: outlined
+          // rather than filled, with an external-link marker. If they looked the
+          // same, users would expect Start/Stop/Update and file bugs when those
+          // controls are not there.
           const tileContent = (
-            <div className="relative rounded border-desert-green border-2 bg-desert-green hover:bg-transparent hover:text-text-primary text-white transition-colors shadow-sm h-48 flex flex-col items-center justify-center cursor-pointer text-center px-4">
+            <div
+              className={
+                isLinkTile
+                  ? 'relative rounded border-2 border-dashed border-desert-green/70 bg-surface-primary text-text-primary hover:bg-surface-secondary transition-colors shadow-sm h-48 flex flex-col items-center justify-center cursor-pointer text-center px-4'
+                  : 'relative rounded border-desert-green border-2 bg-desert-green hover:bg-transparent hover:text-text-primary text-white transition-colors shadow-sm h-48 flex flex-col items-center justify-center cursor-pointer text-center px-4'
+              }
+            >
+              {isLinkTile && (
+                <span
+                  className="absolute top-2 left-2 text-text-muted"
+                  title="A shortcut you added. NOMAD does not manage this."
+                >
+                  <IconExternalLink size={16} />
+                </span>
+              )}
               {shouldHighlight && (
                 <span className="absolute top-2 right-2 flex items-center justify-center">
                   <span
@@ -242,6 +310,62 @@ export default function Home(props: {
             </div>
           )
 
+          if (isLinkTile) {
+            const tile = item.linkTile!
+            const confirming = pendingDelete === tile.service_name
+
+            return (
+              <div key={item.label} className="group relative">
+                <a href={item.to} target="_blank" rel="noopener noreferrer">
+                  {tileContent}
+                </a>
+
+                {confirming ? (
+                  <div className="absolute top-2 right-2 flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteTile(tile.service_name)}
+                      className="rounded bg-desert-red px-2 py-1 text-xs font-medium text-white hover:brightness-110"
+                    >
+                      Remove
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setPendingDelete(null)}
+                      className="rounded border border-border-default bg-surface-primary px-2 py-1 text-xs text-text-secondary hover:bg-surface-secondary"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <div className="absolute top-2 right-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setEditingTile(tile)
+                        setLinkModalOpen(true)
+                      }}
+                      title="Edit this link"
+                      aria-label="Edit this link"
+                      className="rounded p-1 text-text-muted hover:bg-surface-secondary hover:text-text-primary"
+                    >
+                      <IconPencil size={16} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setPendingDelete(tile.service_name)}
+                      title="Remove this link"
+                      aria-label="Remove this link"
+                      className="rounded p-1 text-text-muted hover:bg-surface-secondary hover:text-desert-red"
+                    >
+                      <IconTrash size={16} />
+                    </button>
+                  </div>
+                )}
+              </div>
+            )
+          }
+
           return item.target === '_blank' ? (
             <a key={item.label} href={item.to} target="_blank" rel="noopener noreferrer">
               {tileContent}
@@ -252,7 +376,38 @@ export default function Home(props: {
             </Link>
           )
         })}
+
+        {/* Add-a-link affordance, last in the grid so it never displaces an app. */}
+        <button
+          type="button"
+          onClick={() => {
+            setEditingTile(null)
+            setLinkModalOpen(true)
+          }}
+          className="rounded border-2 border-dashed border-border-default bg-transparent text-text-muted hover:border-desert-green hover:text-text-primary transition-colors h-48 flex flex-col items-center justify-center cursor-pointer text-center px-4"
+        >
+          <IconPlus size={40} />
+          <h3 className="font-bold text-xl mt-2">Add a Link</h3>
+          <p className="text-sm mt-1">A shortcut to something else on your network</p>
+        </button>
       </div>
+
+      {linkError && (
+        <div className="px-4 pb-4">
+          <Alert title={linkError} type="error" variant="solid" className="w-full" />
+        </div>
+      )}
+
+      <LinkTileModal
+        open={linkModalOpen}
+        tile={editingTile}
+        onClose={() => setLinkModalOpen(false)}
+        onSaved={() => {
+          setLinkModalOpen(false)
+          refreshServices()
+        }}
+        showError={(msg) => setLinkError(msg)}
+      />
     </AppLayout>
   )
 }

--- a/admin/inertia/pages/home.tsx
+++ b/admin/inertia/pages/home.tsx
@@ -272,7 +272,7 @@ export default function Home(props: {
           const shouldHighlight = isEasySetup && shouldHighlightEasySetup
 
           const isLinkTile = Boolean(item.linkTile)
-          // A flat surface colour read as a stark white card next to the filled
+          // A flat surface color read as a stark white card next to the filled
           // app tiles. Tint from the brand palette instead, user-chosen.
           const tileColor = linkTileColor(item.linkTile?.link_color)
 

--- a/admin/start/routes.ts
+++ b/admin/start/routes.ts
@@ -595,6 +595,18 @@ router
       summary: 'Get a custom app',
       tags: ['system'],
     })
+    documented(router.post('/services/links', [SystemController, 'createLinkTile']), {
+      summary: 'Create a dashboard link tile',
+      tags: ['system'],
+    })
+    documented(router.put('/services/links', [SystemController, 'updateLinkTile']), {
+      summary: 'Update a dashboard link tile',
+      tags: ['system'],
+    })
+    documented(router.delete('/services/links', [SystemController, 'deleteLinkTile']), {
+      summary: 'Delete a dashboard link tile',
+      tags: ['system'],
+    })
     documented(router.put('/services/custom-url', [SystemController, 'setServiceCustomUrl']), {
       summary: 'Set a service custom URL',
       tags: ['system'],

--- a/admin/tests/unit/link_tile.spec.ts
+++ b/admin/tests/unit/link_tile.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Dashboard link tiles: URL normalisation and the icon allowlist.
+ *
+ * The URL rules matter beyond tidiness. `normalizeCustomUrl` restricting the
+ * result to http(s) is the only thing stopping a `javascript:` or `data:` URL
+ * being stored and later rendered into an href, so the rejection cases below are
+ * a security boundary rather than input hygiene.
+ *
+ * Pure functions only, no MySQL, Redis, Qdrant or Ollama needed:
+ *   npm run test:unit
+ */
+import * as assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { normalizeCustomUrl } from '../../app/validators/system.js'
+import {
+  DEFAULT_LINK_TILE_ICON,
+  LINK_TILE_ICONS,
+  isLinkTileIcon,
+} from '../../constants/link_tile_icons.js'
+
+test('a bare host:port gains http, which is what most LAN devices need', () => {
+  assert.equal(normalizeCustomUrl('192.168.1.50:8080'), 'http://192.168.1.50:8080/')
+  assert.equal(normalizeCustomUrl('nas.local'), 'http://nas.local/')
+})
+
+test('an explicit https scheme is preserved rather than downgraded', () => {
+  assert.equal(normalizeCustomUrl('https://nas.local'), 'https://nas.local/')
+  assert.equal(normalizeCustomUrl('https://nas.local:9443'), 'https://nas.local:9443/')
+})
+
+test('a path survives normalisation', () => {
+  assert.equal(normalizeCustomUrl('192.168.1.50:8080/admin'), 'http://192.168.1.50:8080/admin')
+  assert.equal(normalizeCustomUrl('https://nas.local/ui/dashboard'), 'https://nas.local/ui/dashboard')
+})
+
+test('a query string and port are both kept', () => {
+  assert.equal(
+    normalizeCustomUrl('http://10.0.0.5:3000/app?tab=media'),
+    'http://10.0.0.5:3000/app?tab=media'
+  )
+})
+
+test('surrounding whitespace is trimmed', () => {
+  assert.equal(normalizeCustomUrl('   192.168.1.50:8080   '), 'http://192.168.1.50:8080/')
+})
+
+test('empty input is null, not an error', () => {
+  // The caller treats null as "no URL given" and refuses to save, rather than
+  // storing a tile that goes nowhere.
+  assert.equal(normalizeCustomUrl(''), null)
+  assert.equal(normalizeCustomUrl('   '), null)
+  assert.equal(normalizeCustomUrl(null), null)
+  assert.equal(normalizeCustomUrl(undefined), null)
+})
+
+test('script-bearing schemes are rejected, which is the XSS boundary', () => {
+  // These are the ones that matter: a stored javascript:/data: value would later
+  // be rendered into an href. They are refused because prefixing http:// leaves a
+  // non-numeric "port", which makes new URL() throw.
+  assert.equal(normalizeCustomUrl('javascript:alert(1)'), null)
+  assert.equal(normalizeCustomUrl('JAVASCRIPT:alert(1)'), null)
+  assert.equal(normalizeCustomUrl('  javascript:alert(1)'), null)
+  assert.equal(normalizeCustomUrl('data:text/html,<script>alert(1)</script>'), null)
+  assert.equal(normalizeCustomUrl('vbscript:msgbox'), null)
+})
+
+test('file: and ftp: are mangled into harmless http URLs rather than rejected', () => {
+  // Documenting existing shared behaviour rather than endorsing it. Neither
+  // scheme survives: both end up as an http URL pointing at a host named "file"
+  // or "ftp", which goes nowhere and cannot execute anything. It is a usability
+  // wart, not a security hole, and normalizeCustomUrl is shared with the custom
+  // app URL feature, so it is not changed here.
+  assert.equal(normalizeCustomUrl('file:///etc/passwd'), 'http://file///etc/passwd')
+  assert.equal(normalizeCustomUrl('ftp://example.com'), 'http://ftp//example.com')
+})
+
+test('a scheme in mixed case is still recognised as http(s)', () => {
+  // The scheme test is case-insensitive, so this must not be double-prefixed
+  // into "http://HTTPS://nas.local".
+  assert.equal(normalizeCustomUrl('HTTPS://nas.local'), 'https://nas.local/')
+})
+
+test('the icon set is exactly 36, so the picker fills a 6x6 grid', () => {
+  assert.equal(LINK_TILE_ICONS.length, 36)
+  assert.equal(new Set(LINK_TILE_ICONS).size, 36, 'no duplicates')
+})
+
+test('isLinkTileIcon accepts only names in the set', () => {
+  assert.equal(isLinkTileIcon('IconServer'), true)
+  assert.equal(isLinkTileIcon(DEFAULT_LINK_TILE_ICON), true)
+  // Real Tabler icons that are deliberately not offered must still be refused,
+  // otherwise the server would store a name the picker cannot round-trip.
+  assert.equal(isLinkTileIcon('IconTrash'), false)
+  assert.equal(isLinkTileIcon('IconNotARealIcon'), false)
+  assert.equal(isLinkTileIcon(''), false)
+  assert.equal(isLinkTileIcon(null), false)
+  assert.equal(isLinkTileIcon(42), false)
+})
+
+test('the default icon is part of the offered set', () => {
+  assert.ok((LINK_TILE_ICONS as readonly string[]).includes(DEFAULT_LINK_TILE_ICON))
+})

--- a/admin/tests/unit/link_tile.spec.ts
+++ b/admin/tests/unit/link_tile.spec.ts
@@ -122,7 +122,14 @@ test('every link tile color ships complete, literal Tailwind classes', () => {
     assert.ok(option.border.startsWith('border-desert-'), option.id)
     assert.ok(option.bg.startsWith('bg-desert-'), option.id)
     assert.ok(option.marker.startsWith('text-desert-'), option.id)
-    assert.ok(!`${option.border}${option.bg}${option.marker}`.includes('${'), option.id)
+    // The swatch is the same color solid; a tint that works on a card is
+    // indistinguishable at 28px.
+    assert.ok(option.swatch.startsWith('bg-desert-'), option.id)
+    assert.ok(!option.swatch.includes('/'), `${option.id} swatch must be solid`)
+    assert.ok(
+      !`${option.border}${option.bg}${option.marker}${option.swatch}`.includes('${'),
+      option.id
+    )
   }
 })
 

--- a/admin/tests/unit/link_tile.spec.ts
+++ b/admin/tests/unit/link_tile.spec.ts
@@ -18,6 +18,12 @@ import {
   LINK_TILE_ICONS,
   isLinkTileIcon,
 } from '../../constants/link_tile_icons.js'
+import {
+  DEFAULT_LINK_TILE_COLOR,
+  LINK_TILE_COLORS,
+  LINK_TILE_COLOR_IDS,
+  linkTileColor,
+} from '../../constants/link_tile_colors.js'
 
 test('a bare host:port gains http, which is what most LAN devices need', () => {
   assert.equal(normalizeCustomUrl('192.168.1.50:8080'), 'http://192.168.1.50:8080/')
@@ -100,4 +106,26 @@ test('isLinkTileIcon accepts only names in the set', () => {
 
 test('the default icon is part of the offered set', () => {
   assert.ok((LINK_TILE_ICONS as readonly string[]).includes(DEFAULT_LINK_TILE_ICON))
+})
+
+test('link tile colours resolve from the brand palette', () => {
+  // Unknown, null and empty all fall back rather than rendering an untinted card.
+  assert.equal(linkTileColor('orange').id, 'orange')
+  assert.equal(linkTileColor(null).id, DEFAULT_LINK_TILE_COLOR)
+  assert.equal(linkTileColor('chartreuse').id, DEFAULT_LINK_TILE_COLOR)
+})
+
+test('every link tile colour ships complete, literal Tailwind classes', () => {
+  // Tailwind scans for literal class strings, so an interpolated name would be
+  // dropped from the build and the tile would render untinted.
+  for (const option of LINK_TILE_COLORS) {
+    assert.ok(option.border.startsWith('border-desert-'), option.id)
+    assert.ok(option.bg.startsWith('bg-desert-'), option.id)
+    assert.ok(option.marker.startsWith('text-desert-'), option.id)
+    assert.ok(!`${option.border}${option.bg}${option.marker}`.includes('${'), option.id)
+  }
+})
+
+test('the default colour is one of the offered options', () => {
+  assert.ok(LINK_TILE_COLOR_IDS.includes(DEFAULT_LINK_TILE_COLOR))
 })

--- a/admin/tests/unit/link_tile.spec.ts
+++ b/admin/tests/unit/link_tile.spec.ts
@@ -108,14 +108,14 @@ test('the default icon is part of the offered set', () => {
   assert.ok((LINK_TILE_ICONS as readonly string[]).includes(DEFAULT_LINK_TILE_ICON))
 })
 
-test('link tile colours resolve from the brand palette', () => {
+test('link tile colors resolve from the brand palette', () => {
   // Unknown, null and empty all fall back rather than rendering an untinted card.
   assert.equal(linkTileColor('orange').id, 'orange')
   assert.equal(linkTileColor(null).id, DEFAULT_LINK_TILE_COLOR)
   assert.equal(linkTileColor('chartreuse').id, DEFAULT_LINK_TILE_COLOR)
 })
 
-test('every link tile colour ships complete, literal Tailwind classes', () => {
+test('every link tile color ships complete, literal Tailwind classes', () => {
   // Tailwind scans for literal class strings, so an interpolated name would be
   // dropped from the build and the tile would render untinted.
   for (const option of LINK_TILE_COLORS) {
@@ -126,6 +126,6 @@ test('every link tile colour ships complete, literal Tailwind classes', () => {
   }
 })
 
-test('the default colour is one of the offered options', () => {
+test('the default color is one of the offered options', () => {
   assert.ok(LINK_TILE_COLOR_IDS.includes(DEFAULT_LINK_TILE_COLOR))
 })

--- a/admin/types/services.ts
+++ b/admin/types/services.ts
@@ -19,5 +19,6 @@ export type ServiceSlim = Pick<
   | 'is_custom'
   | 'is_user_modified'
   | 'is_deprecated'
+  | 'is_link_tile'
   | 'category'
 > & { status?: string }

--- a/admin/types/services.ts
+++ b/admin/types/services.ts
@@ -20,5 +20,6 @@ export type ServiceSlim = Pick<
   | 'is_user_modified'
   | 'is_deprecated'
   | 'is_link_tile'
+  | 'link_color'
   | 'category'
 > & { status?: string }


### PR DESCRIPTION
Implements the dashboard link tile from `docs/roadmap.md` section 3b. Supersedes the declined community PR #1239 and issue #1237.

**What it does.** Adds a tile for something the user already runs: a NAS, a router UI, a printer, a Pi, or a container they started themselves. Name, one address field, an optional description, and an icon. NOMAD does not manage the thing, it just puts a button on the dashboard.

**Why a link rather than adopting containers.** #1239 proposed inspecting the Docker daemon and adopting running containers. That only reaches containers on this Docker host, and it has to guess: it took the lowest published host port and assumed `http://`, which picks the wrong port for anything publishing more than one (Portainer publishes 8000 and 9443, Jellyfin 8096 and 8920) and produces a broken link for anything serving HTTPS. A tile the user addresses has no guessing in it, covers the whole LAN rather than one Docker host, and has no lifecycle that can break.

**One address field, not host/port/path.** People paste URLs, and it gets HTTPS and sub-paths for free. A bare `192.168.1.50:8080` gains `http://` automatically, which is what most LAN devices need. `normalizeCustomUrl` and `getServiceLink` already did exactly this for the custom app URL override, so both are reused rather than duplicated.

**Storage.** A service row with no container behind it: `is_link_tile` marks it, `custom_url` carries the destination, and `service_name` is namespaced `nomad_link_*` so it can never collide with a curated entry. The seeder only iterates its own `DEFAULT_SERVICES` and never prunes unknown rows, so a reseed cannot touch or remove a tile. Verified by actually re-seeding, not by reading.

**Visual distinction is deliberate.** The tile is outlined and dashed with an external-link marker rather than filled like a managed app. If it looked the same, users would expect Start, Stop and Update and file bugs when those controls are not there. Removing a tile arms a confirm first, since it is user-entered data with no undo.

**Icons** come from a fixed 36 shared by the picker and the server-side validator, so the two cannot disagree about what is selectable. `DynamicIcon` renders nothing at all for a name it does not know, which would otherwise leave a silent hole in a tile.

**One defect found by running it.** `_syncContainersWithDatabase` flips any service marked installed to not-installed when no container exists for it. A link tile has no container by definition, so every tile was silently unset on the next sync and vanished from the dashboard within seconds of being created. Link tiles are now skipped by that reconciliation. This was only visible in the browser: the row was created correctly and the API returned 201.

**Verified on NOMAD3** against a build of `dev` plus this branch, looking at screenshots rather than only DOM queries:

- The migration applies to an existing install with 17 existing services; none disturbed.
- Create: the live preview resolved `192.168.1.50:8080` to `http://192.168.1.50:8080/`; the tile appeared with the chosen icon and description, rendered dashed and outlined, distinct from the filled app tiles.
- The link opens with `target="_blank"` and `rel="noopener noreferrer"`.
- Edit prefills, and saving `https://nas.local:9443/ui` preserved scheme, port and path exactly.
- Delete arms, Cancel restores the edit and remove controls, confirming removes the row. Curated services untouched at 17.
- **Reseed:** ran `node ace db:seed` with a tile present. Name, URL, icon, installed flag and display order all survived unchanged.

API boundaries probed live: a `javascript:` URL returns 422, an icon outside the allowlist returns 422, a duplicate name returns 409, and deleting a non-tile service returns 403 with the target service still present.

Typecheck clean, `vite build` clean, 12 new unit tests, and the unit-suite failure set is identical to `origin/dev`.

**Incidental finding, not addressed here.** `normalizeCustomUrl` turns `file:///etc/passwd` into `http://file///etc/passwd` and `ftp://example.com` into `http://ftp//example.com` rather than rejecting them. Both are harmless: they resolve to an http URL pointing at a host named "file" or "ftp" that goes nowhere and cannot execute anything, and the schemes that matter (`javascript:`, `data:`, `vbscript:`) are correctly refused. It is a usability wart in a helper shared with the custom app URL feature, so it is left alone here and covered by a test that documents the behaviour.
