### PR TITLE
copy(dashboard): tighten the Drug Reference tile description

### DIFF
--- a/admin/inertia/pages/home.tsx
+++ b/admin/inertia/pages/home.tsx
@@ -43,7 +43,7 @@ const DRUG_REFERENCE_ITEM = {
   label: 'Drug Reference',
   to: '/drug-reference',
   target: '',
-  description: 'Offline FDA drug labels — search by drug name, or by situation (burn, fever, diarrhea)',
+  description: 'Offline FDA drug labels. Search by drug name or by symptom',
   icon: <IconPill size={48} />,
   installed: true,
   displayOrder: 5,


### PR DESCRIPTION
One line of dashboard copy.

Before:

> Offline FDA drug labels — search by drug name, or by situation (burn, fever, diarrhea)

After:

> Offline FDA drug labels. Search by drug name or by symptom

The condition examples put a clinical term front and centre on the home screen, which is the first thing anyone sees. The search-by-symptom capability is still stated, just without naming conditions. It was also the longest description on the dashboard and the only one carrying an em dash, so this brings it closer to its neighbours ("View offline maps", "Browse and install curated apps, or add your own Docker container").

This is a hardcoded tile in `home.tsx`, not a seeded service row, so unlike a catalog `description` it does reach existing installs on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8Mgg1vd2eKSs8StZiuyMV
