### PR TITLE
feat(content): content-language filter for curated collections, Wikipedia and Kiwix search

### DIFF
--- a/admin/app/controllers/easy_setup_controller.ts
+++ b/admin/app/controllers/easy_setup_controller.ts
@@ -35,18 +35,19 @@ export default class EasySetupController {
 
   async refreshManifests({}: HttpContext) {
     const manifestService = new CollectionManifestService()
-    const [zimChanged, mapsChanged, wikiChanged] = await Promise.all([
+    const [zimChanged, mapsChanged, wikiChanged, otherLanguages] = await Promise.all([
       manifestService.fetchAndCacheSpec('zim_categories'),
       manifestService.fetchAndCacheSpec('maps'),
       manifestService.fetchAndCacheSpec('wikipedia'),
+      manifestService.refreshAdditionalLanguageManifests(),
     ])
 
     return {
       success: true,
       changed: {
-        zim_categories: zimChanged,
+        zim_categories: zimChanged || otherLanguages.zim_categories,
         maps: mapsChanged,
-        wikipedia: wikiChanged,
+        wikipedia: wikiChanged || otherLanguages.wikipedia,
       },
     }
   }

--- a/admin/app/models/collection_manifest.ts
+++ b/admin/app/models/collection_manifest.ts
@@ -1,12 +1,15 @@
 import { DateTime } from 'luxon'
 import { BaseModel, column, SnakeCaseNamingStrategy } from '@adonisjs/lucid/orm'
-import type { ManifestType } from '../../types/collections.js'
-
 export default class CollectionManifest extends BaseModel {
   static namingStrategy = new SnakeCaseNamingStrategy()
 
+  /**
+   * Cache key: the bare ManifestType for English ('zim_categories'), or
+   * `<type>:<language>` for another content language ('zim_categories:fr').
+   * See manifestCacheKey in utils/content_languages.
+   */
   @column({ isPrimary: true })
-  declare type: ManifestType
+  declare type: string
 
   @column()
   declare spec_version: string

--- a/admin/app/services/collection_manifest_service.ts
+++ b/admin/app/services/collection_manifest_service.ts
@@ -10,6 +10,16 @@ import { QueueService } from './queue_service.js'
 import { RunDownloadJob } from '#jobs/run_download_job'
 import { zimCategoriesSpecSchema, mapsSpecSchema, wikipediaSpecSchema, creatorPacksSpecSchema } from '#validators/curated_collections'
 import { isGatedResource } from '../utils/hosted_content.js'
+import KVStore from '#models/kv_store'
+import {
+  isSupportedContentLanguage,
+  manifestCacheKey,
+  manifestUrlFor,
+  mergeZimCategorySpecs,
+  parseContentLanguages,
+  type LanguageScopedManifestType,
+} from '../utils/content_languages.js'
+import { DEFAULT_CONTENT_LANGUAGE } from '../../constants/content_languages.js'
 import {
   ensureDirectoryExists,
   listDirectoryContents,
@@ -47,16 +57,35 @@ export class CollectionManifestService {
 
   // ---- Spec management ----
 
-  async fetchAndCacheSpec(type: ManifestType): Promise<boolean> {
+  /**
+   * Fetch a manifest and cache it. `language` defaults to English, which keeps
+   * the historical URL and cache key. Other languages only exist for the
+   * language-scoped types (categories, Wikipedia) and read from
+   * `collections/<language>/…`.
+   */
+  async fetchAndCacheSpec(
+    type: ManifestType,
+    language: string = DEFAULT_CONTENT_LANGUAGE
+  ): Promise<boolean> {
+    const isEnglish = language === DEFAULT_CONTENT_LANGUAGE
+    if (!isEnglish && !CollectionManifestService.isLanguageScoped(type)) return false
+    // Only allow-listed codes ever reach the URL path (defence in depth: callers
+    // already pass parsed setting values).
+    if (!isSupportedContentLanguage(language)) return false
+
+    const url = isEnglish
+      ? SPEC_URLS[type]
+      : manifestUrlFor(type as LanguageScopedManifestType, language)
+    const cacheKey = manifestCacheKey(type, language)
     try {
-      const response = await axios.get(SPEC_URLS[type], { timeout: 15000 })
+      const response = await axios.get(url, { timeout: 15000 })
 
       const validated = await vine.validate({
         schema: VALIDATORS[type],
         data: response.data,
       })
 
-      const existing = await CollectionManifest.find(type)
+      const existing = await CollectionManifest.find(cacheKey)
       const specVersion = validated.spec_version
 
       if (existing) {
@@ -69,7 +98,7 @@ export class CollectionManifestService {
       }
 
       await CollectionManifest.create({
-        type,
+        type: cacheKey,
         spec_version: specVersion,
         spec_data: validated,
         fetched_at: DateTime.now(),
@@ -77,30 +106,120 @@ export class CollectionManifestService {
 
       return true
     } catch (error) {
-      logger.error(`[CollectionManifestService] Failed to fetch spec for ${type}:`, error?.message || error)
+      if (isEnglish) {
+        logger.error(
+          `[CollectionManifestService] Failed to fetch spec for ${type}:`,
+          error?.message || error
+        )
+      } else if (error?.response?.status === 404) {
+        // Expected until a language has curated manifests of its own: that language
+        // simply contributes no curated content. Not worth a warning on every page load.
+        logger.debug(
+          `[CollectionManifestService] No ${type} manifest for content language '${language}'`
+        )
+      } else {
+        logger.warn(
+          `[CollectionManifestService] Failed to fetch ${type} manifest for content language '${language}': ${error?.message || error}`
+        )
+      }
       return false
     }
   }
 
-  async getCachedSpec<T>(type: ManifestType): Promise<T | null> {
-    const manifest = await CollectionManifest.find(type)
+  async getCachedSpec<T>(
+    type: ManifestType,
+    language: string = DEFAULT_CONTENT_LANGUAGE
+  ): Promise<T | null> {
+    const manifest = await CollectionManifest.find(manifestCacheKey(type, language))
     if (!manifest) return null
     return manifest.spec_data as T
   }
 
-  async getSpecWithFallback<T>(type: ManifestType): Promise<T | null> {
+  async getSpecWithFallback<T>(
+    type: ManifestType,
+    language: string = DEFAULT_CONTENT_LANGUAGE
+  ): Promise<T | null> {
     try {
-      await this.fetchAndCacheSpec(type)
+      await this.fetchAndCacheSpec(type, language)
     } catch {
       // Fetch failed, will fall back to cache
     }
-    return this.getCachedSpec<T>(type)
+    return this.getCachedSpec<T>(type, language)
+  }
+
+  static isLanguageScoped(type: ManifestType): type is LanguageScopedManifestType {
+    return type === 'zim_categories' || type === 'wikipedia'
+  }
+
+  /** The user's content languages (`content.languages`), English when unset. */
+  async getContentLanguages(): Promise<string[]> {
+    return parseContentLanguages(await KVStore.getValue('content.languages'))
+  }
+
+  /**
+   * Category spec for the picker, merged across content languages. With the
+   * default (English only) this is exactly the English manifest, as before.
+   *
+   * `fetch: false` reads the cache only, for paths that must not hit the
+   * network. `languages` overrides the user's setting.
+   */
+  async getZimCategoriesSpec(
+    { fetch, languages }: { fetch: boolean; languages?: string[] } = { fetch: true }
+  ): Promise<ZimCategoriesSpec | null> {
+    const codes = languages ?? (await this.getContentLanguages())
+    const specs = await Promise.all(
+      codes.map(async (language) => ({
+        language,
+        spec: fetch
+          ? await this.getSpecWithFallback<ZimCategoriesSpec>('zim_categories', language)
+          : await this.getCachedSpec<ZimCategoriesSpec>('zim_categories', language),
+      }))
+    )
+    return mergeZimCategorySpecs(specs)
+  }
+
+  /**
+   * Cached categories for bookkeeping (gated-id guard, filesystem reconcile).
+   * English is always included even if deselected, so installed English content
+   * keeps its safeguards and metadata.
+   */
+  private async getCachedZimCategoriesForBookkeeping(): Promise<ZimCategoriesSpec | null> {
+    const enabled = await this.getContentLanguages()
+    const languages = [
+      DEFAULT_CONTENT_LANGUAGE,
+      ...enabled.filter((l) => l !== DEFAULT_CONTENT_LANGUAGE),
+    ]
+    return this.getZimCategoriesSpec({ fetch: false, languages })
+  }
+
+  /**
+   * Refresh the language-scoped manifests of every enabled non-English
+   * language. English is refreshed by the callers exactly as before.
+   * Returns whether anything changed.
+   */
+  async refreshAdditionalLanguageManifests(): Promise<{
+    zim_categories: boolean
+    wikipedia: boolean
+  }> {
+    const languages = await this.getContentLanguages()
+    const others = languages.filter((l) => l !== DEFAULT_CONTENT_LANGUAGE)
+    let zimChanged = false
+    let wikiChanged = false
+    for (const language of others) {
+      const [zim, wiki] = await Promise.all([
+        this.fetchAndCacheSpec('zim_categories', language),
+        this.fetchAndCacheSpec('wikipedia', language),
+      ])
+      zimChanged ||= zim
+      wikiChanged ||= wiki
+    }
+    return { zim_categories: zimChanged, wikipedia: wikiChanged }
   }
 
   // ---- Status computation ----
 
   async getCategoriesWithStatus(): Promise<CategoryWithStatus[]> {
-    const spec = await this.getSpecWithFallback<ZimCategoriesSpec>('zim_categories')
+    const spec = await this.getZimCategoriesSpec({ fetch: true })
     if (!spec) return []
 
     // Include 'dataset' rows alongside 'zim' so a curated tier carrying the FDA
@@ -335,7 +454,7 @@ export class CollectionManifestService {
    */
   async getGatedZimResourceIds(): Promise<Set<string>> {
     const ids = new Set<string>()
-    const spec = await this.getCachedSpec<ZimCategoriesSpec>('zim_categories')
+    const spec = await this.getCachedZimCategoriesForBookkeeping()
     if (!spec) return ids
 
     for (const category of spec.categories) {
@@ -430,7 +549,7 @@ export class CollectionManifestService {
       console.log(`Found ${zimFiles.length} ZIM files on disk. Reconciling with database...`)
 
       // Get spec for URL lookup
-      const zimSpec = await this.getCachedSpec<ZimCategoriesSpec>('zim_categories')
+      const zimSpec = await this.getCachedZimCategoriesForBookkeeping()
       const specResourceMap = new Map<string, SpecResource>()
       if (zimSpec) {
         for (const cat of zimSpec.categories) {

--- a/admin/app/services/download_service.ts
+++ b/admin/app/services/download_service.ts
@@ -9,6 +9,7 @@ import { DownloadJobWithProgress, DownloadProgressData, RunDownloadJobParams } f
 import type { Job, Queue } from 'bullmq'
 import { normalize } from 'path'
 import { deleteFileIfExists } from '../utils/fs.js'
+import { isWikipediaZimFilename } from '../utils/zim_filename.js'
 import transmit from '@adonisjs/transmit/services/main'
 import { BROADCAST_CHANNELS } from '../../constants/broadcast.js'
 
@@ -333,7 +334,7 @@ export class DownloadService {
 
     // If this was a Wikipedia download, update selection status to failed
     // (the worker's failed event may not fire if we removed the job first)
-    if (job.data.filetype === 'zim' && job.data.url?.includes('wikipedia_en_')) {
+    if (job.data.filetype === 'zim' && job.data.url && isWikipediaZimFilename(job.data.url)) {
       try {
         const { DockerService } = await import('#services/docker_service')
         const { ZimService } = await import('#services/zim_service')

--- a/admin/app/services/zim_service.ts
+++ b/admin/app/services/zim_service.ts
@@ -7,7 +7,17 @@ import axios from 'axios'
 import * as cheerio from 'cheerio'
 import { XMLParser } from 'fast-xml-parser'
 import { isRawListRemoteZimFilesResponse, isRawRemoteZimFileEntry } from '../../util/zim.js'
-import { findReplacedWikipediaFiles } from '../utils/zim_filename.js'
+import {
+  findReplacedWikipediaFiles,
+  isSelectorManagedWikipedia,
+  isWikipediaZimFilename,
+} from '../utils/zim_filename.js'
+import {
+  filterWikipediaOptions,
+  mergeWikipediaOptions,
+  toKiwixLangParam,
+} from '../utils/content_languages.js'
+import { DEFAULT_CONTENT_LANGUAGE } from '../../constants/content_languages.js'
 import { decideSupersededDeletion } from '../utils/superseded_resource.js'
 import logger from '@adonisjs/core/services/logger'
 import { DockerService } from './docker_service.js'
@@ -25,7 +35,6 @@ import vine from '@vinejs/vine'
 import { wikipediaOptionsFileSchema } from '#validators/curated_collections'
 import WikipediaSelection from '#models/wikipedia_selection'
 import InstalledResource from '#models/installed_resource'
-import CollectionManifest from '#models/collection_manifest'
 import { RunDownloadJob } from '#jobs/run_download_job'
 import { DownloadDrugDataJob } from '#jobs/download_drug_data_job'
 import { DrugReferenceService } from './drug_reference_service.js'
@@ -38,6 +47,8 @@ import CustomLibrarySource from '#models/custom_library_source'
 import { assertNotPrivateUrl } from '#validators/common'
 import { resolveZimDownload } from '../utils/zim_download_resolution.js'
 import { getHostedContentHeaders } from '../utils/hosted_content_auth.js'
+
+type WikipediaOptionsSpec = { options: WikipediaOption[] }
 
 const ZIM_MIME_TYPES = ['application/x-zim', 'application/x-openzim', 'application/octet-stream']
 const WIKIPEDIA_OPTIONS_URL = 'https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/main/collections/wikipedia.json'
@@ -101,6 +112,9 @@ export class ZimService {
     const existing = await this.list()
     const existingKeys = new Set(existing.files.map((file) => file.name))
 
+    // Search the user's content languages ("eng" by default, as before).
+    const lang = toKiwixLangParam(await new CollectionManifestService().getContentLanguages())
+
     const accumulated: RemoteZimFileEntry[] = []
     const seenIds = new Set<string>()
     let currentStart = start
@@ -111,7 +125,7 @@ export class ZimService {
         params: {
           start: currentStart,
           count: KIWIX_PAGE_SIZE,
-          lang: 'eng',
+          lang,
           ...(query ? { q: query } : {}),
         },
         responseType: 'text',
@@ -247,7 +261,8 @@ export class ZimService {
 
   async downloadCategoryTier(categorySlug: string, tierSlug: string): Promise<string[] | null> {
     const manifestService = new CollectionManifestService()
-    const spec = await manifestService.getSpecWithFallback<import('../../types/collections.js').ZimCategoriesSpec>('zim_categories')
+    // Same merged view the picker shows, so namespaced (non-English) slugs resolve.
+    const spec = await manifestService.getZimCategoriesSpec({ fetch: true })
     if (!spec) {
       throw new Error('Could not load ZIM categories spec')
     }
@@ -347,9 +362,19 @@ export class ZimService {
   }
 
   async downloadRemoteSuccessCallback(urls: string[], restart = true) {
-    // Check if any URL is a Wikipedia download and handle it
+    // Decided up front, before onWikipediaDownloadComplete moves the selection to the new file.
+    const selection = await this.getWikipediaSelection()
+    const managedWikipediaUrls = new Set<string>()
     for (const url of urls) {
-      if (url.includes('wikipedia_en_')) {
+      if (await this.isManagedWikipediaDownload(url, selection?.filename)) {
+        managedWikipediaUrls.add(url)
+      }
+    }
+    const isManagedWikipedia = (url: string) => managedWikipediaUrls.has(url)
+
+    // Check if any URL is the picker's Wikipedia download and handle it
+    for (const url of urls) {
+      if (isManagedWikipedia(url)) {
         await this.onWikipediaDownloadComplete(url, true)
       }
     }
@@ -414,8 +439,9 @@ export class ZimService {
     const zimStorageDir = join(process.cwd(), ZIM_STORAGE_PATH)
     let removedSupersededZim = false
     for (const url of urls) {
-      // Skip Wikipedia files (managed separately)
-      if (url.includes('wikipedia_en_')) continue
+      // Skip the picker's Wikipedia (managed separately). Wikipedia-derived corpora
+      // from curated tiers (e.g. WikiMed) are bookkept like any other ZIM.
+      if (isManagedWikipedia(url)) continue
 
       const filename = url.split('/').pop()
       if (!filename) continue
@@ -553,10 +579,9 @@ export class ZimService {
 
     // If the uploaded file matches a known Wikipedia option, mark it as installed
     try {
-      const manifest = await CollectionManifest.find('wikipedia')
-      if (manifest) {
-        const spec = manifest.spec_data as { options: Array<{ id: string; url: string | null }> }
-        const matchedOption = spec.options.find(
+      const knownOptions = await this.getCachedWikipediaOptions()
+      if (knownOptions.length > 0) {
+        const matchedOption = knownOptions.find(
           (opt) => opt.url && opt.url.split('/').pop() === filename
         )
         if (matchedOption && matchedOption.url) {
@@ -577,17 +602,19 @@ export class ZimService {
           }
           logger.info(`[ZimService] Marked Wikipedia option '${matchedOption.id}' as installed from local upload`)
 
-          // Remove any other wikipedia_en_*.zim files, same as the download flow
+          // Remove prior releases of the same Wikipedia variant, same as the download
+          // flow (#884): distinct corpora such as a curated tier's WikiMed are kept
           const allFiles = await this.list()
-          const staleWikipediaFiles = allFiles.files.filter(
-            (f) => f.name.startsWith('wikipedia_en_') && f.name !== filename
+          const staleWikipediaFiles = findReplacedWikipediaFiles(
+            filename,
+            allFiles.files.map((f) => f.name)
           )
           for (const stale of staleWikipediaFiles) {
             try {
-              await this.delete(stale.name)
-              logger.info(`[ZimService] Deleted stale Wikipedia file after upload: ${stale.name}`)
+              await this.delete(stale)
+              logger.info(`[ZimService] Deleted stale Wikipedia file after upload: ${stale}`)
             } catch (err) {
-              logger.warn(`[ZimService] Could not delete stale Wikipedia file: ${stale.name}`, err)
+              logger.warn(`[ZimService] Could not delete stale Wikipedia file: ${stale}`, err)
             }
           }
         }
@@ -693,7 +720,14 @@ export class ZimService {
 
   // Wikipedia selector methods
 
-  async getWikipediaOptions(): Promise<WikipediaOption[]> {
+  /**
+   * Every known Wikipedia option: the English manifest (fetched exactly as
+   * before, and still required) plus each other enabled content language's
+   * manifest, whose ids are namespaced (`fr:all-maxi`). A missing non-English
+   * manifest just contributes nothing.
+   */
+  private async getAllWikipediaOptions(): Promise<WikipediaOption[]> {
+    let english: WikipediaOption[]
     try {
       const response = await axios.get(WIKIPEDIA_OPTIONS_URL)
       const data = response.data
@@ -703,11 +737,88 @@ export class ZimService {
         data,
       })
 
-      return validated.options
+      english = validated.options
     } catch (error) {
       logger.error(`[ZimService] Failed to fetch Wikipedia options:`, error)
       throw new Error('Failed to fetch Wikipedia options')
     }
+
+    const manifestService = new CollectionManifestService()
+    const others = await this.getAdditionalContentLanguages(manifestService)
+    const extra = await Promise.all(
+      others.map(async (language) => {
+        const spec = await manifestService.getSpecWithFallback<WikipediaOptionsSpec>(
+          'wikipedia',
+          language
+        )
+        return { language, options: spec?.options ?? [] }
+      })
+    )
+    return mergeWikipediaOptions(english, extra)
+  }
+
+  /**
+   * Options shown in the picker for the user's content languages. The current
+   * selection is always kept so an installed Wikipedia never disappears when
+   * its language is deselected.
+   */
+  async getWikipediaOptions(currentOptionId?: string | null): Promise<WikipediaOption[]> {
+    const all = await this.getAllWikipediaOptions()
+    const languages = await new CollectionManifestService().getContentLanguages()
+    let keep = currentOptionId
+    if (keep === undefined) {
+      const selection = await this.getWikipediaSelection()
+      keep = selection?.option_id
+    }
+    return filterWikipediaOptions(all, languages, keep)
+  }
+
+  /** Wikipedia options from cached manifests only (no network), all languages. */
+  private async getCachedWikipediaOptions(): Promise<WikipediaOption[]> {
+    const manifestService = new CollectionManifestService()
+    const englishSpec = await manifestService.getCachedSpec<WikipediaOptionsSpec>('wikipedia')
+    const others = await this.getAdditionalContentLanguages(manifestService)
+    const extra = await Promise.all(
+      others.map(async (language) => {
+        const spec = await manifestService.getCachedSpec<WikipediaOptionsSpec>(
+          'wikipedia',
+          language
+        )
+        return { language, options: spec?.options ?? [] }
+      })
+    )
+    return mergeWikipediaOptions(englishSpec?.options ?? [], extra)
+  }
+
+  /**
+   * Is this finished download the picker's Wikipedia: same variant as the current
+   * selection or a known option (see isSelectorManagedWikipedia)? Ordinary ZIMs
+   * and the usual picker download are answered without any I/O; the option list
+   * (network, falling back to the cache) is only consulted for other Wikipedia
+   * files, so an offline install never waits on GitHub to finish a download.
+   */
+  private async isManagedWikipediaDownload(
+    url: string,
+    selectionFilename: string | null | undefined
+  ): Promise<boolean> {
+    if (!isWikipediaZimFilename(url)) return false
+    if (isSelectorManagedWikipedia(url, selectionFilename, [])) return true
+    let options: WikipediaOption[]
+    try {
+      options = await this.getAllWikipediaOptions()
+    } catch {
+      options = await this.getCachedWikipediaOptions()
+    }
+    const optionUrls = options.map((o) => o.url).filter((u): u is string => !!u)
+    return isSelectorManagedWikipedia(url, selectionFilename, optionUrls)
+  }
+
+  /** Enabled content languages other than English (which has its own, unchanged path). */
+  private async getAdditionalContentLanguages(
+    manifestService: CollectionManifestService
+  ): Promise<string[]> {
+    const languages = await manifestService.getContentLanguages()
+    return languages.filter((language) => language !== DEFAULT_CONTENT_LANGUAGE)
   }
 
   async getWikipediaSelection(): Promise<WikipediaSelection | null> {
@@ -716,8 +827,8 @@ export class ZimService {
   }
 
   async getWikipediaState(): Promise<WikipediaState> {
-    const options = await this.getWikipediaOptions()
     const selection = await this.getWikipediaSelection()
+    const options = await this.getWikipediaOptions(selection?.option_id ?? null)
 
     return {
       options,
@@ -859,7 +970,7 @@ export class ZimService {
     // Determine which Wikipedia option this file belongs to by matching filename
     let matchedOptionId: string | null = null
     try {
-      const options = await this.getWikipediaOptions()
+      const options = await this.getAllWikipediaOptions()
       for (const opt of options) {
         if (opt.url && opt.url.split('/').pop() === filename) {
           matchedOptionId = opt.id

--- a/admin/app/utils/content_languages.ts
+++ b/admin/app/utils/content_languages.ts
@@ -1,0 +1,186 @@
+import {
+  CONTENT_LANGUAGES,
+  DEFAULT_CONTENT_LANGUAGE,
+  type ContentLanguageCode,
+} from '../../constants/content_languages.js'
+import type { ZimCategoriesSpec } from '../../types/collections.js'
+
+/**
+ * Content-language plumbing, kept free of I/O so it can be unit tested.
+ *
+ * The one rule everything here protects: with the default setting (`en` only)
+ * NOMAD must fetch exactly the same manifest URLs, cache them under exactly the
+ * same keys and show exactly the same options as before this feature existed.
+ * Other languages are purely additive and live in their own manifest files
+ * (`collections/<code>/…`), which released builds never request.
+ */
+
+const SUPPORTED_CODES = new Set<string>(CONTENT_LANGUAGES.map((l) => l.code))
+
+const COLLECTIONS_BASE_URL =
+  'https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/main/collections'
+
+/** Manifest types that have per-language variants. Maps and creator packs don't. */
+export type LanguageScopedManifestType = 'zim_categories' | 'wikipedia'
+
+const MANIFEST_FILENAMES: Record<LanguageScopedManifestType, string> = {
+  zim_categories: 'kiwix-categories.json',
+  wikipedia: 'wikipedia.json',
+}
+
+export function isSupportedContentLanguage(code: string): code is ContentLanguageCode {
+  return SUPPORTED_CODES.has(code)
+}
+
+/**
+ * Read the stored `content.languages` value ("en,fr"). Unknown codes are
+ * dropped, duplicates collapsed, order kept. Anything unusable, including an
+ * unset setting, falls back to English so a fresh install behaves as before.
+ */
+export function parseContentLanguages(raw: string | null | undefined): ContentLanguageCode[] {
+  if (typeof raw !== 'string') return [DEFAULT_CONTENT_LANGUAGE]
+  const codes: ContentLanguageCode[] = []
+  for (const part of raw.split(',')) {
+    const code = part.trim().toLowerCase()
+    if (isSupportedContentLanguage(code) && !codes.includes(code)) codes.push(code)
+  }
+  return codes.length > 0 ? codes : [DEFAULT_CONTENT_LANGUAGE]
+}
+
+/** Setting-value validation for `content.languages`. Returns an error message or null. */
+export function validateContentLanguagesValue(value: unknown): string | null {
+  // The body parser turns "" into null, so an empty selection arrives here as null.
+  if (value === null || value === undefined) {
+    return 'Select at least one content language.'
+  }
+  if (typeof value !== 'string') {
+    return 'Content languages must be a comma-separated list of language codes (e.g. "en,fr").'
+  }
+  const parts = value
+    .split(',')
+    .map((p) => p.trim().toLowerCase())
+    .filter((p) => p.length > 0)
+  if (parts.length === 0) {
+    return 'Select at least one content language.'
+  }
+  const unknown = parts.filter((p) => !isSupportedContentLanguage(p))
+  if (unknown.length > 0) {
+    return `Unsupported content language: ${unknown.join(', ')}.`
+  }
+  return null
+}
+
+/** Kiwix OPDS `lang` filter for the selected languages ("eng,fra"). */
+export function toKiwixLangParam(codes: readonly string[]): string {
+  const kiwix = codes
+    .map((code) => CONTENT_LANGUAGES.find((l) => l.code === code)?.kiwix)
+    .filter((k): k is (typeof CONTENT_LANGUAGES)[number]['kiwix'] => !!k)
+  return kiwix.length > 0 ? kiwix.join(',') : 'eng'
+}
+
+/**
+ * Where to fetch a manifest. English keeps its historical URL, byte for byte;
+ * other languages read `collections/<code>/<file>`, a path no released build
+ * knows about, so publishing one can never change what existing installs show.
+ */
+export function manifestUrlFor(type: LanguageScopedManifestType, code: string): string {
+  const file = MANIFEST_FILENAMES[type]
+  return code === DEFAULT_CONTENT_LANGUAGE
+    ? `${COLLECTIONS_BASE_URL}/${file}`
+    : `${COLLECTIONS_BASE_URL}/${code}/${file}`
+}
+
+/** Cache key in `collection_manifests`. English keeps the bare type so no migration is needed. */
+export function manifestCacheKey(type: string, code: string): string {
+  return code === DEFAULT_CONTENT_LANGUAGE ? type : `${type}:${code}`
+}
+
+/**
+ * Prefix an id/slug with its language so a French "medicine" category or
+ * "all-maxi" Wikipedia option can't collide with the English one. English ids
+ * are left untouched, and prefixing is idempotent.
+ */
+export function namespaceForLanguage(id: string, code: string): string {
+  if (code === DEFAULT_CONTENT_LANGUAGE) return id
+  const prefix = `${code}:`
+  return id.startsWith(prefix) ? id : `${prefix}${id}`
+}
+
+/**
+ * Merge per-language category manifests into one spec for the picker. Each
+ * category is stamped with the language of the manifest it came from, and
+ * non-English slugs are namespaced. With only English present the English spec
+ * is returned unchanged. Returns null when no language produced a spec.
+ */
+export function mergeZimCategorySpecs(
+  specs: ReadonlyArray<{ language: string; spec: ZimCategoriesSpec | null }>
+): ZimCategoriesSpec | null {
+  const present = specs.filter(
+    (s): s is { language: string; spec: ZimCategoriesSpec } => s.spec !== null
+  )
+  if (present.length === 0) return null
+  if (present.length === 1 && present[0].language === DEFAULT_CONTENT_LANGUAGE) {
+    return present[0].spec
+  }
+
+  const seen = new Set<string>()
+  const categories: ZimCategoriesSpec['categories'] = []
+  for (const { language, spec } of present) {
+    for (const category of spec.categories) {
+      const slug = namespaceForLanguage(category.slug, language)
+      if (seen.has(slug)) continue
+      seen.add(slug)
+      categories.push({ ...category, slug, language })
+    }
+  }
+  return {
+    spec_version: present.map((s) => `${s.language}@${s.spec.spec_version}`).join('+'),
+    categories,
+  }
+}
+
+type LanguageTaggable = { id: string; language?: string }
+
+/**
+ * Merge Wikipedia options: English first (tagged `en`), then each other
+ * language with ids namespaced. Only the English manifest's "none" option is
+ * kept, so the picker still has exactly one "No Wikipedia" choice.
+ */
+export function mergeWikipediaOptions<T extends LanguageTaggable>(
+  english: readonly T[],
+  others: ReadonlyArray<{ language: string; options: readonly T[] }>
+): Array<T & { language: string }> {
+  const merged: Array<T & { language: string }> = english.map((opt) => ({
+    ...opt,
+    language: opt.language ?? DEFAULT_CONTENT_LANGUAGE,
+  }))
+  const seen = new Set(merged.map((o) => o.id))
+  for (const { language, options } of others) {
+    for (const opt of options) {
+      if (opt.id === 'none') continue
+      const id = namespaceForLanguage(opt.id, language)
+      if (seen.has(id)) continue
+      seen.add(id)
+      merged.push({ ...opt, id, language })
+    }
+  }
+  return merged
+}
+
+/**
+ * Options to show for the selected languages: always "none", every option in a
+ * selected language, and the current selection even when its language was
+ * deselected, so an installed Wikipedia never disappears from the picker.
+ */
+export function filterWikipediaOptions<T extends LanguageTaggable>(
+  options: readonly T[],
+  codes: readonly string[],
+  currentOptionId?: string | null
+): T[] {
+  return options.filter(
+    (opt) =>
+      opt.id === 'none' ||
+      opt.id === currentOptionId ||
+      codes.includes(opt.language ?? DEFAULT_CONTENT_LANGUAGE)
+  )
+}

--- a/admin/app/utils/zim_filename.ts
+++ b/admin/app/utils/zim_filename.ts
@@ -8,11 +8,51 @@ export function zimFilenameStem(name: string): string {
   return name.replace(/_\d{4}-\d{2}(?:-\d{2})?\.zim$/i, '')
 }
 
+const WIKIPEDIA_FILENAME = /^wikipedia_([a-z]{2,3}(?:-[a-z]+)?)_/i
+
+/**
+ * True for a Kiwix Wikipedia ZIM in any language (`wikipedia_en_…`,
+ * `wikipedia_fr_…`). Accepts a bare filename or a download URL.
+ */
+export function isWikipediaZimFilename(nameOrUrl: string): boolean {
+  const name = nameOrUrl.split('/').pop() ?? ''
+  return WIKIPEDIA_FILENAME.test(name)
+}
+
+/** Language segment of a Wikipedia ZIM filename (`fr` for `wikipedia_fr_all_maxi_…`), or null. */
+export function wikipediaFilenameLanguage(nameOrUrl: string): string | null {
+  const name = nameOrUrl.split('/').pop() ?? ''
+  const match = name.match(WIKIPEDIA_FILENAME)
+  return match ? match[1].toLowerCase() : null
+}
+
+/**
+ * Is this downloaded ZIM the Wikipedia the picker manages, as opposed to a
+ * Wikipedia-derived corpus that merely shares the prefix (a curated tier's
+ * `wikipedia_en_medicine_maxi`, a Kiwix-search download)? It is when its stem
+ * matches the current selection (same variant, possibly a newer release) or
+ * one of the known Wikipedia options. Only those may update the selection;
+ * everything else is bookkept like any other ZIM.
+ */
+export function isSelectorManagedWikipedia(
+  nameOrUrl: string,
+  selectionFilename: string | null | undefined,
+  optionFilenames: readonly string[]
+): boolean {
+  const name = nameOrUrl.split('/').pop() ?? ''
+  if (!isWikipediaZimFilename(name)) return false
+  const stem = zimFilenameStem(name)
+  return [selectionFilename, ...optionFilenames]
+    .filter((f): f is string => !!f)
+    .some((f) => zimFilenameStem(f.split('/').pop() ?? '') === stem)
+}
+
 /**
  * Of the existing files, return only those that are prior-version replacements
  * of `currentFilename` — same Wikipedia variant stem, different release. Used
  * by the post-download cleanup to avoid deleting unrelated Wikipedia corpora
- * the user has installed independently (issue #884).
+ * the user has installed independently (issue #884). The stem includes the
+ * language, so a French download never removes an English corpus or vice versa.
  */
 export function findReplacedWikipediaFiles(
   currentFilename: string,
@@ -20,7 +60,6 @@ export function findReplacedWikipediaFiles(
 ): string[] {
   const currentStem = zimFilenameStem(currentFilename)
   return existingNames.filter(
-    (n) =>
-      n.startsWith('wikipedia_en_') && n !== currentFilename && zimFilenameStem(n) === currentStem
+    (n) => isWikipediaZimFilename(n) && n !== currentFilename && zimFilenameStem(n) === currentStem
   )
 }

--- a/admin/app/validators/curated_collections.ts
+++ b/admin/app/validators/curated_collections.ts
@@ -72,6 +72,8 @@ export const wikipediaSpecSchema = vine.object({
       size_mb: vine.number().min(0),
       url: vine.string().url().nullable(),
       version: vine.string().nullable(),
+      // Content language (absent == 'en'). Declared so VineJS doesn't strip it.
+      language: vine.string().minLength(2).maxLength(5).optional(),
     })
   ).minLength(1),
 })
@@ -109,6 +111,7 @@ export const wikipediaOptionSchema = vine.object({
   description: vine.string(),
   size_mb: vine.number().min(0),
   url: vine.string().url().nullable(),
+  language: vine.string().minLength(2).maxLength(5).optional(),
 })
 
 export const wikipediaOptionsFileSchema = vine.object({

--- a/admin/app/validators/settings.ts
+++ b/admin/app/validators/settings.ts
@@ -2,6 +2,7 @@ import vine from "@vinejs/vine";
 import { SETTINGS_KEYS } from "../../constants/kv_store.js";
 import type { KVStoreKey } from "../../types/kv_store.js";
 import { CONTEXT_LADDER } from "../utils/context_window.js";
+import { validateContentLanguagesValue } from "../utils/content_languages.js";
 
 export const getSettingSchema = vine.compile(vine.object({
     key: vine.enum(SETTINGS_KEYS),
@@ -55,6 +56,8 @@ export function validateSettingValue(key: KVStoreKey, value: unknown): string | 
             }
             return null
         }
+        case 'content.languages':
+            return validateContentLanguagesValue(value)
         case 'contentAutoUpdate.maxBytesPerWindow': {
             // Per-window download budget in bytes. 0 = unlimited.
             const num = Number(value)

--- a/admin/constants/content_languages.ts
+++ b/admin/constants/content_languages.ts
@@ -1,0 +1,40 @@
+/**
+ * Languages a user can pick for *content* (curated collections, Wikipedia
+ * options, Kiwix library search). This is not UI localization: the Command
+ * Center stays in English, only the offered content changes.
+ *
+ * `code` is ISO 639-1 and names the per-language manifest directory
+ * (`collections/<code>/…`). `kiwix` is the ISO 639-3 code the Kiwix OPDS
+ * catalog filters on. `name` is the language's own name (an endonym), shown
+ * as-is so a speaker can find it without reading English.
+ */
+export const CONTENT_LANGUAGES = [
+  { code: 'en', kiwix: 'eng', name: 'English' },
+  { code: 'fr', kiwix: 'fra', name: 'Français' },
+  { code: 'de', kiwix: 'deu', name: 'Deutsch' },
+  { code: 'es', kiwix: 'spa', name: 'Español' },
+  { code: 'it', kiwix: 'ita', name: 'Italiano' },
+  { code: 'pt', kiwix: 'por', name: 'Português' },
+  { code: 'nl', kiwix: 'nld', name: 'Nederlands' },
+  { code: 'pl', kiwix: 'pol', name: 'Polski' },
+  { code: 'ro', kiwix: 'ron', name: 'Română' },
+  { code: 'el', kiwix: 'ell', name: 'Ελληνικά' },
+  { code: 'ru', kiwix: 'rus', name: 'Русский' },
+  { code: 'uk', kiwix: 'ukr', name: 'Українська' },
+  { code: 'tr', kiwix: 'tur', name: 'Türkçe' },
+  { code: 'ar', kiwix: 'ara', name: 'العربية' },
+  { code: 'he', kiwix: 'heb', name: 'עברית' },
+  { code: 'fa', kiwix: 'fas', name: 'فارسی' },
+  { code: 'hi', kiwix: 'hin', name: 'हिन्दी' },
+  { code: 'bn', kiwix: 'ben', name: 'বাংলা' },
+  { code: 'id', kiwix: 'ind', name: 'Bahasa Indonesia' },
+  { code: 'vi', kiwix: 'vie', name: 'Tiếng Việt' },
+  { code: 'zh', kiwix: 'zho', name: '中文' },
+  { code: 'ja', kiwix: 'jpn', name: '日本語' },
+  { code: 'ko', kiwix: 'kor', name: '한국어' },
+] as const
+
+export type ContentLanguageCode = (typeof CONTENT_LANGUAGES)[number]['code']
+
+/** What every install offers until the user changes the setting. */
+export const DEFAULT_CONTENT_LANGUAGE: ContentLanguageCode = 'en'

--- a/admin/constants/kv_store.ts
+++ b/admin/constants/kv_store.ts
@@ -5,6 +5,7 @@ export const SETTINGS_KEYS: KVStoreKey[] = [
     'chat.lastModel',
     'ui.hasVisitedEasySetup',
     'ui.theme',
+    'content.languages',
     'system.earlyAccess',
     'system.internetStatusTestUrl',
     'ai.assistantCustomName',

--- a/admin/inertia/components/CategoryCard.tsx
+++ b/admin/inertia/components/CategoryCard.tsx
@@ -65,6 +65,11 @@ const CategoryCard: React.FC<CategoryCardProps> = ({ category, selectedTier, onC
           <div className="flex items-center">
             <DynamicIcon icon={category.icon as DynamicIconName} className="w-6 h-6 mr-2" />
             <h3 className="text-lg font-semibold">{category.name}</h3>
+            {category.language && category.language !== 'en' && (
+              <span className="ml-2 text-xs uppercase px-1.5 py-0.5 rounded bg-white/15 text-white/90">
+                {category.language}
+              </span>
+            )}
           </div>
           {badgeTier ? (
             <div className="flex items-center">

--- a/admin/inertia/components/ContentLanguageSelector.tsx
+++ b/admin/inertia/components/ContentLanguageSelector.tsx
@@ -1,0 +1,116 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import classNames from 'classnames'
+import { IconCheck, IconLanguage } from '@tabler/icons-react'
+import api from '~/lib/api'
+import { useNotifications } from '~/context/NotificationContext'
+import { CONTENT_LANGUAGES } from '../../constants/content_languages'
+import { parseContentLanguages } from '../../app/utils/content_languages'
+
+export const CONTENT_LANGUAGES_KEY = 'content-languages'
+
+/** Queries whose results depend on the content languages, refreshed on change. */
+const DEPENDENT_QUERY_KEYS = ['curated-categories', 'wikipedia-state', 'remote-zim-files']
+
+export interface ContentLanguageSelectorProps {
+  disabled?: boolean
+  className?: string
+}
+
+/**
+ * Picks which languages of curated content, Wikipedia packages and Kiwix
+ * library results are offered. Saved immediately to `content.languages`.
+ * This does not translate the interface.
+ */
+const ContentLanguageSelector: React.FC<ContentLanguageSelectorProps> = ({
+  disabled = false,
+  className,
+}) => {
+  const queryClient = useQueryClient()
+  const { addNotification } = useNotifications()
+
+  const { data: selected = ['en'] } = useQuery({
+    queryKey: [CONTENT_LANGUAGES_KEY],
+    queryFn: async () => {
+      const res = await api.getSetting('content.languages')
+      return parseContentLanguages(res?.value ?? null) as string[]
+    },
+    refetchOnWindowFocus: false,
+  })
+
+  const save = useMutation({
+    mutationFn: async (codes: string[]) => {
+      const res = await api.updateSetting('content.languages', codes.join(','))
+      if (!res?.success) throw new Error(res?.message || 'Failed to save content languages')
+      return codes
+    },
+    onSuccess: (codes) => {
+      queryClient.setQueryData([CONTENT_LANGUAGES_KEY], codes)
+      for (const key of DEPENDENT_QUERY_KEYS) {
+        queryClient.invalidateQueries({ queryKey: [key] })
+      }
+    },
+    onError: (error) => {
+      addNotification({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Failed to save content languages',
+      })
+    },
+  })
+
+  const toggle = (code: string) => {
+    if (disabled || save.isPending) return
+    const isOn = selected.includes(code)
+    // Keep at least one language: an empty selection would offer no content at all.
+    if (isOn && selected.length === 1) return
+    const next = isOn ? selected.filter((c) => c !== code) : [...selected, code]
+    save.mutate(next)
+  }
+
+  return (
+    <div className={classNames('w-full', className)}>
+      <div className="flex items-center gap-3 mb-4">
+        <div className="w-10 h-10 rounded-full bg-surface-primary border border-border-subtle flex items-center justify-center shadow-sm">
+          <IconLanguage className="w-6 h-6 text-text-primary" />
+        </div>
+        <h3 className="text-xl font-semibold text-text-primary">Content Languages</h3>
+      </div>
+
+      <div className="flex flex-wrap gap-2" role="group" aria-label="Content languages">
+        {CONTENT_LANGUAGES.map((language) => {
+          const isOn = selected.includes(language.code)
+          const isLastSelected = isOn && selected.length === 1
+          return (
+            <button
+              key={language.code}
+              type="button"
+              aria-pressed={isOn}
+              disabled={disabled || save.isPending || isLastSelected}
+              onClick={() => toggle(language.code)}
+              className={classNames(
+                'flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-sm transition-colors',
+                isOn
+                  ? 'bg-desert-green border-desert-green text-white'
+                  : 'bg-surface-primary border-border-subtle text-text-secondary hover:border-border-default',
+                (disabled || save.isPending) && 'opacity-60 cursor-not-allowed',
+                isLastSelected && 'cursor-default'
+              )}
+            >
+              {isOn && <IconCheck size={14} />}
+              <span lang={language.code}>{language.name}</span>
+              <span
+                className={classNames(
+                  'text-xs uppercase',
+                  isOn ? 'text-white/70' : 'text-text-muted'
+                )}
+              >
+                {language.code}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default ContentLanguageSelector

--- a/admin/inertia/components/WikipediaSelector.tsx
+++ b/admin/inertia/components/WikipediaSelector.tsx
@@ -125,7 +125,14 @@ const WikipediaSelector: React.FC<WikipediaSelectorProps> = ({
 
               {/* Option content */}
               <div className="pr-16 flex flex-col h-full">
-                <h4 className="text-lg font-semibold text-text-primary mb-1">{option.name}</h4>
+                <h4 className="text-lg font-semibold text-text-primary mb-1">
+                  {option.name}
+                  {option.language && option.language !== 'en' && (
+                    <span className="ml-2 align-middle text-xs uppercase font-medium px-1.5 py-0.5 rounded bg-surface-secondary text-text-secondary">
+                      {option.language}
+                    </span>
+                  )}
+                </h4>
                 <p className="text-sm text-text-secondary mb-3 flex-grow">{option.description}</p>
                 <div className="flex items-center gap-3">
                   {/* Radio indicator */}

--- a/admin/inertia/components/ZimUploader/index.tsx
+++ b/admin/inertia/components/ZimUploader/index.tsx
@@ -4,6 +4,7 @@ import XHRUpload from '@uppy/xhr-upload'
 import '@uppy/core/css/style.min.css'
 import '@uppy/dashboard/css/style.min.css'
 import { useEffect, useRef, useState } from 'react'
+import { isWikipediaZimFilename } from '../../../app/utils/zim_filename'
 
 interface ZimUploaderProps {
   onUploadComplete: (added: number) => void
@@ -54,9 +55,10 @@ export default function ZimUploader({ onUploadComplete, existingFilenames }: Zim
         return
       }
 
-      const isWikipedia = (name: string) => name.startsWith('wikipedia_en_')
-      if (isWikipedia(file.name)) {
-        const alreadyQueued = uppy.getFiles().some((f) => f.id !== file.id && isWikipedia(f.name))
+      if (isWikipediaZimFilename(file.name)) {
+        const alreadyQueued = uppy
+          .getFiles()
+          .some((f) => f.id !== file.id && isWikipediaZimFilename(f.name))
         if (alreadyQueued) {
           uppy.removeFile(file.id)
           uppy.info('Only one Wikipedia file can be uploaded at a time', 'error', 6000)

--- a/admin/inertia/pages/easy-setup/index.tsx
+++ b/admin/inertia/pages/easy-setup/index.tsx
@@ -10,6 +10,7 @@ import CategoryCard from '~/components/CategoryCard'
 import CreatorPackCard from '~/components/CreatorPackCard'
 import TierSelectionModal from '~/components/TierSelectionModal'
 import WikipediaSelector from '~/components/WikipediaSelector'
+import ContentLanguageSelector from '~/components/ContentLanguageSelector'
 import LoadingSpinner from '~/components/LoadingSpinner'
 import Alert from '~/components/Alert'
 import { IconCheck, IconCpu, IconBooks } from '@tabler/icons-react'
@@ -186,6 +187,26 @@ export default function EasySetupWizard(props: {
     queryFn: () => api.getWikipediaState(),
     refetchOnWindowFocus: false,
   })
+
+  // A content-language change can remove options from the lists above: drop
+  // pending picks that are no longer offered so Finish never submits them.
+  useEffect(() => {
+    if (
+      wikipediaState &&
+      selectedWikipedia &&
+      !wikipediaState.options.some((option) => option.id === selectedWikipedia)
+    ) {
+      setSelectedWikipedia(null)
+    }
+  }, [wikipediaState, selectedWikipedia])
+
+  useEffect(() => {
+    if (!categories) return
+    setSelectedTiers((prev) => {
+      const kept = [...prev].filter(([slug]) => categories.some((c) => c.slug === slug))
+      return kept.length === prev.size ? prev : new Map(kept)
+    })
+  }, [categories])
 
   // All services for display purposes
   const allServices = props.system.services
@@ -931,6 +952,13 @@ export default function EasySetupWizard(props: {
               : 'Configure content for your selected capabilities.'}
           </p>
         </div>
+
+        {/* Content languages - filter the Wikipedia packages and collections offered below */}
+        {isInformationSelected && (
+          <div className="mb-8">
+            <ContentLanguageSelector disabled={!isOnline} />
+          </div>
+        )}
 
         {/* Wikipedia Selection - Only show if Information capability is selected */}
         {isInformationSelected && (

--- a/admin/inertia/pages/settings/zim/remote-explorer.tsx
+++ b/admin/inertia/pages/settings/zim/remote-explorer.tsx
@@ -35,6 +35,7 @@ import CategoryCard from '~/components/CategoryCard'
 import CreatorPacksSection from '~/components/CreatorPacksSection'
 import TierSelectionModal from '~/components/TierSelectionModal'
 import WikipediaSelector from '~/components/WikipediaSelector'
+import ContentLanguageSelector from '~/components/ContentLanguageSelector'
 import StyledSectionHeader from '~/components/StyledSectionHeader'
 import type { CategoryWithStatus, SpecTier } from '../../../../types/collections'
 import useDownloads from '~/hooks/useDownloads'
@@ -105,6 +106,17 @@ export default function ZimRemoteExplorer() {
     queryFn: () => api.getWikipediaState(),
     refetchOnWindowFocus: false,
   })
+
+  // A content-language change can hide the pending Wikipedia pick: drop it.
+  useEffect(() => {
+    if (
+      wikipediaState &&
+      selectedWikipedia &&
+      !wikipediaState.options.some((option) => option.id === selectedWikipedia)
+    ) {
+      setSelectedWikipedia(null)
+    }
+  }, [wikipediaState, selectedWikipedia])
 
   const { data: localFiles } = useQuery<ZimFileWithMetadata[]>({
     queryKey: [ZIM_FILES_KEY],
@@ -495,6 +507,11 @@ export default function ZimRemoteExplorer() {
             >
               Force Refresh Collections
             </StyledButton>
+          </div>
+
+          {/* Content languages: filters Wikipedia, curated collections and Kiwix search below */}
+          <div className="mt-8 bg-surface-primary rounded-lg border border-border-subtle p-6">
+            <ContentLanguageSelector />
           </div>
 
           {/* Wikipedia Selector */}

--- a/admin/tests/unit/content_languages.spec.ts
+++ b/admin/tests/unit/content_languages.spec.ts
@@ -1,0 +1,320 @@
+import * as assert from 'node:assert/strict'
+import { test } from 'node:test'
+import vine from '@vinejs/vine'
+
+import {
+  filterWikipediaOptions,
+  isSupportedContentLanguage,
+  manifestCacheKey,
+  manifestUrlFor,
+  mergeWikipediaOptions,
+  mergeZimCategorySpecs,
+  namespaceForLanguage,
+  parseContentLanguages,
+  toKiwixLangParam,
+  validateContentLanguagesValue,
+} from '../../app/utils/content_languages.js'
+import { validateSettingValue } from '../../app/validators/settings.js'
+import { wikipediaSpecSchema } from '../../app/validators/curated_collections.js'
+import type { ZimCategoriesSpec } from '../../types/collections.js'
+
+/**
+ * The invariant that matters most: with the default setting (English only)
+ * nothing observable changes. Same manifest URLs, same cache keys, same
+ * category slugs, same Wikipedia options. Other languages are additive.
+ */
+
+// ---- parsing & validation of the `content.languages` setting ----
+
+test('parseContentLanguages defaults to English when the setting is unset or unusable', () => {
+  assert.deepEqual(parseContentLanguages(null), ['en'])
+  assert.deepEqual(parseContentLanguages(undefined), ['en'])
+  assert.deepEqual(parseContentLanguages(''), ['en'])
+  assert.deepEqual(parseContentLanguages('xx, zz'), ['en'])
+})
+
+test('parseContentLanguages keeps order, trims, lowercases, drops unknown codes and duplicates', () => {
+  assert.deepEqual(parseContentLanguages(' FR , en,fr,xx '), ['fr', 'en'])
+  assert.deepEqual(parseContentLanguages('fr'), ['fr'])
+})
+
+test('validateContentLanguagesValue accepts a comma-separated list of supported codes', () => {
+  assert.equal(validateContentLanguagesValue('en'), null)
+  assert.equal(validateContentLanguagesValue('en,fr'), null)
+  assert.equal(validateContentLanguagesValue(' fr , DE '), null)
+})
+
+test('validateContentLanguagesValue rejects empty, unknown and non-string values', () => {
+  assert.match(validateContentLanguagesValue('')!, /at least one/)
+  assert.match(validateContentLanguagesValue(' , ')!, /at least one/)
+  assert.match(
+    validateContentLanguagesValue('en,klingon')!,
+    /Unsupported content language: klingon/
+  )
+  assert.match(validateContentLanguagesValue(['en', 'fr'])!, /comma-separated/)
+  // the body parser turns an empty string into null before validation
+  assert.match(validateContentLanguagesValue(null)!, /at least one/)
+  assert.match(validateContentLanguagesValue(undefined)!, /at least one/)
+})
+
+test('the settings endpoint validates content.languages through the same rule', () => {
+  assert.equal(validateSettingValue('content.languages', 'en,fr'), null)
+  assert.ok(validateSettingValue('content.languages', 'xx'))
+  assert.ok(validateSettingValue('content.languages', ''))
+})
+
+// ---- Kiwix catalog filter ----
+
+test('toKiwixLangParam maps ISO 639-1 codes to the ISO 639-3 codes Kiwix filters on', () => {
+  assert.equal(toKiwixLangParam(['en']), 'eng')
+  assert.equal(toKiwixLangParam(['fr', 'en']), 'fra,eng')
+  assert.equal(toKiwixLangParam([]), 'eng')
+})
+
+// ---- manifest URLs and cache keys ----
+
+test('English manifest URLs are byte-for-byte the historical ones', () => {
+  assert.equal(
+    manifestUrlFor('zim_categories', 'en'),
+    'https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/main/collections/kiwix-categories.json'
+  )
+  assert.equal(
+    manifestUrlFor('wikipedia', 'en'),
+    'https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/main/collections/wikipedia.json'
+  )
+})
+
+test('other languages read a per-language directory that released builds never request', () => {
+  assert.equal(
+    manifestUrlFor('zim_categories', 'fr'),
+    'https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/main/collections/fr/kiwix-categories.json'
+  )
+  assert.equal(
+    manifestUrlFor('wikipedia', 'fr'),
+    'https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/refs/heads/main/collections/fr/wikipedia.json'
+  )
+})
+
+test('English cache keys are unchanged so no migration is needed; other languages get their own row', () => {
+  assert.equal(manifestCacheKey('zim_categories', 'en'), 'zim_categories')
+  assert.equal(manifestCacheKey('wikipedia', 'en'), 'wikipedia')
+  assert.equal(manifestCacheKey('zim_categories', 'fr'), 'zim_categories:fr')
+})
+
+test('namespaceForLanguage leaves English ids alone and is idempotent', () => {
+  assert.equal(namespaceForLanguage('medicine', 'en'), 'medicine')
+  assert.equal(namespaceForLanguage('medicine', 'fr'), 'fr:medicine')
+  assert.equal(namespaceForLanguage('fr:medicine', 'fr'), 'fr:medicine')
+})
+
+// ---- merging curated categories ----
+
+function categorySpec(version: string, slugs: string[], language = 'en'): ZimCategoriesSpec {
+  return {
+    spec_version: version,
+    categories: slugs.map((slug) => ({
+      name: slug,
+      slug,
+      icon: 'IconBooks',
+      description: `${slug} description`,
+      language,
+      tiers: [{ name: 'Essential', slug: 'essential', description: 'd', resources: [] }],
+    })),
+  }
+}
+
+test('mergeZimCategorySpecs returns the English spec untouched when English is the only language', () => {
+  const english = categorySpec('2026-09-01', ['medicine', 'survival'])
+  assert.equal(mergeZimCategorySpecs([{ language: 'en', spec: english }]), english)
+})
+
+test('mergeZimCategorySpecs ignores a language whose manifest does not exist yet', () => {
+  const english = categorySpec('2026-09-01', ['medicine'])
+  assert.equal(
+    mergeZimCategorySpecs([
+      { language: 'en', spec: english },
+      { language: 'fr', spec: null },
+    ]),
+    english
+  )
+  assert.equal(mergeZimCategorySpecs([{ language: 'fr', spec: null }]), null)
+})
+
+test('mergeZimCategorySpecs namespaces non-English slugs and stamps each category with its language', () => {
+  const merged = mergeZimCategorySpecs([
+    { language: 'en', spec: categorySpec('1.0', ['medicine']) },
+    // `language` in the file is overridden by the directory it was fetched from
+    { language: 'fr', spec: categorySpec('1.1', ['medicine', 'fr:repair'], 'en') },
+  ])!
+  assert.deepEqual(
+    merged.categories.map((c) => [c.slug, c.language]),
+    [
+      ['medicine', 'en'],
+      ['fr:medicine', 'fr'],
+      ['fr:repair', 'fr'],
+    ]
+  )
+  assert.equal(merged.spec_version, 'en@1.0+fr@1.1')
+})
+
+test('mergeZimCategorySpecs offers French alone when English is deselected', () => {
+  const merged = mergeZimCategorySpecs([
+    { language: 'fr', spec: categorySpec('1.1', ['medicine']) },
+  ])!
+  assert.deepEqual(
+    merged.categories.map((c) => c.slug),
+    ['fr:medicine']
+  )
+})
+
+// ---- Wikipedia options ----
+
+const englishOptions = [
+  { id: 'none', name: 'No Wikipedia', url: null },
+  { id: 'all-mini', name: 'Mini', url: 'https://x/wikipedia_en_all_mini_2026-05.zim' },
+  { id: 'all-maxi', name: 'Maxi', url: 'https://x/wikipedia_en_all_maxi_2026-05.zim' },
+]
+const frenchOptions = [
+  { id: 'none', name: 'Pas de Wikipédia', url: null },
+  {
+    id: 'all-maxi',
+    name: 'Wikipédia complète',
+    url: 'https://x/wikipedia_fr_all_maxi_2026-05.zim',
+  },
+]
+
+test('mergeWikipediaOptions with English only just tags every option as English', () => {
+  const merged = mergeWikipediaOptions(englishOptions, [])
+  assert.deepEqual(
+    merged.map((o) => [o.id, o.language]),
+    [
+      ['none', 'en'],
+      ['all-mini', 'en'],
+      ['all-maxi', 'en'],
+    ]
+  )
+})
+
+test('mergeWikipediaOptions namespaces other languages and keeps a single "none" option', () => {
+  const merged = mergeWikipediaOptions(englishOptions, [{ language: 'fr', options: frenchOptions }])
+  assert.deepEqual(
+    merged.map((o) => [o.id, o.language]),
+    [
+      ['none', 'en'],
+      ['all-mini', 'en'],
+      ['all-maxi', 'en'],
+      ['fr:all-maxi', 'fr'],
+    ]
+  )
+})
+
+test('filterWikipediaOptions shows only the selected languages, plus "none"', () => {
+  const merged = mergeWikipediaOptions(englishOptions, [{ language: 'fr', options: frenchOptions }])
+  assert.deepEqual(
+    filterWikipediaOptions(merged, ['en']).map((o) => o.id),
+    ['none', 'all-mini', 'all-maxi']
+  )
+  assert.deepEqual(
+    filterWikipediaOptions(merged, ['fr']).map((o) => o.id),
+    ['none', 'fr:all-maxi']
+  )
+})
+
+test('filterWikipediaOptions keeps the installed selection visible after its language is deselected', () => {
+  const merged = mergeWikipediaOptions(englishOptions, [{ language: 'fr', options: frenchOptions }])
+  assert.deepEqual(
+    filterWikipediaOptions(merged, ['fr'], 'all-mini').map((o) => o.id),
+    ['none', 'all-mini', 'fr:all-maxi']
+  )
+})
+
+test('filterWikipediaOptions treats options without a language as English', () => {
+  assert.deepEqual(
+    filterWikipediaOptions(englishOptions, ['en']).map((o) => o.id),
+    ['none', 'all-mini', 'all-maxi']
+  )
+})
+
+// ---- manifest schema ----
+
+test('wikipediaSpecSchema keeps the optional language field (VineJS strips undeclared keys)', async () => {
+  const spec = {
+    spec_version: '1.0',
+    options: [
+      {
+        id: 'all-maxi',
+        name: 'Maxi',
+        description: 'd',
+        size_mb: 1,
+        url: 'https://download.kiwix.org/zim/wikipedia/wikipedia_fr_all_maxi_2026-05.zim',
+        version: '2026-05',
+        language: 'fr',
+      },
+      { id: 'none', name: 'None', description: 'd', size_mb: 0, url: null, version: null },
+    ],
+  }
+  const validated = await vine.validate({ schema: wikipediaSpecSchema, data: spec })
+  assert.equal(validated.options[0].language, 'fr')
+  assert.equal(validated.options[1].language, undefined)
+})
+
+// ---- security: the setting can never inject into a URL, a path or the picker ----
+
+const HOSTILE_VALUES = [
+  '../../etc/passwd',
+  'fr/../../secrets',
+  'fr%2F..%2F..',
+  'fr?token=x',
+  'fr#x',
+  'fr&lang=eng',
+  '<script>alert(1)</script>',
+  'FR\u0000',
+  'en,../fr',
+]
+
+test('security: hostile content.languages values are rejected by the settings endpoint', () => {
+  for (const value of HOSTILE_VALUES) {
+    assert.ok(
+      validateSettingValue('content.languages', value),
+      `accepted: ${JSON.stringify(value)}`
+    )
+  }
+})
+
+test('security: hostile values stored anyway (e.g. edited in the DB) are dropped when read', () => {
+  for (const value of HOSTILE_VALUES) {
+    const codes = parseContentLanguages(value)
+    assert.ok(
+      codes.every((c) => isSupportedContentLanguage(c)),
+      `leaked: ${JSON.stringify(codes)}`
+    )
+  }
+})
+
+test('security: only allow-listed codes can reach a manifest URL or the Kiwix lang filter', () => {
+  for (const value of HOSTILE_VALUES) {
+    const codes = parseContentLanguages(value)
+    for (const code of codes) {
+      assert.match(
+        manifestUrlFor('zim_categories', code),
+        /\/collections\/(?:[a-z]{2}\/)?kiwix-categories\.json$/
+      )
+    }
+    assert.match(toKiwixLangParam(codes), /^[a-z]{3}(,[a-z]{3})*$/)
+  }
+})
+
+test('security: a non-English manifest cannot shadow English categories or the "none" option', () => {
+  const merged = mergeZimCategorySpecs([
+    { language: 'en', spec: categorySpec('1.0', ['medicine']) },
+    { language: 'fr', spec: categorySpec('1.0', ['medicine']) },
+  ])!
+  const english = merged.categories.find((c) => c.slug === 'medicine')!
+  assert.equal(english.language, 'en')
+
+  const options = mergeWikipediaOptions(englishOptions, [
+    { language: 'fr', options: [{ id: 'none', name: 'hijacked none', url: null }] },
+  ])
+  assert.equal(options.filter((o) => o.id === 'none').length, 1)
+  assert.equal(options.find((o) => o.id === 'none')!.name, 'No Wikipedia')
+})

--- a/admin/tests/unit/zim_filename.spec.ts
+++ b/admin/tests/unit/zim_filename.spec.ts
@@ -1,7 +1,13 @@
 import * as assert from 'node:assert/strict'
 import { test } from 'node:test'
 
-import { findReplacedWikipediaFiles, zimFilenameStem } from '../../app/utils/zim_filename.js'
+import {
+  findReplacedWikipediaFiles,
+  isSelectorManagedWikipedia,
+  isWikipediaZimFilename,
+  wikipediaFilenameLanguage,
+  zimFilenameStem,
+} from '../../app/utils/zim_filename.js'
 
 test('zimFilenameStem strips YYYY-MM date suffix', () => {
   assert.equal(zimFilenameStem('wikipedia_en_all_nopic_2026-02.zim'), 'wikipedia_en_all_nopic')
@@ -69,5 +75,102 @@ test('findReplacedWikipediaFiles preserves manually-named files without a date s
       'wikipedia_en_all_nopic_2026-04.zim',
     ]),
     []
+  )
+})
+
+test('isWikipediaZimFilename recognises Wikipedia ZIMs in any language, from a name or a URL', () => {
+  assert.equal(isWikipediaZimFilename('wikipedia_en_all_maxi_2026-05.zim'), true)
+  assert.equal(isWikipediaZimFilename('wikipedia_fr_all_maxi_2026-05.zim'), true)
+  assert.equal(isWikipediaZimFilename('wikipedia_zh-classical_all_2025-01.zim'), true)
+  assert.equal(
+    isWikipediaZimFilename(
+      'https://download.kiwix.org/zim/wikipedia/wikipedia_de_all_nopic_2026-04.zim'
+    ),
+    true
+  )
+})
+
+test('isWikipediaZimFilename ignores other projects, including ones whose directory is "wikipedia"', () => {
+  assert.equal(isWikipediaZimFilename('wiktionary_fr_all_2026-02.zim'), false)
+  assert.equal(isWikipediaZimFilename('vikidia_fr_all_maxi_2026-09.zim'), false)
+  assert.equal(
+    isWikipediaZimFilename('https://mirror/zim/wikipedia/ifixit_fr_all_2026-03.zim'),
+    false
+  )
+})
+
+test('wikipediaFilenameLanguage extracts the language segment', () => {
+  assert.equal(wikipediaFilenameLanguage('wikipedia_fr_all_maxi_2026-05.zim'), 'fr')
+  assert.equal(wikipediaFilenameLanguage('https://x/wikipedia_en_all_mini_2026-05.zim'), 'en')
+  assert.equal(wikipediaFilenameLanguage('gutenberg_fr_all_2026-01.zim'), null)
+})
+
+test('findReplacedWikipediaFiles cleans up an older version of a non-English variant', () => {
+  assert.deepEqual(
+    findReplacedWikipediaFiles('wikipedia_fr_all_maxi_2026-05.zim', [
+      'wikipedia_fr_all_maxi_2025-11.zim',
+      'wikipedia_fr_all_maxi_2026-05.zim',
+    ]),
+    ['wikipedia_fr_all_maxi_2025-11.zim']
+  )
+})
+
+test('findReplacedWikipediaFiles never removes a corpus in another language', () => {
+  assert.deepEqual(
+    findReplacedWikipediaFiles('wikipedia_fr_all_maxi_2026-05.zim', [
+      'wikipedia_en_all_maxi_2026-05.zim',
+      'wikipedia_en_all_maxi_2025-11.zim',
+      'wikipedia_fr_all_maxi_2026-05.zim',
+    ]),
+    []
+  )
+})
+
+// ---- which downloads the Wikipedia picker manages ----
+
+const OPTIONS = [
+  'https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_maxi_2026-05.zim',
+  'https://download.kiwix.org/zim/wikipedia/wikipedia_fr_all_mini_2026-05.zim',
+]
+
+test('isSelectorManagedWikipedia: the selected file and known options are managed', () => {
+  assert.equal(isSelectorManagedWikipedia('wikipedia_en_all_maxi_2026-05.zim', null, OPTIONS), true)
+  assert.equal(
+    isSelectorManagedWikipedia('https://mirror/x/wikipedia_fr_all_mini_2026-05.zim', null, OPTIONS),
+    true
+  )
+})
+
+test('isSelectorManagedWikipedia: a newer release of the selected variant is managed (auto-update)', () => {
+  assert.equal(
+    isSelectorManagedWikipedia(
+      'wikipedia_en_all_nopic_2026-08.zim',
+      'wikipedia_en_all_nopic_2026-05.zim',
+      []
+    ),
+    true
+  )
+})
+
+test('isSelectorManagedWikipedia: curated Wikipedia-derived corpora are NOT managed', () => {
+  // Medicine tiers ship WikiMed; it must not hijack the Wikipedia selection
+  assert.equal(
+    isSelectorManagedWikipedia(
+      'wikipedia_en_medicine_maxi_2026-01.zim',
+      'wikipedia_en_all_maxi_2026-05.zim',
+      OPTIONS
+    ),
+    false
+  )
+  assert.equal(
+    isSelectorManagedWikipedia('wikipedia_fr_medicine_nopic_2026-07.zim', null, OPTIONS),
+    false
+  )
+})
+
+test('isSelectorManagedWikipedia: non-Wikipedia files are never managed', () => {
+  assert.equal(
+    isSelectorManagedWikipedia('ifixit_fr_all_2026-03.zim', 'ifixit_fr_all_2025-12.zim', []),
+    false
   )
 })

--- a/admin/types/collections.ts
+++ b/admin/types/collections.ts
@@ -70,6 +70,8 @@ export type WikipediaOption = {
   size_mb: number
   url: string | null
   version: string | null
+  /** ISO 639-1 content language. Absent in the English manifest, which means `en`. */
+  language?: string
 }
 
 export type WikipediaSpec = {

--- a/admin/types/downloads.ts
+++ b/admin/types/downloads.ts
@@ -86,6 +86,8 @@ export type WikipediaOption = {
   description: string
   size_mb: number
   url: string | null
+  /** ISO 639-1 content language. Absent in the English manifest, which means `en`. */
+  language?: string
 }
 
 export type WikipediaOptionsFile = {

--- a/admin/types/kv_store.ts
+++ b/admin/types/kv_store.ts
@@ -44,6 +44,11 @@ export const KV_STORE_SCHEMA = {
   'contentAutoUpdate.windowResetAt':     'string',
   'ui.hasVisitedEasySetup':     'boolean',
   'ui.theme':                   'string',
+  // Languages offered for curated content, Wikipedia and Kiwix search, as a
+  // comma-separated list of ISO 639-1 codes ("en,fr"). Unset means English
+  // only, the behaviour before this setting existed. Content only: the UI
+  // itself is not translated.
+  'content.languages':          'string',
   'ai.assistantCustomName':     'string',
   'gpu.type':                   'string',
   'ai.remoteOllamaUrl':         'string',


### PR DESCRIPTION
Hi Chris, hi Jake 👋

This PR follows up directly on your answer in #1262:

> The content path isn't blocked on the framework, it's blocked on a language filter in the picker, and that's a smaller piece of work than full i18n.

It implements that language filter and nothing more. **This is not i18n:** no translation framework, no string extraction, and the UI stays in English. It only changes *which content is offered*. It also respects the constraint you raised on #1267 (manifest changes and app changes must not ship together): this PR is app code only, with no manifest changes.

I know CONTRIBUTING asks for an issue before a non-trivial PR. I treated #1262 and your note there as the design discussion, and it also overlaps #1323 (configurable catalog sources). If you'd rather have a fresh issue, I'll gladly open one and park this. And if it doesn't fit your plans, closing it is completely fine.

## What it does

A new **Content Languages** selector appears in **Easy Setup → Choose Content** and in **Settings → Content Explorer**. It saves a `content.languages` setting (ISO 639-1 codes, **default `en`**). The selected languages drive:

- **Curated collections**: English still comes from `collections/kiwix-categories.json`. Each other enabled language reads `collections/<code>/kiwix-categories.json`. Categories are merged and stamped with their language, and non-English slugs are namespaced (`fr:medicine`) so they can't collide with English ones.
- **Wikipedia picker**: same scheme for `wikipedia.json`. Option ids are namespaced (`fr:all-maxi`) and only English's "none" option is kept. The installed selection stays visible even if its language is deselected.
- **Kiwix library search**: `lang` becomes the selected languages (`eng,fra`) instead of the hardcoded `eng`.

Non-English categories and Wikipedia options get a small language badge. English-only users see no change.

## Why existing installs are safe

- With the default (`en` only), the manifest URLs, `collection_manifests` cache keys, category slugs and Wikipedia option ids are **exactly** what they are today. Tests pin this.
- Non-English manifests live in `collections/<code>/`, a path no released build requests. Publishing French content later can't reach an existing install; the safety comes from the file layout, not from a filter that old builds lack.
- There's **no DB migration**: non-English manifests are cached as `<type>:<code>` rows in the existing string-keyed table.
- The Wikipedia option schema gains an optional `language` field. VineJS strips unknown keys, so old builds simply ignore it.

## A related Wikipedia fix

The picker's Wikipedia used to be recognised by the `wikipedia_en_` prefix, and just extending that prefix to other languages would have spread an existing bug. Medicine's Comprehensive tier ships `wikipedia_en_medicine_maxi`, and when it finishes downloading it's treated as *the* Wikipedia:

- the selection's `filename` is overwritten with WikiMed;
- its `InstalledResource` row is skipped;
- on the next restart, `reconcileFromFilesystem` skips it as "the managed Wikipedia" and removes its row, so the tier silently shows as not installed.

I reproduced this end to end with a French WikiMed tier.

A new pure helper, `isSelectorManagedWikipedia()`, now treats a download as the picker's only when its stem matches the current selection (so auto-updates to a newer release still count) or a known option. None of the curated `wikipedia_*` resources share a stem with an option today (checked against `collections/`). Ordinary ZIMs are answered without any I/O, so an offline install never waits on GitHub to finish a download. The upload path now uses `findReplacedWikipediaFiles` like the download flow (#884), instead of deleting every other `wikipedia_en_*` file. Happy to split this into its own PR if you prefer.

## Security review

- `content.languages` is validated server-side against a fixed allow-list (23 languages). Empty, unknown and malformed values are rejected with a clear message.
- Only allow-listed codes can reach a manifest URL path or the Kiwix `lang` parameter. Values stored anyway (e.g. edited in the DB) are dropped when read, and `fetchAndCacheSpec` refuses unknown codes as defence in depth. Tests cover path traversal (`../`), encoded slashes, query/fragment injection, markup and NUL bytes.
- A non-English manifest can't shadow an English category or the "none" option (namespacing plus dedupe, tested).
- Non-English manifests go through the same VineJS schemas as English ones. There are no new routes and no dependency changes, and the UI renders language names as plain text.
- The Wikipedia fix *narrows* file deletion (only older releases of the same variant). Deletion still goes through `ZimService.delete()`, with its existing path-traversal guard.

## Testing

**Automated, run by Claude:**
- **Unit tests**: `content_languages.spec.ts` (24 new tests, 4 of them security) and `zim_filename.spec.ts` (+9).
- **Non-regression**: `npm run test:unit` gives 526/535. The 9 failing files (`app_auto_update`, `content_auto_update`, `content_auto_update_backoff`, `custom_app_guard`, `drug_ingest_status`, `drug_interactions`, `drug_labels`, `ollama_controller_chat`, `rag_retrieval_toggle`) fail the same way on `dev` without this change, in a plain `node:24` container. They look like they need services I didn't run.
- **Types and build**: `npm run typecheck` is clean and `npm run build` passes (what `build-admin-on-pr` runs). The inertia `tsc` error count is unchanged (35 before and after).
- **Lint**: no new ESLint/Prettier findings on the changed lines. Some touched files weren't Prettier-formatted before, and I matched their existing style rather than reformatting them.
- **End to end**, on a throwaway instance built from this branch with its own MySQL/Redis:
  - English-only is byte-identical;
  - EN+FR and FR-only filter collections, Wikipedia options and Kiwix search as expected;
  - invalid values are rejected;
  - a French Wikipedia package can be selected, cancelled (→ `failed`) and fully downloaded;
  - a French curated tier installs without touching the Wikipedia selection;
  - a Wikipedia-derived corpus (`wikipedia_en_knots_maxi`) and an ordinary ZIM are bookkept correctly;
  - everything survives a restart.

  French curated content was simulated with demo manifests injected into the cache, since `collections/fr/` doesn't exist yet.
- **UI** was checked in a real headless Chromium through Claude Code's browser skill: desktop, 390 px mobile and dark theme, with no console errors.

**Manual:** I tested it myself on that instance. I switched languages in Content Explorer and Easy Setup, downloaded French content (French Wikipedia, WikiMed FR, iFixit FR), and browsed it in Kiwix. Everything worked as expected.

## Noticed while testing (not addressed here)

- **Kiwix search on `dev`**: search queries `browse.library.kiwix.org`, which currently answers with an HTML "Access confirmation" page, so search is broken on `dev` regardless of this PR. `main` uses `opds.library.kiwix.org` (see the revert in 93be567). I patched it locally only to test.
- **Update checks**: `KiwixCatalogService` queries with `lang: 'eng'`, so sideloaded non-English ZIMs never resolve an update. `name=wikipedia_fr_all` returns 0 results with `lang=eng` and 3 without. I'm happy to open an issue or a one-line PR if useful.

## Next step (separate PR, once this ships)

A content-only PR adding `collections/fr/kiwix-categories.json` and `collections/fr/wikipedia.json` (Wikipédia, WikiMed FR, iFixit FR, Wiktionnaire, Wikilivres, Vikidia, Gutenberg FR, Les fondamentaux). I'd be glad to maintain those files. The same layout works for any language.

<details>
<summary>Suggested release note (optional)</summary>

> **Content languages**: Easy Setup and the Content Explorer now let you choose which languages of curated collections, Wikipedia packages and Kiwix library results are offered. English remains the default, and the interface itself is unchanged.
</details>

## Transparency

This change was written by Claude (Anthropic's Claude Opus 5, through Claude Code), working under my direction. It ran the automated, security and regression checks above. I reviewed the result and tested it by hand before opening this PR. Thanks a lot for NOMAD, and for taking the time to explain the constraints so clearly in #1262. It made this much easier to get right. Any feedback is very welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
