### PR TITLE
fix(zim): resolve flavoured and non-English ZIMs in the update check

### DIFF
--- a/admin/app/services/kiwix_catalog_service.ts
+++ b/admin/app/services/kiwix_catalog_service.ts
@@ -113,14 +113,43 @@ export class KiwixCatalogService {
   async getLatestZim(resourceId: string): Promise<CatalogResult | null> {
     const pattern = new RegExp(`^${escapeRegex(resourceId)}_(\\d{4}-\\d{2})\\.zim$`)
 
-    // 1. Exact-name lookup (the robust path).
+    // 1. Exact-name lookup (the robust path). Resolves most books, whose OPDS `<name>`
+    //    is the full filename base: devdocs_en_python, zimgit-water_en,
+    //    freecodecamp_en_all, nhs.uk_en_medicines ...
     const named = await this.fetchZimEntries({ name: resourceId, count: 50, start: 0 })
     const exact = this.pickNewestZim(named, pattern)
     if (exact) return exact
 
-    // 2. Fallback: bounded keyword scan in case the catalog ignored `name=` or
-    //    indexes the book under a slightly different name.
+    // 2. Flavoured books index under the base WITHOUT the flavour, which the catalog
+    //    carries in a separate `<flavour>` element: `wikibooks_en_all_nopic_2026-04.zim`
+    //    is `<name>wikibooks_en_all</name><flavour>nopic</flavour>`. Our resource ids are
+    //    filename bases, so `name=wikibooks_en_all_nopic` matched nothing and every
+    //    maxi/mini/nopic book -- including every Wikipedia -- was unresolvable.
+    //    Retry against the base; `pattern` still decides, so a broader query is safe.
+    const base = this.stripFlavourSuffix(resourceId)
+    if (base) {
+      const byBase = await this.fetchZimEntries({ name: base, count: 50, start: 0 })
+      const flavoured = this.pickNewestZim(byBase, pattern)
+      if (flavoured) return flavoured
+    }
+
+    // 3. Fallback: bounded keyword scan in case the catalog ignored `name=` or indexes
+    //    the book under a slightly different name. Note `q=` searches title and summary,
+    //    not the filename, so it has not been observed to resolve a resource id on its
+    //    own -- it is a safety net, not a working second path.
     return this.scanZimByQuery(resourceId, pattern)
+  }
+
+  /**
+   * Drop the trailing `_<flavour>` segment from a resource id, or null when there is
+   * nothing to drop. Deliberately not matched against a flavour allowlist: openZIM adds
+   * flavours over time, and a wrong guess costs one extra catalog request because the
+   * authoritative filename check still gates every result.
+   */
+  private stripFlavourSuffix(resourceId: string): string | null {
+    const cut = resourceId.lastIndexOf('_')
+    if (cut <= 0) return null
+    return resourceId.slice(0, cut)
   }
 
   /** Newest catalog version of a single PMTiles map, or null if none/older. */
@@ -191,7 +220,10 @@ export class KiwixCatalogService {
       params: {
         start: params.start,
         count: params.count,
-        lang: 'eng',
+        // No `lang` filter. This is a freshness check for an ALREADY-INSTALLED book, so
+        // the language is whatever the user installed; `lang: 'eng'` made every
+        // non-English ZIM permanently unresolvable here. The authoritative
+        // `^<id>_YYYY-MM.zim$` filename check is what resolves the right book.
         ...(params.name ? { name: params.name } : {}),
         ...(params.q ? { q: params.q } : {}),
       },

--- a/admin/app/services/kiwix_catalog_service.ts
+++ b/admin/app/services/kiwix_catalog_service.ts
@@ -29,9 +29,6 @@ const GITHUB_PMTILES_URL =
   'https://api.github.com/repos/Crosstalk-Solutions/project-nomad-maps/contents/pmtiles'
 
 const CATALOG_TIMEOUT_MS = 15000
-/** Bounded paginated fallback scan when the exact `name=` lookup comes up empty. */
-const KIWIX_PAGE_SIZE = 60
-const MAX_KIWIX_FETCHES = 5
 /** Concurrent ZIM catalog lookups — keep small to avoid hammering the mirror. */
 const ZIM_CHECK_CONCURRENCY = 4
 
@@ -133,11 +130,14 @@ export class KiwixCatalogService {
       if (flavoured) return flavoured
     }
 
-    // 3. Fallback: bounded keyword scan in case the catalog ignored `name=` or indexes
-    //    the book under a slightly different name. Note `q=` searches title and summary,
-    //    not the filename, so it has not been observed to resolve a resource id on its
-    //    own -- it is a safety net, not a working second path.
-    return this.scanZimByQuery(resourceId, pattern)
+    // Nothing in the catalog matches this id. There used to be a third step here: a
+    // bounded `q=` keyword scan, up to 5 paged requests per unresolved book on every
+    // check. It was removed because `q=` searches an entry's title and summary, never
+    // its filename, so it cannot match a resource id -- across every id tested it
+    // resolved nothing while the two `name=` lookups above resolved everything that
+    // was resolvable. It was pure repeat traffic aimed at a mirror that has just had
+    // to deploy anti-crawler measures.
+    return null
   }
 
   /**
@@ -173,36 +173,8 @@ export class KiwixCatalogService {
     return latest
   }
 
-  private async scanZimByQuery(
-    resourceId: string,
-    pattern: RegExp
-  ): Promise<CatalogResult | null> {
-    let start = 0
-    let total = 0
-    let latest: CatalogResult | null = null
-
-    for (let i = 0; i < MAX_KIWIX_FETCHES; i++) {
-      const { entries, totalResults } = await this.fetchZimEntriesPage({
-        q: resourceId,
-        count: KIWIX_PAGE_SIZE,
-        start,
-      })
-      total = totalResults
-      if (entries.length === 0) break
-      start += entries.length
-
-      const candidate = this.pickNewestZim(entries, pattern)
-      if (candidate && (!latest || candidate.version > latest.version)) {
-        latest = candidate
-      }
-      if (start >= total) break
-    }
-    return latest
-  }
-
   private async fetchZimEntries(params: {
     name?: string
-    q?: string
     count: number
     start: number
   }): Promise<CatalogZimEntry[]> {
@@ -212,7 +184,6 @@ export class KiwixCatalogService {
 
   private async fetchZimEntriesPage(params: {
     name?: string
-    q?: string
     count: number
     start: number
   }): Promise<{ entries: CatalogZimEntry[]; totalResults: number }> {
@@ -225,7 +196,6 @@ export class KiwixCatalogService {
         // non-English ZIM permanently unresolvable here. The authoritative
         // `^<id>_YYYY-MM.zim$` filename check is what resolves the right book.
         ...(params.name ? { name: params.name } : {}),
-        ...(params.q ? { q: params.q } : {}),
       },
       responseType: 'text',
       timeout: CATALOG_TIMEOUT_MS,


### PR DESCRIPTION
Stacked on #1296 so the diff is just this change; GitHub will retarget it to `dev` when that merges.

Two independent reasons `getLatestZim()` returns null for books that do have newer versions. Both predate the catalog-host problem in #1296 — that outage was masking them.

### 1. Flavoured books are indexed under their base name

OPDS carries the flavour in a separate `<flavour>` element:

```
name=wikipedia_en_all_maxi   -> 0 entries
name=wikipedia_en_all        -> 3 entries (maxi_2026-02, mini_2026-06, nopic_2026-06)
q=wikipedia_en_all_maxi      -> 0 entries
```

Our resource ids are filename bases, flavour included, so the exact-name path missed **every maxi/mini/nopic book — including every Wikipedia**. The `q=` fallback doesn't cover it either: `q=` searches title and summary, not the filename, and was not observed to resolve any resource id on its own.

This adds a retry against the flavour-stripped base. No flavour allowlist: openZIM adds flavours over time, and the authoritative `^<id>_YYYY-MM\.zim$` check still gates every result, so a wrong guess costs one request and nothing else.

### 2. `lang: 'eng'` on a freshness check

This is a lookup for an already-installed book, so its language is whatever the user installed. A French or Spanish ZIM was permanently unresolvable. The filename regex is what identifies the book; the language filter only removed correct answers.

Note this differs from the Content Explorer path, where a language filter is user-facing and should stay.

### 3. Drop the dead keyword-scan fallback

`scanZimByQuery` cost up to 5 catalog requests per unresolved book on every check and never resolved one, for the reason above. Removed rather than left as traffic aimed at a mirror that has just deployed anti-crawler measures.

### Verification

On a test box against the live catalog, via `POST /api/content-updates/check` with 30 installed ZIMs:

| | before | after |
|---|---|---|
| updates found | 11 | **13** |
| flavoured ids resolved | 0 | 2 |

The two that appeared are `wikibooks_en_all_nopic` (2026-01 → 2026-04) and `wikiversity_en_all_maxi` (2026-02 → 2026-05). Nothing dropped out.

Silent failure mode worth noting: when this lookup fails it does not error, it returns "no newer version", which is indistinguishable from "you are up to date".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8Mgg1vd2eKSs8StZiuyMV
