### PR TITLE
ci: add Build Translate Proxy Image workflow

### DIFF
--- a/.github/workflows/build-translate-proxy.yml
+++ b/.github/workflows/build-translate-proxy.yml
@@ -1,0 +1,52 @@
+name: Build Translate Proxy Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semantic version to label the Docker image under (no "v" prefix, e.g. "1.2.3")'
+        required: true
+        type: string
+      tag_latest:
+        description: 'Also tag this image as :latest?'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  check_authorization:
+    name: Check authorization to publish new Docker image
+    runs-on: ubuntu-latest
+    outputs:
+      isAuthorized: ${{ steps.check-auth.outputs.is_authorized }}
+    steps:
+      - name: check-auth
+        id: check-auth
+        run: echo "is_authorized=${{ contains(secrets.DEPLOYMENT_AUTHORIZED_USERS, github.triggering_actor) }}" >> $GITHUB_OUTPUT
+  build:
+    name: Build translate-proxy image
+    needs: check_authorization
+    if: needs.check_authorization.outputs.isAuthorized == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: install/nomad-translate
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/crosstalk-solutions/project-nomad-translate:${{ inputs.version }}
+            ghcr.io/crosstalk-solutions/project-nomad-translate:v${{ inputs.version }}
+            ${{ inputs.tag_latest && 'ghcr.io/crosstalk-solutions/project-nomad-translate:latest' || '' }}


### PR DESCRIPTION
Adds the manual build workflow for the `project-nomad-translate` image (#1292).

`workflow_dispatch` workflows are only dispatchable if the file exists on the default branch, so this has to land on `main` before the image can be published — even when dispatching against the feature branch. Identical in shape to `build-sidecar-updater.yml`: same `DEPLOYMENT_AUTHORIZED_USERS` gate, same `version` / `tag_latest` inputs, same tag triple.

Inert until dispatched. Once merged, dispatching at `0.1.0` against `feat/offline-translation-proxy` publishes `ghcr.io/crosstalk-solutions/project-nomad-translate:0.1.0`, which is the tag the catalog entry in `service_seeder.ts` pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8Mgg1vd2eKSs8StZiuyMV
