### PR TITLE
install: add Project NOMAD ASCII banner to the installer

### DIFF
--- a/install/install_nomad.sh
+++ b/install/install_nomad.sh
@@ -54,6 +54,22 @@ header_red() {
   echo -e "${RED}#########################################################################${RESET}\\n"
 }
 
+banner() {
+  echo ""
+  echo -e "${GREEN}"
+  cat <<'NOMAD_ART'
+                             P R O J E C T
+                    _   _  ___  __  __    _    ____
+                   | \ | |/ _ \|  \/  |  / \  |  _ \
+                   |  \| | | | | |\/| | / _ \ | | | |
+                   | |\  | |_| | |  | |/ ___ \| |_| |
+                   |_| \_|\___/|_|  |_/_/   \_\____/
+NOMAD_ART
+  echo -e "${RESET}"
+  echo -e "${WHITE_R}                 Offline knowledge and education server${RESET}\n"
+  echo -e "${GREEN}#########################################################################${RESET}\n"
+}
+
 check_has_sudo() {
   if sudo -n true 2>/dev/null; then
     echo -e "${GREEN}#${RESET} User has sudo permissions.\\n"
@@ -623,6 +639,7 @@ ensure_dependencies_installed
 check_is_debug_mode
 
 # Main install
+banner
 get_install_confirmation
 accept_terms
 ensure_docker_installed


### PR DESCRIPTION
Adds a branded ASCII header to `install/install_nomad.sh`, printed once at the top of the main install flow.

```
                             P R O J E C T
                    _   _  ___  __  __    _    ____
                   | \ | |/ _ \|  \/  |  / \  |  _ \
                   |  \| | | | | |\/| | / _ \ | | | |
                   | |\  | |_| | |  | |/ ___ \| |_| |
                   |_| \_|\___/|_|  |_/_/   \_\____/

                 Offline knowledge and education server

#########################################################################
```

Art in green, tagline in gray, using the colour variables already defined in the script.

### Changes

17 lines added, nothing removed or modified:

- a `banner()` function, added above `check_has_sudo()`
- one `banner` call at the top of the main install flow, before `get_install_confirmation`

### Notes

- The art sits in a **quoted heredoc** (`<<'NOMAD_ART'`) so the backslashes survive verbatim. In an `echo -e` string every `\` would need escaping and the art would be unreadable in source. That is also why the colour codes are emitted on separate lines either side of it rather than inline.
- **Pure ASCII**, max 44 columns, so it renders safely over SSH regardless of terminal encoding or width.
- Nothing in the main flow clears the screen, so the banner stays visible while the install runs.
- `bash -n` passes.

### Out of scope, but noticed

`header()` in this script is **dead code** - it is defined but called zero times, while `header_red()` is used five times for error paths. Left alone here to keep the diff cosmetic-only. Happy to remove it in a follow-up if wanted.

### Reaching real installs

Worth flagging that merging to `dev` will not change anything users see. The installer and its helper script URLs are pinned to `refs/heads/main`, so the banner only appears in real installs once it ships there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8Mgg1vd2eKSs8StZiuyMV